### PR TITLE
Add AI-powered RAG pipeline for clinical chart search

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,6 +18,13 @@
 			<artifactId>openmrs-api</artifactId>
 			<type>jar</type>
 		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.11.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.openmrs.api</groupId>
 			<artifactId>openmrs-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -1,0 +1,40 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai;
+
+public class ChartSearchAiConstants {
+
+	public static final String PRIV_QUERY_PATIENT_DATA = "AI Query Patient Data";
+
+	public static final String PRIV_VIEW_AUDIT_LOG = "View AI Audit Log";
+
+	public static final String GP_LLM_PROVIDER = "chartsearchai.llm.provider";
+
+	public static final String GP_LLM_API_KEY = "chartsearchai.llm.apiKey";
+
+	public static final String GP_LLM_MODEL = "chartsearchai.llm.model";
+
+	public static final String GP_LLM_API_URL = "chartsearchai.llm.apiUrl";
+
+	public static final String GP_RETRIEVAL_TOP_K = "chartsearchai.retrieval.topK";
+
+	public static final String DEFAULT_LLM_PROVIDER = "claude";
+
+	public static final String DEFAULT_LLM_MODEL = "claude-sonnet-4-6";
+
+	public static final String DEFAULT_LLM_API_URL = "https://api.anthropic.com/v1/messages";
+
+	public static final int DEFAULT_RETRIEVAL_TOP_K = 20;
+
+	public static final int EMBEDDING_DIMENSIONS = 384;
+
+	private ChartSearchAiConstants() {
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiModuleActivator.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.chartsearchai;
 
+import org.openmrs.api.context.Context;
 import org.openmrs.module.BaseModuleActivator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,10 +21,21 @@ public class ChartSearchAiModuleActivator extends BaseModuleActivator {
 	@Override
 	public void started() {
 		log.info("Chart Search AI Module started");
+		validateConfiguration();
 	}
 
 	@Override
 	public void stopped() {
 		log.info("Chart Search AI Module stopped");
+	}
+
+	private void validateConfiguration() {
+		String apiKey = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_LLM_API_KEY);
+		if (apiKey == null || apiKey.trim().isEmpty()) {
+			log.warn("Chart Search AI: No LLM API key configured. "
+					+ "Set '{}' in global properties before using the module.",
+					ChartSearchAiConstants.GP_LLM_API_KEY);
+		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/adapter/ClaudeAdapter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/adapter/ClaudeAdapter.java
@@ -1,0 +1,148 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.adapter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * LLM adapter for the Claude API (Anthropic Messages API). Sends clinical queries to Claude and
+ * parses the response. Uses standard HttpURLConnection to avoid additional HTTP client dependencies.
+ */
+@Component("chartsearchai.claudeAdapter")
+public class ClaudeAdapter implements LlmAdapter {
+
+	private static final Logger log = LoggerFactory.getLogger(ClaudeAdapter.class);
+
+	private static final String ANTHROPIC_VERSION = "2023-06-01";
+
+	private static final int MAX_TOKENS = 4096;
+
+	private static final int CONNECT_TIMEOUT_MS = 10000;
+
+	private static final int READ_TIMEOUT_MS = 60000;
+
+	@Override
+	public LlmResponse chat(String systemPrompt, String userMessage) {
+		String apiKey = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_LLM_API_KEY);
+		if (apiKey == null || apiKey.trim().isEmpty()) {
+			throw new APIException("chartsearchai.error.noApiKey", (Object[]) null);
+		}
+
+		String model = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_LLM_MODEL, ChartSearchAiConstants.DEFAULT_LLM_MODEL);
+		String apiUrl = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_LLM_API_URL, ChartSearchAiConstants.DEFAULT_LLM_API_URL);
+
+		JsonObject requestBody = buildRequestBody(systemPrompt, userMessage, model);
+		String responseJson = sendRequest(apiUrl, apiKey, requestBody.toString());
+		return parseResponse(responseJson);
+	}
+
+	private JsonObject buildRequestBody(String systemPrompt, String userMessage, String model) {
+		JsonObject body = new JsonObject();
+		body.addProperty("model", model);
+		body.addProperty("max_tokens", MAX_TOKENS);
+		body.addProperty("system", systemPrompt);
+
+		JsonArray messages = new JsonArray();
+		JsonObject userMsg = new JsonObject();
+		userMsg.addProperty("role", "user");
+		userMsg.addProperty("content", userMessage);
+		messages.add(userMsg);
+
+		body.add("messages", messages);
+		return body;
+	}
+
+	private String sendRequest(String apiUrl, String apiKey, String body) {
+		HttpURLConnection connection = null;
+		try {
+			URL url = new URL(apiUrl);
+			connection = (HttpURLConnection) url.openConnection();
+			connection.setRequestMethod("POST");
+			connection.setRequestProperty("Content-Type", "application/json");
+			connection.setRequestProperty("x-api-key", apiKey);
+			connection.setRequestProperty("anthropic-version", ANTHROPIC_VERSION);
+			connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+			connection.setReadTimeout(READ_TIMEOUT_MS);
+			connection.setDoOutput(true);
+
+			try (OutputStream os = connection.getOutputStream()) {
+				os.write(body.getBytes(StandardCharsets.UTF_8));
+			}
+
+			int responseCode = connection.getResponseCode();
+			if (responseCode != 200) {
+				String errorBody = readStream(connection.getErrorStream());
+				log.error("Claude API returned HTTP {}: {}", responseCode, errorBody);
+				throw new APIException("chartsearchai.error.llmRequestFailed",
+						new Object[] { responseCode, errorBody });
+			}
+
+			return readStream(connection.getInputStream());
+		}
+		catch (IOException e) {
+			throw new APIException("chartsearchai.error.llmConnectionFailed", new Object[] { e.getMessage() }, e);
+		}
+		finally {
+			if (connection != null) {
+				connection.disconnect();
+			}
+		}
+	}
+
+	private String readStream(java.io.InputStream stream) throws IOException {
+		if (stream == null) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder();
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				sb.append(line);
+			}
+		}
+		return sb.toString();
+	}
+
+	private LlmResponse parseResponse(String json) {
+		JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+		String model = root.has("model") ? root.get("model").getAsString() : "unknown";
+
+		JsonArray content = root.getAsJsonArray("content");
+		StringBuilder text = new StringBuilder();
+		for (int i = 0; i < content.size(); i++) {
+			JsonObject block = content.get(i).getAsJsonObject();
+			if ("text".equals(block.get("type").getAsString())) {
+				text.append(block.get("text").getAsString());
+			}
+		}
+
+		return new LlmResponse(text.toString(), model);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/adapter/LlmAdapter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/adapter/LlmAdapter.java
@@ -1,0 +1,26 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.adapter;
+
+/**
+ * Abstraction for LLM providers. Implementations handle the HTTP communication with specific AI
+ * services (Claude, Ollama, etc.) while the rest of the module remains provider-agnostic.
+ */
+public interface LlmAdapter {
+
+	/**
+	 * Send a chat request with a system prompt and user message.
+	 *
+	 * @param systemPrompt the system-level instructions for the LLM
+	 * @param userMessage the user's question along with retrieved clinical context
+	 * @return the LLM's response
+	 */
+	LlmResponse chat(String systemPrompt, String userMessage);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/adapter/LlmResponse.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/adapter/LlmResponse.java
@@ -1,0 +1,58 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.adapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response from an LLM provider, including the generated text, the model that produced it, and any
+ * guardrail warnings detected during post-processing.
+ */
+public class LlmResponse {
+
+	private String text;
+
+	private String modelId;
+
+	private List<String> warnings = new ArrayList<>();
+
+	public LlmResponse() {
+	}
+
+	public LlmResponse(String text, String modelId) {
+		this.text = text;
+		this.modelId = modelId;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public String getModelId() {
+		return modelId;
+	}
+
+	public void setModelId(String modelId) {
+		this.modelId = modelId;
+	}
+
+	public List<String> getWarnings() {
+		return warnings;
+	}
+
+	public void addWarning(String warning) {
+		this.warnings.add(warning);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/AiQueryResponse.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/AiQueryResponse.java
@@ -1,0 +1,72 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api;
+
+import java.util.List;
+
+import org.openmrs.module.chartsearchai.model.EmbeddingChunk;
+
+/**
+ * Result object returned from a chart search AI query. Contains the generated response text, the
+ * clinical data chunks that were used as context, and any safety warnings from guardrail validation.
+ */
+public class AiQueryResponse {
+
+	private String responseText;
+
+	private List<EmbeddingChunk> sourceChunks;
+
+	private List<String> warnings;
+
+	private String modelUsed;
+
+	public AiQueryResponse() {
+	}
+
+	public AiQueryResponse(String responseText, List<EmbeddingChunk> sourceChunks, List<String> warnings,
+			String modelUsed) {
+		this.responseText = responseText;
+		this.sourceChunks = sourceChunks;
+		this.warnings = warnings;
+		this.modelUsed = modelUsed;
+	}
+
+	public String getResponseText() {
+		return responseText;
+	}
+
+	public void setResponseText(String responseText) {
+		this.responseText = responseText;
+	}
+
+	public List<EmbeddingChunk> getSourceChunks() {
+		return sourceChunks;
+	}
+
+	public void setSourceChunks(List<EmbeddingChunk> sourceChunks) {
+		this.sourceChunks = sourceChunks;
+	}
+
+	public List<String> getWarnings() {
+		return warnings;
+	}
+
+	public void setWarnings(List<String> warnings) {
+		this.warnings = warnings;
+	}
+
+	public String getModelUsed() {
+		return modelUsed;
+	}
+
+	public void setModelUsed(String modelUsed) {
+		this.modelUsed = modelUsed;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchAiService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchAiService.java
@@ -1,0 +1,55 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api;
+
+import java.util.List;
+
+import org.openmrs.Patient;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.api.OpenmrsService;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.model.AiQueryLog;
+
+/**
+ * Primary service for AI-powered chart search. Provides natural-language querying of patient charts
+ * with clinical safety guardrails, citation requirements, and full audit logging.
+ */
+public interface ChartSearchAiService extends OpenmrsService {
+
+	/**
+	 * Ask a natural-language question about a specific patient's chart. The patient's clinical data
+	 * is retrieved, relevant chunks are selected via vector similarity, and the question is answered
+	 * by an LLM with clinical safety guardrails.
+	 *
+	 * @param patient the patient whose chart to query
+	 * @param question the clinician's natural-language question
+	 * @return the AI response with citations and any safety warnings
+	 */
+	@Authorized(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA)
+	AiQueryResponse queryPatientChart(Patient patient, String question);
+
+	/**
+	 * Generate a clinical summary for a patient based on their complete chart data.
+	 *
+	 * @param patient the patient to summarize
+	 * @return the AI-generated summary with citations
+	 */
+	@Authorized(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA)
+	AiQueryResponse generatePatientSummary(Patient patient);
+
+	/**
+	 * Retrieve the audit log of all AI queries made for a specific patient.
+	 *
+	 * @param patient the patient whose query history to retrieve
+	 * @return list of query log entries, most recent first
+	 */
+	@Authorized(ChartSearchAiConstants.PRIV_VIEW_AUDIT_LOG)
+	List<AiQueryLog> getQueryAuditLog(Patient patient);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/EmbeddingService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/EmbeddingService.java
@@ -1,0 +1,64 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api;
+
+import java.util.List;
+
+import org.openmrs.Encounter;
+import org.openmrs.Patient;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.api.OpenmrsService;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.model.EmbeddingChunk;
+
+/**
+ * Service for managing the vector embedding index of patient clinical data. Handles full and
+ * incremental indexing, as well as similarity-based retrieval of relevant chunks for a query.
+ */
+public interface EmbeddingService extends OpenmrsService {
+
+	/**
+	 * Index (or re-index) all clinical data for a patient. Deletes any existing chunks and creates
+	 * new embeddings from the current state of the patient's chart.
+	 *
+	 * @param patient the patient to index
+	 */
+	@Authorized(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA)
+	void indexPatient(Patient patient);
+
+	/**
+	 * Incrementally index a single encounter. Creates embedding chunks for the encounter's data
+	 * without re-indexing the entire patient record.
+	 *
+	 * @param encounter the encounter to index
+	 */
+	@Authorized(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA)
+	void indexEncounter(Encounter encounter);
+
+	/**
+	 * Retrieve the most relevant embedding chunks for a natural-language query against a patient's
+	 * indexed data. Uses cosine similarity between the query embedding and stored chunk embeddings.
+	 *
+	 * @param patient the patient whose chunks to search
+	 * @param query the natural-language query to match against
+	 * @param topK the maximum number of chunks to return
+	 * @return the most relevant chunks, ordered by similarity (highest first)
+	 */
+	@Authorized(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA)
+	List<EmbeddingChunk> retrieveRelevantChunks(Patient patient, String query, int topK);
+
+	/**
+	 * Check whether a patient's data has been indexed.
+	 *
+	 * @param patient the patient to check
+	 * @return true if the patient has embedding chunks in the index
+	 */
+	boolean isPatientIndexed(Patient patient);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/db/ChartSearchAiDAO.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/db/ChartSearchAiDAO.java
@@ -1,0 +1,32 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.db;
+
+import java.util.List;
+
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.model.AiQueryLog;
+import org.openmrs.module.chartsearchai.model.EmbeddingChunk;
+
+/**
+ * Data access interface for AI chart search persistence operations.
+ */
+public interface ChartSearchAiDAO {
+
+	EmbeddingChunk saveEmbeddingChunk(EmbeddingChunk chunk);
+
+	List<EmbeddingChunk> getEmbeddingChunksByPatient(Patient patient);
+
+	void deleteEmbeddingChunksByPatient(Patient patient);
+
+	AiQueryLog saveQueryLog(AiQueryLog queryLog);
+
+	List<AiQueryLog> getQueryLogsByPatient(Patient patient);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/db/hibernate/HibernateChartSearchAiDAO.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/db/hibernate/HibernateChartSearchAiDAO.java
@@ -1,0 +1,67 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.db.hibernate;
+
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.db.ChartSearchAiDAO;
+import org.openmrs.module.chartsearchai.model.AiQueryLog;
+import org.openmrs.module.chartsearchai.model.EmbeddingChunk;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+@Repository("chartsearchai.ChartSearchAiDAO")
+public class HibernateChartSearchAiDAO implements ChartSearchAiDAO {
+
+	@Autowired
+	@Qualifier("sessionFactory")
+	private SessionFactory sessionFactory;
+
+	@Override
+	public EmbeddingChunk saveEmbeddingChunk(EmbeddingChunk chunk) {
+		sessionFactory.getCurrentSession().saveOrUpdate(chunk);
+		return chunk;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<EmbeddingChunk> getEmbeddingChunksByPatient(Patient patient) {
+		return sessionFactory.getCurrentSession()
+				.createQuery("FROM EmbeddingChunk WHERE patient = :patient ORDER BY sourceDate DESC")
+				.setParameter("patient", patient)
+				.list();
+	}
+
+	@Override
+	public void deleteEmbeddingChunksByPatient(Patient patient) {
+		sessionFactory.getCurrentSession()
+				.createQuery("DELETE FROM EmbeddingChunk WHERE patient = :patient")
+				.setParameter("patient", patient)
+				.executeUpdate();
+	}
+
+	@Override
+	public AiQueryLog saveQueryLog(AiQueryLog queryLog) {
+		sessionFactory.getCurrentSession().saveOrUpdate(queryLog);
+		return queryLog;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<AiQueryLog> getQueryLogsByPatient(Patient patient) {
+		return sessionFactory.getCurrentSession()
+				.createQuery("FROM AiQueryLog WHERE patient = :patient ORDER BY dateQueried DESC")
+				.setParameter("patient", patient)
+				.list();
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchAiServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchAiServiceImpl.java
@@ -1,0 +1,163 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.util.Date;
+import java.util.List;
+
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.impl.BaseOpenmrsService;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.adapter.LlmAdapter;
+import org.openmrs.module.chartsearchai.adapter.LlmResponse;
+import org.openmrs.module.chartsearchai.api.AiQueryResponse;
+import org.openmrs.module.chartsearchai.api.ChartSearchAiService;
+import org.openmrs.module.chartsearchai.api.EmbeddingService;
+import org.openmrs.module.chartsearchai.api.db.ChartSearchAiDAO;
+import org.openmrs.module.chartsearchai.model.AiQueryLog;
+import org.openmrs.module.chartsearchai.model.EmbeddingChunk;
+import org.openmrs.module.chartsearchai.prompt.ClinicalSystemPrompt;
+import org.openmrs.module.chartsearchai.prompt.GuardrailValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Implementation of the chart search AI service. Orchestrates the full RAG pipeline: indexing,
+ * retrieval, prompt assembly, LLM call, guardrail validation, and audit logging.
+ */
+@Service("chartsearchai.ChartSearchAiService")
+@Transactional
+public class ChartSearchAiServiceImpl extends BaseOpenmrsService implements ChartSearchAiService {
+
+	private static final Logger log = LoggerFactory.getLogger(ChartSearchAiServiceImpl.class);
+
+	@Autowired
+	private EmbeddingService embeddingService;
+
+	@Autowired
+	private LlmAdapter llmAdapter;
+
+	@Autowired
+	private ChartSearchAiDAO dao;
+
+	@Override
+	public AiQueryResponse queryPatientChart(Patient patient, String question) {
+		log.info("Processing chart query for patient {}: {}", patient.getUuid(), question);
+
+		// 1. Ensure patient is indexed
+		if (!embeddingService.isPatientIndexed(patient)) {
+			embeddingService.indexPatient(patient);
+		}
+
+		// 2. Retrieve relevant chunks
+		int topK = getTopK();
+		List<EmbeddingChunk> relevantChunks = embeddingService.retrieveRelevantChunks(patient, question, topK);
+
+		// 3. Assemble prompt with clinical context
+		String userPrompt = assembleUserPrompt(patient, relevantChunks, question);
+
+		// 4. Call LLM
+		LlmResponse llmResponse = llmAdapter.chat(ClinicalSystemPrompt.SYSTEM_PROMPT, userPrompt);
+
+		// 5. Validate guardrails
+		GuardrailValidator.validate(llmResponse);
+
+		// 6. Audit log
+		saveAuditLog(patient, question, llmResponse, relevantChunks);
+
+		return new AiQueryResponse(
+				llmResponse.getText(),
+				relevantChunks,
+				llmResponse.getWarnings(),
+				llmResponse.getModelId());
+	}
+
+	@Override
+	public AiQueryResponse generatePatientSummary(Patient patient) {
+		return queryPatientChart(patient,
+				"Please provide a comprehensive clinical summary of this patient's chart, "
+				+ "including active conditions, current medications, recent encounters, "
+				+ "allergies, and any notable lab trends.");
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<AiQueryLog> getQueryAuditLog(Patient patient) {
+		return dao.getQueryLogsByPatient(patient);
+	}
+
+	private String assembleUserPrompt(Patient patient, List<EmbeddingChunk> chunks, String question) {
+		StringBuilder prompt = new StringBuilder();
+		prompt.append("## PATIENT CLINICAL DATA\n");
+		prompt.append("Patient: ").append(patient.getFamilyName());
+		prompt.append(", ").append(patient.getGender());
+		if (patient.getBirthdate() != null) {
+			prompt.append(", DOB: ").append(patient.getBirthdate());
+		}
+		prompt.append("\n\n");
+
+		for (EmbeddingChunk chunk : chunks) {
+			prompt.append("---\n");
+			prompt.append("[").append(chunk.getChunkType());
+			if (chunk.getSourceDate() != null) {
+				prompt.append(" | ").append(chunk.getSourceDate());
+			}
+			if (chunk.getSourceUuid() != null) {
+				prompt.append(" | ID:").append(chunk.getSourceUuid());
+			}
+			prompt.append("]\n");
+			prompt.append(chunk.getChunkText()).append("\n");
+		}
+
+		prompt.append("\n## CLINICIAN QUESTION\n");
+		prompt.append(question).append("\n");
+
+		return prompt.toString();
+	}
+
+	private void saveAuditLog(Patient patient, String question, LlmResponse response,
+			List<EmbeddingChunk> chunks) {
+		AiQueryLog auditEntry = new AiQueryLog();
+		auditEntry.setPatient(patient);
+		auditEntry.setUser(Context.getAuthenticatedUser());
+		auditEntry.setQueryText(question);
+		auditEntry.setResponseText(response.getText());
+		auditEntry.setModelUsed(response.getModelId());
+		auditEntry.setDateQueried(new Date());
+
+		StringBuilder chunkIds = new StringBuilder();
+		for (int i = 0; i < chunks.size(); i++) {
+			if (i > 0) {
+				chunkIds.append(",");
+			}
+			chunkIds.append(chunks.get(i).getChunkId());
+		}
+		auditEntry.setChunksUsed(chunkIds.toString());
+
+		dao.saveQueryLog(auditEntry);
+	}
+
+	private int getTopK() {
+		String value = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_RETRIEVAL_TOP_K);
+		if (value != null && !value.trim().isEmpty()) {
+			try {
+				return Integer.parseInt(value.trim());
+			} catch (NumberFormatException e) {
+				log.warn("Invalid topK value '{}', using default", value);
+			}
+		}
+		return ChartSearchAiConstants.DEFAULT_RETRIEVAL_TOP_K;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/EmbeddingServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/EmbeddingServiceImpl.java
@@ -1,0 +1,182 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.openmrs.Encounter;
+import org.openmrs.Patient;
+import org.openmrs.api.impl.BaseOpenmrsService;
+import org.openmrs.module.chartsearchai.api.EmbeddingService;
+import org.openmrs.module.chartsearchai.api.db.ChartSearchAiDAO;
+import org.openmrs.module.chartsearchai.model.EmbeddingChunk;
+import org.openmrs.module.chartsearchai.model.TextChunk;
+import org.openmrs.module.chartsearchai.pipeline.ClinicalChunker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Implementation of the embedding service. Currently uses a simple term-frequency based embedding
+ * as a placeholder. In production, this should be replaced with a proper embedding model (e.g.,
+ * ONNX Runtime with all-MiniLM-L6-v2 or an external embedding API).
+ *
+ * <p>For single-patient retrieval (typically &lt;500 chunks), brute-force cosine similarity in Java
+ * is fast enough (&lt;10ms), so no vector database is needed.</p>
+ */
+@Service("chartsearchai.EmbeddingService")
+@Transactional
+public class EmbeddingServiceImpl extends BaseOpenmrsService implements EmbeddingService {
+
+	private static final Logger log = LoggerFactory.getLogger(EmbeddingServiceImpl.class);
+
+	@Autowired
+	private ChartSearchAiDAO dao;
+
+	@Autowired
+	private ClinicalChunker clinicalChunker;
+
+	@Override
+	public void indexPatient(Patient patient) {
+		log.info("Indexing patient {}", patient.getUuid());
+
+		dao.deleteEmbeddingChunksByPatient(patient);
+
+		List<TextChunk> textChunks = clinicalChunker.chunkPatientData(patient);
+		Date now = new Date();
+
+		for (TextChunk textChunk : textChunks) {
+			EmbeddingChunk chunk = new EmbeddingChunk();
+			chunk.setPatient(patient);
+			chunk.setChunkType(textChunk.getMetadata().getChunkType());
+			chunk.setSourceUuid(textChunk.getMetadata().getSourceUuid());
+			chunk.setSourceDate(textChunk.getMetadata().getSourceDate());
+			chunk.setChunkText(textChunk.getText());
+			chunk.setEmbeddingVector(computeEmbedding(textChunk.getText()));
+			chunk.setDateIndexed(now);
+
+			dao.saveEmbeddingChunk(chunk);
+		}
+
+		log.info("Indexed {} chunks for patient {}", textChunks.size(), patient.getUuid());
+	}
+
+	@Override
+	public void indexEncounter(Encounter encounter) {
+		Patient patient = encounter.getPatient();
+		log.info("Incrementally indexing encounter {} for patient {}",
+				encounter.getUuid(), patient.getUuid());
+
+		// For incremental indexing, we re-index the entire patient.
+		// A more sophisticated implementation could index just the encounter's chunks.
+		indexPatient(patient);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<EmbeddingChunk> retrieveRelevantChunks(Patient patient, String query, int topK) {
+		List<EmbeddingChunk> allChunks = dao.getEmbeddingChunksByPatient(patient);
+		if (allChunks.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		float[] queryEmbedding = computeEmbedding(query);
+
+		// Compute cosine similarity for each chunk and sort by score
+		List<Map.Entry<EmbeddingChunk, Double>> scored = new ArrayList<>();
+		for (EmbeddingChunk chunk : allChunks) {
+			double similarity = cosineSimilarity(queryEmbedding, chunk.getEmbeddingVector());
+			scored.add(new AbstractMap.SimpleEntry<>(chunk, similarity));
+		}
+
+		Collections.sort(scored, new Comparator<Map.Entry<EmbeddingChunk, Double>>() {
+			@Override
+			public int compare(Map.Entry<EmbeddingChunk, Double> a, Map.Entry<EmbeddingChunk, Double> b) {
+				return Double.compare(b.getValue(), a.getValue());
+			}
+		});
+
+		List<EmbeddingChunk> results = new ArrayList<>();
+		int limit = Math.min(topK, scored.size());
+		for (int i = 0; i < limit; i++) {
+			results.add(scored.get(i).getKey());
+		}
+		return results;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public boolean isPatientIndexed(Patient patient) {
+		return !dao.getEmbeddingChunksByPatient(patient).isEmpty();
+	}
+
+	/**
+	 * Placeholder embedding function using simple term-frequency hashing. This produces a
+	 * deterministic vector that enables basic keyword-overlap retrieval.
+	 *
+	 * <p>TODO: Replace with a proper embedding model (ONNX Runtime + all-MiniLM-L6-v2 or an
+	 * external embedding API) for semantic similarity.</p>
+	 */
+	private float[] computeEmbedding(String text) {
+		int dimensions = 384;
+		float[] embedding = new float[dimensions];
+
+		String[] tokens = text.toLowerCase().split("\\W+");
+		for (String token : tokens) {
+			if (token.isEmpty()) {
+				continue;
+			}
+			// Hash each token to a dimension and increment
+			int index = Math.abs(token.hashCode() % dimensions);
+			embedding[index] += 1.0f;
+		}
+
+		// L2 normalize
+		double norm = 0;
+		for (float v : embedding) {
+			norm += v * v;
+		}
+		norm = Math.sqrt(norm);
+		if (norm > 0) {
+			for (int i = 0; i < embedding.length; i++) {
+				embedding[i] /= (float) norm;
+			}
+		}
+
+		return embedding;
+	}
+
+	private double cosineSimilarity(float[] a, float[] b) {
+		if (a.length != b.length) {
+			return 0;
+		}
+		double dot = 0;
+		double normA = 0;
+		double normB = 0;
+		for (int i = 0; i < a.length; i++) {
+			dot += a[i] * b[i];
+			normA += a[i] * a[i];
+			normB += b[i] * b[i];
+		}
+		double denominator = Math.sqrt(normA) * Math.sqrt(normB);
+		if (denominator == 0) {
+			return 0;
+		}
+		return dot / denominator;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/AiQueryLog.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/AiQueryLog.java
@@ -1,0 +1,105 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import org.openmrs.Patient;
+import org.openmrs.User;
+
+/**
+ * Audit log entry for every AI query made against a patient's chart. Records the question asked,
+ * the response generated, which data chunks were used, and the model that produced the answer.
+ */
+public class AiQueryLog implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private Integer queryId;
+
+	private Patient patient;
+
+	private User user;
+
+	private String queryText;
+
+	private String responseText;
+
+	private String chunksUsed;
+
+	private String modelUsed;
+
+	private Date dateQueried;
+
+	public Integer getQueryId() {
+		return queryId;
+	}
+
+	public void setQueryId(Integer queryId) {
+		this.queryId = queryId;
+	}
+
+	public Patient getPatient() {
+		return patient;
+	}
+
+	public void setPatient(Patient patient) {
+		this.patient = patient;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	public String getQueryText() {
+		return queryText;
+	}
+
+	public void setQueryText(String queryText) {
+		this.queryText = queryText;
+	}
+
+	public String getResponseText() {
+		return responseText;
+	}
+
+	public void setResponseText(String responseText) {
+		this.responseText = responseText;
+	}
+
+	public String getChunksUsed() {
+		return chunksUsed;
+	}
+
+	public void setChunksUsed(String chunksUsed) {
+		this.chunksUsed = chunksUsed;
+	}
+
+	public String getModelUsed() {
+		return modelUsed;
+	}
+
+	public void setModelUsed(String modelUsed) {
+		this.modelUsed = modelUsed;
+	}
+
+	public Date getDateQueried() {
+		return dateQueried;
+	}
+
+	public void setDateQueried(Date dateQueried) {
+		this.dateQueried = dateQueried;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/ChunkMetadata.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/ChunkMetadata.java
@@ -1,0 +1,68 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+import java.util.Date;
+
+/**
+ * Metadata about the clinical source of an embedding chunk.
+ */
+public class ChunkMetadata {
+
+	private String chunkType;
+
+	private String sourceUuid;
+
+	private Date sourceDate;
+
+	private String patientUuid;
+
+	public ChunkMetadata() {
+	}
+
+	public ChunkMetadata(String chunkType, String sourceUuid, Date sourceDate, String patientUuid) {
+		this.chunkType = chunkType;
+		this.sourceUuid = sourceUuid;
+		this.sourceDate = sourceDate;
+		this.patientUuid = patientUuid;
+	}
+
+	public String getChunkType() {
+		return chunkType;
+	}
+
+	public void setChunkType(String chunkType) {
+		this.chunkType = chunkType;
+	}
+
+	public String getSourceUuid() {
+		return sourceUuid;
+	}
+
+	public void setSourceUuid(String sourceUuid) {
+		this.sourceUuid = sourceUuid;
+	}
+
+	public Date getSourceDate() {
+		return sourceDate;
+	}
+
+	public void setSourceDate(Date sourceDate) {
+		this.sourceDate = sourceDate;
+	}
+
+	public String getPatientUuid() {
+		return patientUuid;
+	}
+
+	public void setPatientUuid(String patientUuid) {
+		this.patientUuid = patientUuid;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/EmbeddingChunk.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/EmbeddingChunk.java
@@ -1,0 +1,133 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+import java.io.ByteBuffer;
+import java.io.Serializable;
+import java.nio.ByteOrder;
+import java.util.Date;
+
+import org.openmrs.Patient;
+
+/**
+ * Persistent entity representing a single embedded text chunk derived from a patient's clinical
+ * data. Each chunk contains the original text, its vector embedding, and metadata linking it back
+ * to the source clinical record.
+ */
+public class EmbeddingChunk implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private Integer chunkId;
+
+	private Patient patient;
+
+	private String chunkType;
+
+	private String sourceUuid;
+
+	private Date sourceDate;
+
+	private String chunkText;
+
+	private byte[] embedding;
+
+	private Date dateIndexed;
+
+	public Integer getChunkId() {
+		return chunkId;
+	}
+
+	public void setChunkId(Integer chunkId) {
+		this.chunkId = chunkId;
+	}
+
+	public Patient getPatient() {
+		return patient;
+	}
+
+	public void setPatient(Patient patient) {
+		this.patient = patient;
+	}
+
+	public String getChunkType() {
+		return chunkType;
+	}
+
+	public void setChunkType(String chunkType) {
+		this.chunkType = chunkType;
+	}
+
+	public String getSourceUuid() {
+		return sourceUuid;
+	}
+
+	public void setSourceUuid(String sourceUuid) {
+		this.sourceUuid = sourceUuid;
+	}
+
+	public Date getSourceDate() {
+		return sourceDate;
+	}
+
+	public void setSourceDate(Date sourceDate) {
+		this.sourceDate = sourceDate;
+	}
+
+	public String getChunkText() {
+		return chunkText;
+	}
+
+	public void setChunkText(String chunkText) {
+		this.chunkText = chunkText;
+	}
+
+	public byte[] getEmbedding() {
+		return embedding;
+	}
+
+	public void setEmbedding(byte[] embedding) {
+		this.embedding = embedding;
+	}
+
+	public Date getDateIndexed() {
+		return dateIndexed;
+	}
+
+	public void setDateIndexed(Date dateIndexed) {
+		this.dateIndexed = dateIndexed;
+	}
+
+	/**
+	 * Converts the stored byte array embedding back to a float array for similarity computation.
+	 */
+	public float[] getEmbeddingVector() {
+		if (embedding == null) {
+			return new float[0];
+		}
+		ByteBuffer buffer = ByteBuffer.wrap(embedding).order(ByteOrder.LITTLE_ENDIAN);
+		float[] vector = new float[embedding.length / 4];
+		for (int i = 0; i < vector.length; i++) {
+			vector[i] = buffer.getFloat();
+		}
+		return vector;
+	}
+
+	/**
+	 * Stores a float array embedding as a byte array for persistence.
+	 */
+	public void setEmbeddingVector(float[] vector) {
+		ByteBuffer buffer = ByteBuffer.allocate(vector.length * 4).order(ByteOrder.LITTLE_ENDIAN);
+		for (float v : vector) {
+			buffer.putFloat(v);
+		}
+		this.embedding = buffer.array();
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/TextChunk.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/TextChunk.java
@@ -1,0 +1,44 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+/**
+ * A text chunk with its associated clinical metadata, ready for embedding.
+ */
+public class TextChunk {
+
+	private String text;
+
+	private ChunkMetadata metadata;
+
+	public TextChunk() {
+	}
+
+	public TextChunk(String text, ChunkMetadata metadata) {
+		this.text = text;
+		this.metadata = metadata;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public void setText(String text) {
+		this.text = text;
+	}
+
+	public ChunkMetadata getMetadata() {
+		return metadata;
+	}
+
+	public void setMetadata(ChunkMetadata metadata) {
+		this.metadata = metadata;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/pipeline/ClinicalChunker.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/pipeline/ClinicalChunker.java
@@ -1,0 +1,275 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.pipeline;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openmrs.Allergy;
+import org.openmrs.AllergyReaction;
+import org.openmrs.Concept;
+import org.openmrs.Condition;
+import org.openmrs.DrugOrder;
+import org.openmrs.Encounter;
+import org.openmrs.Obs;
+import org.openmrs.Order;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.model.ChunkMetadata;
+import org.openmrs.module.chartsearchai.model.TextChunk;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converts structured OpenMRS clinical data into semantically meaningful text chunks. Each chunk is
+ * self-contained and represents a single clinical event or concept group, making it suitable for
+ * vector embedding and retrieval.
+ *
+ * <p>Chunking strategy: one chunk per clinical event (encounter, medication change) rather than
+ * fixed-size text splitting, because clinical meaning is tied to events, not character counts.</p>
+ */
+@Component("chartsearchai.clinicalChunker")
+public class ClinicalChunker {
+
+	private static final Logger log = LoggerFactory.getLogger(ClinicalChunker.class);
+
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+	@Autowired
+	private PatientDataExtractor extractor;
+
+	/**
+	 * Generate all text chunks for a patient's clinical record.
+	 *
+	 * @param patient the patient whose data should be chunked
+	 * @return list of text chunks ready for embedding
+	 */
+	public List<TextChunk> chunkPatientData(Patient patient) {
+		String patientUuid = patient.getUuid();
+		List<TextChunk> chunks = new ArrayList<>();
+
+		chunks.addAll(chunkEncounters(patient, patientUuid));
+		chunks.addAll(chunkConditions(patient, patientUuid));
+		chunks.addAll(chunkAllergies(patient, patientUuid));
+		chunks.addAll(chunkMedications(patient, patientUuid));
+		chunks.addAll(chunkLabTrends(patient, patientUuid));
+
+		log.info("Generated {} chunks for patient {}", chunks.size(), patientUuid);
+		return chunks;
+	}
+
+	private List<TextChunk> chunkEncounters(Patient patient, String patientUuid) {
+		List<TextChunk> chunks = new ArrayList<>();
+		List<Encounter> encounters = extractor.getEncounters(patient);
+
+		for (Encounter encounter : encounters) {
+			StringBuilder text = new StringBuilder();
+			text.append("Encounter on ").append(formatDate(encounter.getEncounterDatetime()));
+
+			if (encounter.getEncounterType() != null) {
+				text.append(" | Type: ").append(encounter.getEncounterType().getName());
+			}
+			if (encounter.getLocation() != null) {
+				text.append(" | Location: ").append(encounter.getLocation().getName());
+			}
+			text.append("\n");
+
+			for (Obs obs : encounter.getAllObs()) {
+				text.append("  - ").append(getConceptName(obs.getConcept()));
+				text.append(": ").append(formatObsValue(obs));
+				text.append("\n");
+			}
+
+			chunks.add(new TextChunk(text.toString(),
+					new ChunkMetadata("encounter", encounter.getUuid(),
+							encounter.getEncounterDatetime(), patientUuid)));
+		}
+		return chunks;
+	}
+
+	private List<TextChunk> chunkConditions(Patient patient, String patientUuid) {
+		List<TextChunk> chunks = new ArrayList<>();
+		List<Condition> conditions = extractor.getActiveConditions(patient);
+
+		if (conditions.isEmpty()) {
+			return chunks;
+		}
+
+		StringBuilder text = new StringBuilder("Active Conditions:\n");
+		for (Condition condition : conditions) {
+			text.append("  - ").append(getConceptName(condition.getCondition().getCoded()));
+			if (condition.getOnsetDate() != null) {
+				text.append(" (onset: ").append(formatDate(condition.getOnsetDate())).append(")");
+			}
+			text.append("\n");
+		}
+
+		chunks.add(new TextChunk(text.toString(),
+				new ChunkMetadata("conditions", null, null, patientUuid)));
+		return chunks;
+	}
+
+	private List<TextChunk> chunkAllergies(Patient patient, String patientUuid) {
+		List<TextChunk> chunks = new ArrayList<>();
+		List<Allergy> allergies = extractor.getAllergies(patient);
+
+		if (allergies.isEmpty()) {
+			return chunks;
+		}
+
+		StringBuilder text = new StringBuilder("Allergies:\n");
+		for (Allergy allergy : allergies) {
+			text.append("  - ").append(allergy.getAllergen().toString());
+
+			List<AllergyReaction> reactions = allergy.getReactions();
+			if (reactions != null && !reactions.isEmpty()) {
+				text.append(" | Reactions: ");
+				for (int i = 0; i < reactions.size(); i++) {
+					if (i > 0) {
+						text.append(", ");
+					}
+					text.append(reactions.get(i).getReaction().getName().getName());
+				}
+			}
+			if (allergy.getSeverity() != null) {
+				text.append(" | Severity: ").append(allergy.getSeverity().getName().getName());
+			}
+			text.append("\n");
+		}
+
+		chunks.add(new TextChunk(text.toString(),
+				new ChunkMetadata("allergies", null, null, patientUuid)));
+		return chunks;
+	}
+
+	private List<TextChunk> chunkMedications(Patient patient, String patientUuid) {
+		List<TextChunk> chunks = new ArrayList<>();
+		List<Order> orders = extractor.getOrders(patient);
+
+		List<DrugOrder> activeDrugOrders = new ArrayList<>();
+		for (Order order : orders) {
+			if (order instanceof DrugOrder && order.isActive()) {
+				activeDrugOrders.add((DrugOrder) order);
+			}
+		}
+
+		if (activeDrugOrders.isEmpty()) {
+			return chunks;
+		}
+
+		StringBuilder text = new StringBuilder("Current Medications:\n");
+		for (DrugOrder drugOrder : activeDrugOrders) {
+			text.append("  - ");
+			if (drugOrder.getDrug() != null) {
+				text.append(drugOrder.getDrug().getName());
+			} else {
+				text.append(getConceptName(drugOrder.getConcept()));
+			}
+			if (drugOrder.getDose() != null) {
+				text.append(" | Dose: ").append(drugOrder.getDose());
+				if (drugOrder.getDoseUnits() != null) {
+					text.append(" ").append(getConceptName(drugOrder.getDoseUnits()));
+				}
+			}
+			if (drugOrder.getFrequency() != null) {
+				text.append(" | Frequency: ").append(drugOrder.getFrequency().toString());
+			}
+			if (drugOrder.getDateActivated() != null) {
+				text.append(" | Since: ").append(formatDate(drugOrder.getDateActivated()));
+			}
+			text.append("\n");
+		}
+
+		chunks.add(new TextChunk(text.toString(),
+				new ChunkMetadata("medications", null, null, patientUuid)));
+		return chunks;
+	}
+
+	private List<TextChunk> chunkLabTrends(Patient patient, String patientUuid) {
+		List<TextChunk> chunks = new ArrayList<>();
+		List<Obs> allObs = extractor.getObservations(patient);
+
+		// Group numeric observations by concept to form lab trends
+		Map<Integer, List<Obs>> labGroups = new HashMap<>();
+		for (Obs obs : allObs) {
+			if (obs.getValueNumeric() != null && obs.getConcept() != null) {
+				Integer conceptId = obs.getConcept().getConceptId();
+				if (!labGroups.containsKey(conceptId)) {
+					labGroups.put(conceptId, new ArrayList<>());
+				}
+				labGroups.get(conceptId).add(obs);
+			}
+		}
+
+		for (Map.Entry<Integer, List<Obs>> entry : labGroups.entrySet()) {
+			List<Obs> obsList = entry.getValue();
+			if (obsList.size() < 2) {
+				continue; // Only create trend chunks for repeated labs
+			}
+
+			String conceptName = getConceptName(obsList.get(0).getConcept());
+			StringBuilder text = new StringBuilder("Lab Trend - " + conceptName + ":\n");
+			for (Obs obs : obsList) {
+				text.append("  ").append(formatDate(obs.getObsDatetime()));
+				text.append(": ").append(obs.getValueNumeric());
+				if (obs.getConcept().getUnits() != null) {
+					text.append(" ").append(obs.getConcept().getUnits());
+				}
+				text.append("\n");
+			}
+
+			chunks.add(new TextChunk(text.toString(),
+					new ChunkMetadata("lab_trend", conceptName, null, patientUuid)));
+		}
+
+		return chunks;
+	}
+
+	private String formatDate(Date date) {
+		if (date == null) {
+			return "unknown";
+		}
+		synchronized (DATE_FORMAT) {
+			return DATE_FORMAT.format(date);
+		}
+	}
+
+	private String formatObsValue(Obs obs) {
+		if (obs.getValueNumeric() != null) {
+			String units = obs.getConcept().getUnits();
+			return obs.getValueNumeric() + (units != null ? " " + units : "");
+		}
+		if (obs.getValueCoded() != null) {
+			return getConceptName(obs.getValueCoded());
+		}
+		if (obs.getValueText() != null) {
+			return obs.getValueText();
+		}
+		if (obs.getValueDatetime() != null) {
+			return formatDate(obs.getValueDatetime());
+		}
+		return obs.getValueAsString(null);
+	}
+
+	private String getConceptName(Concept concept) {
+		if (concept == null) {
+			return "Unknown";
+		}
+		if (concept.getName() != null) {
+			return concept.getName().getName();
+		}
+		return "Concept:" + concept.getConceptId();
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/pipeline/PatientDataExtractor.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/pipeline/PatientDataExtractor.java
@@ -1,0 +1,73 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.pipeline;
+
+import java.util.List;
+
+import org.openmrs.Allergy;
+import org.openmrs.Condition;
+import org.openmrs.Encounter;
+import org.openmrs.Obs;
+import org.openmrs.Order;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Extracts clinical data for a patient from the OpenMRS data model. This is the first stage of the
+ * RAG pipeline: pulling structured data that will be converted into text chunks for embedding.
+ */
+@Component("chartsearchai.patientDataExtractor")
+public class PatientDataExtractor {
+
+	private static final Logger log = LoggerFactory.getLogger(PatientDataExtractor.class);
+
+	/**
+	 * Extract all encounters for a patient, ordered by date.
+	 */
+	public List<Encounter> getEncounters(Patient patient) {
+		log.debug("Extracting encounters for patient {}", patient.getPatientId());
+		return Context.getEncounterService().getEncountersByPatient(patient);
+	}
+
+	/**
+	 * Extract all observations for a patient.
+	 */
+	public List<Obs> getObservations(Patient patient) {
+		log.debug("Extracting observations for patient {}", patient.getPatientId());
+		return Context.getObsService().getObservationsByPerson(patient);
+	}
+
+	/**
+	 * Extract active conditions for a patient.
+	 */
+	public List<Condition> getActiveConditions(Patient patient) {
+		log.debug("Extracting active conditions for patient {}", patient.getPatientId());
+		return Context.getConditionService().getActiveConditions(patient);
+	}
+
+	/**
+	 * Extract all allergies for a patient.
+	 */
+	public List<Allergy> getAllergies(Patient patient) {
+		log.debug("Extracting allergies for patient {}", patient.getPatientId());
+		return Context.getPatientService().getAllergies(patient);
+	}
+
+	/**
+	 * Extract all orders (medications, labs, etc.) for a patient.
+	 */
+	public List<Order> getOrders(Patient patient) {
+		log.debug("Extracting orders for patient {}", patient.getPatientId());
+		return Context.getOrderService().getAllOrdersByPatient(patient);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/prompt/ClinicalSystemPrompt.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/prompt/ClinicalSystemPrompt.java
@@ -1,0 +1,66 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.prompt;
+
+/**
+ * System prompt for the clinical decision support assistant. This prompt establishes the safety
+ * boundaries, citation requirements, and response format for all AI-generated clinical content.
+ */
+public class ClinicalSystemPrompt {
+
+	public static final String SYSTEM_PROMPT =
+			"You are a clinical decision support assistant integrated into an "
+			+ "electronic health record system (OpenMRS). You help clinicians "
+			+ "review patient charts more efficiently.\n\n"
+
+			+ "## ROLE AND BOUNDARIES\n\n"
+			+ "- You SUMMARIZE and HIGHLIGHT information already present in the "
+			+ "patient's medical record.\n"
+			+ "- You DO NOT diagnose, prescribe, or make treatment decisions.\n"
+			+ "- You DO NOT generate information that is not supported by the "
+			+ "provided clinical data.\n"
+			+ "- If the data is insufficient to answer a question, say so explicitly.\n\n"
+
+			+ "## CITATION REQUIREMENTS\n\n"
+			+ "- Every clinical claim MUST reference a specific source record using "
+			+ "the format [Source: <type> <date>].\n"
+			+ "- Example: \"Patient has a history of hypertension [Source: Condition, "
+			+ "onset 2019-03-15] and is currently on lisinopril 10mg daily "
+			+ "[Source: MedicationRequest, 2024-01-20].\"\n"
+			+ "- If you cannot cite a source for a claim, DO NOT make that claim.\n\n"
+
+			+ "## RISK IDENTIFICATION\n\n"
+			+ "When asked about risks, check for these patterns in the data:\n"
+			+ "1. Drug-drug interactions between current medications\n"
+			+ "2. Allergies that conflict with current or recently ordered medications\n"
+			+ "3. Lab values trending outside normal ranges\n"
+			+ "4. Gaps in preventive care (based on age/sex/conditions)\n"
+			+ "5. Chronic conditions without recent follow-up encounters\n\n"
+			+ "Always present risks with their severity and the evidence from the "
+			+ "chart. Never invent risks not supported by the data.\n\n"
+
+			+ "## RESPONSE FORMAT\n\n"
+			+ "- Use clear, concise clinical language appropriate for a physician audience\n"
+			+ "- Structure responses with headers when multiple topics are covered\n"
+			+ "- Flag URGENT items (critical lab values, dangerous interactions) at the "
+			+ "top of the response\n"
+			+ "- End with a \"Data Limitations\" section noting any gaps (e.g., \"No imaging "
+			+ "results were available in the provided data\")\n\n"
+
+			+ "## PROHIBITED ACTIONS\n\n"
+			+ "- DO NOT recommend specific treatments or dosage changes\n"
+			+ "- DO NOT provide prognosis or life expectancy estimates\n"
+			+ "- DO NOT speculate about diagnoses not present in the record\n"
+			+ "- DO NOT use language that could be interpreted as a medical order\n"
+			+ "- DO NOT reference any patient data not provided in the context below\n";
+
+	private ClinicalSystemPrompt() {
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/prompt/GuardrailValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/prompt/GuardrailValidator.java
@@ -1,0 +1,89 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.prompt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.openmrs.module.chartsearchai.adapter.LlmResponse;
+
+/**
+ * Post-processing validator that checks LLM responses for safety violations. Flags prescriptive
+ * language, missing citations, and other patterns that violate clinical decision support boundaries.
+ */
+public class GuardrailValidator {
+
+	private static final List<Pattern> PROHIBITED_PATTERNS = new ArrayList<>();
+
+	private static final Pattern CITATION_PATTERN = Pattern.compile("\\[Source:.*?\\]");
+
+	private static final Pattern CLINICAL_TERM_PATTERN = Pattern.compile(
+			"(?i)\\b(patient|lab|medication|condition|allergy|diagnosis)\\b");
+
+	static {
+		PROHIBITED_PATTERNS.add(Pattern.compile(
+				"(?i)\\b(I recommend|I suggest|you should|prescribe|administer)\\b"));
+		PROHIBITED_PATTERNS.add(Pattern.compile(
+				"(?i)\\b(prognosis is|life expectancy|will likely die)\\b"));
+		PROHIBITED_PATTERNS.add(Pattern.compile(
+				"(?i)\\b(I diagnose|diagnosis:|my assessment is)\\b"));
+	}
+
+	private GuardrailValidator() {
+	}
+
+	/**
+	 * Validates an LLM response and adds warnings for any detected safety violations.
+	 *
+	 * @param response the LLM response to validate (warnings are added in place)
+	 */
+	public static void validate(LlmResponse response) {
+		String text = response.getText();
+		if (text == null || text.isEmpty()) {
+			return;
+		}
+
+		checkProhibitedLanguage(response, text);
+		checkCitationCoverage(response, text);
+	}
+
+	private static void checkProhibitedLanguage(LlmResponse response, String text) {
+		for (Pattern pattern : PROHIBITED_PATTERNS) {
+			if (pattern.matcher(text).find()) {
+				response.addWarning(
+						"Response may contain prescriptive language. "
+						+ "This is decision SUPPORT only - verify all information.");
+				return;
+			}
+		}
+	}
+
+	private static void checkCitationCoverage(LlmResponse response, String text) {
+		String[] sentences = text.split("(?<=[.!?])\\s+");
+		int clinicalSentences = 0;
+		int citedSentences = 0;
+
+		for (String sentence : sentences) {
+			if (CLINICAL_TERM_PATTERN.matcher(sentence).find()) {
+				clinicalSentences++;
+				if (CITATION_PATTERN.matcher(sentence).find()) {
+					citedSentences++;
+				}
+			}
+		}
+
+		if (clinicalSentences > 0 && citedSentences < clinicalSentences / 2) {
+			response.addWarning(
+					"Some clinical claims may lack source citations. "
+					+ "Cross-reference with the patient chart.");
+		}
+	}
+}

--- a/api/src/main/resources/AiQueryLog.hbm.xml
+++ b/api/src/main/resources/AiQueryLog.hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.chartsearchai.model">
+
+	<class name="AiQueryLog" table="chartsearchai_query_log">
+
+		<id name="queryId" type="int" column="query_id">
+			<generator class="native"/>
+		</id>
+
+		<many-to-one name="patient" class="org.openmrs.Patient" column="patient_id" not-null="true"/>
+		<many-to-one name="user" class="org.openmrs.User" column="user_id" not-null="true"/>
+
+		<property name="queryText" type="text" column="query_text"/>
+		<property name="responseText" type="text" column="response_text"/>
+		<property name="chunksUsed" type="text" column="chunks_used"/>
+		<property name="modelUsed" type="string" column="model_used" length="100"/>
+		<property name="dateQueried" type="timestamp" column="date_queried"/>
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/EmbeddingChunk.hbm.xml
+++ b/api/src/main/resources/EmbeddingChunk.hbm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.chartsearchai.model">
+
+	<class name="EmbeddingChunk" table="chartsearchai_embedding_chunk">
+
+		<id name="chunkId" type="int" column="chunk_id">
+			<generator class="native"/>
+		</id>
+
+		<many-to-one name="patient" class="org.openmrs.Patient" column="patient_id" not-null="true"/>
+
+		<property name="chunkType" type="string" column="chunk_type" length="50"/>
+		<property name="sourceUuid" type="string" column="source_uuid" length="38"/>
+		<property name="sourceDate" type="timestamp" column="source_date"/>
+		<property name="chunkText" type="text" column="chunk_text" not-null="true"/>
+		<property name="embedding" type="binary" column="embedding" not-null="true" length="16777215"/>
+		<property name="dateIndexed" type="timestamp" column="date_indexed" not-null="true"/>
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+		xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+	<changeSet id="chartsearchai-001" author="openmrs">
+		<comment>Create embedding chunk table for vector storage</comment>
+		<createTable tableName="chartsearchai_embedding_chunk">
+			<column name="chunk_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="patient_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="chunk_type" type="varchar(50)"/>
+			<column name="source_uuid" type="varchar(38)"/>
+			<column name="source_date" type="datetime"/>
+			<column name="chunk_text" type="text">
+				<constraints nullable="false"/>
+			</column>
+			<column name="embedding" type="mediumblob">
+				<constraints nullable="false"/>
+			</column>
+			<column name="date_indexed" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+		</createTable>
+
+		<addForeignKeyConstraint
+				baseTableName="chartsearchai_embedding_chunk"
+				baseColumnNames="patient_id"
+				referencedTableName="patient"
+				referencedColumnNames="patient_id"
+				constraintName="fk_chartsearchai_chunk_patient"/>
+
+		<createIndex tableName="chartsearchai_embedding_chunk" indexName="idx_chartsearchai_chunk_patient">
+			<column name="patient_id"/>
+		</createIndex>
+	</changeSet>
+
+	<changeSet id="chartsearchai-002" author="openmrs">
+		<comment>Create AI query audit log table</comment>
+		<createTable tableName="chartsearchai_query_log">
+			<column name="query_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="patient_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="user_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="query_text" type="text"/>
+			<column name="response_text" type="text"/>
+			<column name="chunks_used" type="text"/>
+			<column name="model_used" type="varchar(100)"/>
+			<column name="date_queried" type="datetime"/>
+		</createTable>
+
+		<addForeignKeyConstraint
+				baseTableName="chartsearchai_query_log"
+				baseColumnNames="patient_id"
+				referencedTableName="patient"
+				referencedColumnNames="patient_id"
+				constraintName="fk_chartsearchai_log_patient"/>
+
+		<addForeignKeyConstraint
+				baseTableName="chartsearchai_query_log"
+				baseColumnNames="user_id"
+				referencedTableName="users"
+				referencedColumnNames="user_id"
+				constraintName="fk_chartsearchai_log_user"/>
+
+		<createIndex tableName="chartsearchai_query_log" indexName="idx_chartsearchai_log_patient">
+			<column name="patient_id"/>
+		</createIndex>
+
+		<createIndex tableName="chartsearchai_query_log" indexName="idx_chartsearchai_log_date">
+			<column name="date_queried"/>
+		</createIndex>
+	</changeSet>
+
+</databaseChangeLog>

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,2 +1,5 @@
 chartsearchai.module.name=Chart Search AI Module
 chartsearchai.module.description=AI-powered chart search module for OpenMRS
+chartsearchai.error.noApiKey=LLM API key is not configured. Set the chartsearchai.llm.apiKey global property.
+chartsearchai.error.llmRequestFailed=LLM request failed with HTTP {0}: {1}
+chartsearchai.error.llmConnectionFailed=Failed to connect to LLM provider: {0}

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -10,4 +10,23 @@
 
 	<context:component-scan base-package="org.openmrs.module.chartsearchai" />
 
+	<!-- Service registration with the OpenMRS service context -->
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list merge="true">
+				<value>org.openmrs.module.chartsearchai.api.ChartSearchAiService</value>
+				<ref bean="chartsearchai.ChartSearchAiService"/>
+			</list>
+		</property>
+	</bean>
+
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list merge="true">
+				<value>org.openmrs.module.chartsearchai.api.EmbeddingService</value>
+				<ref bean="chartsearchai.EmbeddingService"/>
+			</list>
+		</property>
+	</bean>
+
 </beans>

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/controller/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/controller/ChartSearchAiRestController.java
@@ -1,0 +1,196 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.web.controller;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openmrs.Patient;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.api.AiQueryResponse;
+import org.openmrs.module.chartsearchai.api.ChartSearchAiService;
+import org.openmrs.module.chartsearchai.api.EmbeddingService;
+import org.openmrs.module.chartsearchai.model.AiQueryLog;
+import org.openmrs.module.chartsearchai.model.EmbeddingChunk;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * REST controller for AI chart search operations. Exposes endpoints for querying patient charts,
+ * generating summaries, managing the embedding index, and viewing audit logs.
+ */
+@Controller
+@RequestMapping("/rest/v1/chartsearchai")
+public class ChartSearchAiRestController {
+
+	private static final Logger log = LoggerFactory.getLogger(ChartSearchAiRestController.class);
+
+	/**
+	 * Query a patient's chart with a natural-language question.
+	 *
+	 * POST /rest/v1/chartsearchai/query/{patientUuid}
+	 * Body: { "question": "Does this patient have any drug allergies?" }
+	 */
+	@RequestMapping(value = "/query/{patientUuid}", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Map<String, Object>> queryPatientChart(
+			@PathVariable("patientUuid") String patientUuid,
+			@RequestBody Map<String, String> requestBody) {
+
+		String question = requestBody.get("question");
+		if (question == null || question.trim().isEmpty()) {
+			return badRequest("'question' is required in the request body");
+		}
+
+		Patient patient = getPatientOrNull(patientUuid);
+		if (patient == null) {
+			return notFound("Patient not found: " + patientUuid);
+		}
+
+		ChartSearchAiService service = Context.getService(ChartSearchAiService.class);
+		AiQueryResponse response = service.queryPatientChart(patient, question);
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("response", response.getResponseText());
+		result.put("model", response.getModelUsed());
+		result.put("warnings", response.getWarnings());
+		result.put("sourceChunkCount", response.getSourceChunks() != null ? response.getSourceChunks().size() : 0);
+
+		List<Map<String, Object>> sources = new ArrayList<>();
+		if (response.getSourceChunks() != null) {
+			for (EmbeddingChunk chunk : response.getSourceChunks()) {
+				Map<String, Object> source = new HashMap<>();
+				source.put("type", chunk.getChunkType());
+				source.put("sourceUuid", chunk.getSourceUuid());
+				source.put("sourceDate", chunk.getSourceDate());
+				sources.add(source);
+			}
+		}
+		result.put("sources", sources);
+
+		return new ResponseEntity<>(result, HttpStatus.OK);
+	}
+
+	/**
+	 * Generate a clinical summary for a patient.
+	 *
+	 * POST /rest/v1/chartsearchai/summary/{patientUuid}
+	 */
+	@RequestMapping(value = "/summary/{patientUuid}", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Map<String, Object>> generateSummary(
+			@PathVariable("patientUuid") String patientUuid) {
+
+		Patient patient = getPatientOrNull(patientUuid);
+		if (patient == null) {
+			return notFound("Patient not found: " + patientUuid);
+		}
+
+		ChartSearchAiService service = Context.getService(ChartSearchAiService.class);
+		AiQueryResponse response = service.generatePatientSummary(patient);
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("summary", response.getResponseText());
+		result.put("model", response.getModelUsed());
+		result.put("warnings", response.getWarnings());
+
+		return new ResponseEntity<>(result, HttpStatus.OK);
+	}
+
+	/**
+	 * Trigger re-indexing of a patient's clinical data.
+	 *
+	 * POST /rest/v1/chartsearchai/index/{patientUuid}
+	 */
+	@RequestMapping(value = "/index/{patientUuid}", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Map<String, Object>> indexPatient(
+			@PathVariable("patientUuid") String patientUuid) {
+
+		Patient patient = getPatientOrNull(patientUuid);
+		if (patient == null) {
+			return notFound("Patient not found: " + patientUuid);
+		}
+
+		EmbeddingService embeddingService = Context.getService(EmbeddingService.class);
+		embeddingService.indexPatient(patient);
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("status", "indexed");
+		result.put("patientUuid", patientUuid);
+
+		return new ResponseEntity<>(result, HttpStatus.OK);
+	}
+
+	/**
+	 * Get the AI query audit log for a patient.
+	 *
+	 * GET /rest/v1/chartsearchai/audit/{patientUuid}
+	 */
+	@RequestMapping(value = "/audit/{patientUuid}", method = RequestMethod.GET)
+	@ResponseBody
+	public ResponseEntity<Map<String, Object>> getAuditLog(
+			@PathVariable("patientUuid") String patientUuid) {
+
+		Patient patient = getPatientOrNull(patientUuid);
+		if (patient == null) {
+			return notFound("Patient not found: " + patientUuid);
+		}
+
+		ChartSearchAiService service = Context.getService(ChartSearchAiService.class);
+		List<AiQueryLog> logs = service.getQueryAuditLog(patient);
+
+		List<Map<String, Object>> entries = new ArrayList<>();
+		for (AiQueryLog entry : logs) {
+			Map<String, Object> logEntry = new HashMap<>();
+			logEntry.put("query", entry.getQueryText());
+			logEntry.put("response", entry.getResponseText());
+			logEntry.put("model", entry.getModelUsed());
+			logEntry.put("date", entry.getDateQueried());
+			if (entry.getUser() != null) {
+				logEntry.put("user", entry.getUser().getUsername());
+			}
+			entries.add(logEntry);
+		}
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("auditLog", entries);
+
+		return new ResponseEntity<>(result, HttpStatus.OK);
+	}
+
+	private Patient getPatientOrNull(String uuid) {
+		PatientService patientService = Context.getPatientService();
+		return patientService.getPatientByUuid(uuid);
+	}
+
+	private ResponseEntity<Map<String, Object>> badRequest(String message) {
+		Map<String, Object> error = new HashMap<>();
+		error.put("error", message);
+		return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+	}
+
+	private ResponseEntity<Map<String, Object>> notFound(String message) {
+		Map<String, Object> error = new HashMap<>();
+		error.put("error", message);
+		return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -15,6 +15,49 @@
 	<!-- Module Activator -->
 	<activator>org.openmrs.module.chartsearchai.ChartSearchAiModuleActivator</activator>
 
+	<!-- Hibernate Mappings -->
+	<mappingFiles>
+		EmbeddingChunk.hbm.xml
+		AiQueryLog.hbm.xml
+	</mappingFiles>
+
+	<!-- Privileges -->
+	<privilege>
+		<name>AI Query Patient Data</name>
+		<description>Allows querying patient charts using the AI assistant</description>
+	</privilege>
+	<privilege>
+		<name>View AI Audit Log</name>
+		<description>Allows viewing the audit log of AI queries and responses</description>
+	</privilege>
+
+	<!-- Global Properties -->
+	<globalProperty>
+		<property>chartsearchai.llm.provider</property>
+		<defaultValue>claude</defaultValue>
+		<description>LLM provider to use: claude, ollama</description>
+	</globalProperty>
+	<globalProperty>
+		<property>chartsearchai.llm.apiKey</property>
+		<defaultValue></defaultValue>
+		<description>API key for the LLM provider</description>
+	</globalProperty>
+	<globalProperty>
+		<property>chartsearchai.llm.model</property>
+		<defaultValue>claude-sonnet-4-6</defaultValue>
+		<description>Model identifier for the LLM provider</description>
+	</globalProperty>
+	<globalProperty>
+		<property>chartsearchai.llm.apiUrl</property>
+		<defaultValue>https://api.anthropic.com/v1/messages</defaultValue>
+		<description>API endpoint URL for the LLM provider</description>
+	</globalProperty>
+	<globalProperty>
+		<property>chartsearchai.retrieval.topK</property>
+		<defaultValue>20</defaultValue>
+		<description>Number of embedding chunks to retrieve per query</description>
+	</globalProperty>
+
 	<!-- Internationalization -->
 	<messages>
 		<lang>en</lang>


### PR DESCRIPTION
## Summary

- Implements a full RAG (Retrieval-Augmented Generation) pipeline for natural-language querying of patient charts
- Adds service layer (`ChartSearchAiService`, `EmbeddingService`) following OpenMRS conventions with `@Authorized` privilege checks
- Adds clinical data pipeline: `PatientDataExtractor` → `ClinicalChunker` (event-based chunking, not fixed-size) → vector embeddings
- Adds pluggable `LlmAdapter` interface with Claude API implementation (`ClaudeAdapter`)
- Adds clinical safety guardrails: system prompt with citation requirements, prohibited actions, and post-processing `GuardrailValidator`
- Adds full audit logging of all AI queries and responses (`chartsearchai_query_log` table)
- Adds REST endpoints: `POST /query/{patientUuid}`, `POST /summary/{patientUuid}`, `POST /index/{patientUuid}`, `GET /audit/{patientUuid}`
- Adds Liquibase schema for `chartsearchai_embedding_chunk` and `chartsearchai_query_log` tables
- Adds Hibernate mappings, Spring context wiring, module privileges, and global properties

### Architecture

```
Clinician Question
  → EmbeddingService.retrieveRelevantChunks (cosine similarity)
  → Prompt assembly (system prompt + patient context + question)
  → LlmAdapter.chat (Claude API)
  → GuardrailValidator.validate (safety checks)
  → Audit log + response with citations
```

### Key design decisions

| Decision | Rationale |
|---|---|
| Event-based chunking (per encounter/condition/medication) | Clinical meaning is tied to events, not character counts |
| Brute-force cosine similarity in Java | Single-patient scope = <500 chunks = <10ms retrieval, no vector DB needed |
| Placeholder term-frequency embeddings | Functional for development; marked with TODO for ONNX/external embedding model |
| BLOB storage for embeddings | Works on MySQL/MariaDB without extensions; upgradeable to pgvector |
| Pluggable LlmAdapter | Swap between Claude API and local models (Ollama) via global property |

## Test plan

- [ ] Verify module starts cleanly on OpenMRS 2.6.9
- [ ] Verify Liquibase creates both tables on startup
- [ ] Configure `chartsearchai.llm.apiKey` and verify Claude API connectivity
- [ ] Test `POST /rest/v1/chartsearchai/query/{uuid}` with a patient that has encounters, conditions, and medications
- [ ] Verify response includes `[Source: ...]` citations
- [ ] Verify guardrail warnings are returned when LLM produces prescriptive language
- [ ] Verify audit log entries are created and retrievable via `GET /rest/v1/chartsearchai/audit/{uuid}`
- [ ] Test `POST /rest/v1/chartsearchai/index/{uuid}` triggers re-indexing
- [ ] Verify module stops cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)