### PR TITLE
Build llama-server with static linking to reduce omod size

### DIFF
--- a/.github/workflows/publish-natives.yml
+++ b/.github/workflows/publish-natives.yml
@@ -21,11 +21,11 @@ jobs:
             arch: aarch64
             binary: llama-server
             cmake_extra: ''
-          - os: macos-13
+          - os: macos-14
             platform: Mac
             arch: x86_64
             binary: llama-server
-            cmake_extra: ''
+            cmake_extra: '-DCMAKE_OSX_ARCHITECTURES=x86_64'
           - os: ubuntu-22.04
             platform: Linux
             arch: x86_64
@@ -41,6 +41,11 @@ jobs:
             arch: x86_64
             binary: llama-server.exe
             cmake_extra: ''
+          - os: windows-2022
+            platform: Windows
+            arch: aarch64
+            binary: llama-server.exe
+            cmake_extra: '-A ARM64'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout llama.cpp
@@ -62,7 +67,7 @@ jobs:
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform }}-${{ matrix.arch }}
+          name: ${{ matrix.platform }}---${{ matrix.arch }}
           path: |
             build/bin/${{ matrix.binary }}
             build/bin/Release/${{ matrix.binary }}
@@ -83,8 +88,8 @@ jobs:
           NATIVES=llama-server-natives/src/main/resources/llama-server
           for dir in artifacts/*/; do
             name="$(basename "$dir")"
-            platform="${name%%-*}"
-            arch="${name##*-}"
+            platform="${name%---*}"
+            arch="${name##*---}"
             mkdir -p "$NATIVES/$platform/$arch"
             cp "$dir"/* "$NATIVES/$platform/$arch/"
             chmod +x "$NATIVES/$platform/$arch/"* 2>/dev/null || true

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -591,10 +591,6 @@ public class LocalLlmEngine implements LlmEngine {
 		if (osName.contains("Mac") || osName.contains("Darwin")) {
 			return "Mac";
 		}
-		String runtime = System.getProperty("java.runtime.name", "").toLowerCase();
-		if (runtime.contains("android")) {
-			return "Linux-Android";
-		}
 		return "Linux";
 	}
 

--- a/llama-server-natives/.gitignore
+++ b/llama-server-natives/.gitignore
@@ -1,6 +1,5 @@
-# Native binaries are downloaded in CI, not checked into git.
+# Native binaries are built in CI, not checked into git.
 # Run the publish-natives workflow to build and publish them.
 src/main/resources/llama-server/Mac/
 src/main/resources/llama-server/Linux/
 src/main/resources/llama-server/Windows/
-src/main/resources/llama-server/Linux-Android/


### PR DESCRIPTION
## Summary
- Build llama-server from source with `-DBUILD_SHARED_LIBS=OFF -DGGML_STATIC=ON` instead of downloading pre-built dynamically-linked release binaries
- Produces one statically-linked binary per platform (~5-6 MB each), matching the old JNI approach (12 MB total) instead of 57 MB with shared libraries
- Fix Windows artifact path (`build/bin/Release/` vs `build/bin/`)
- Cross-compile Mac x86_64 on macos-14 to avoid slow macos-13 runner queue
- Remove Android platform (OpenMRS is server-side Java)
- 6 platforms: Mac aarch64/x86_64, Linux aarch64/x86_64, Windows aarch64/x86_64

## Test plan
- [ ] Merge and trigger `publish-natives` workflow
- [ ] Verify all 6 platform builds succeed and upload artifacts
- [ ] Verify published JAR on Nexus is ~15 MB (not 57 MB)
- [ ] Clean local Maven cache, `mvn clean install -U`, verify omod size ~50 MB (not 126 MB)
- [ ] Deploy omod to standalone, restart, verify no llama-server errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)