### PR TITLE
Fix Mac x86_64 cross-compile: disable native CPU detection

### DIFF
--- a/.github/workflows/publish-natives.yml
+++ b/.github/workflows/publish-natives.yml
@@ -25,7 +25,7 @@ jobs:
             platform: Mac
             arch: x86_64
             binary: llama-server
-            cmake_extra: '-DCMAKE_OSX_ARCHITECTURES=x86_64'
+            cmake_extra: '-DCMAKE_OSX_ARCHITECTURES=x86_64 -DGGML_NATIVE=OFF'
           - os: ubuntu-22.04
             platform: Linux
             arch: x86_64


### PR DESCRIPTION
## Summary
- Add `GGML_NATIVE=OFF` to the Mac x86_64 cross-compile build to prevent cmake from using the host ARM CPU target (`apple-m1`) which is invalid for x86_64

## Test plan
- [ ] Merge and trigger `publish-natives` workflow
- [ ] Verify Mac x86_64 build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)