### PR TITLE
Replace Windows/aarch64 with Windows/x86 to match old JNI platforms

### DIFF
--- a/.github/workflows/publish-natives.yml
+++ b/.github/workflows/publish-natives.yml
@@ -43,9 +43,9 @@ jobs:
             cmake_extra: ''
           - os: windows-2022
             platform: Windows
-            arch: aarch64
+            arch: x86
             binary: llama-server.exe
-            cmake_extra: '-A ARM64'
+            cmake_extra: '-A Win32'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout llama.cpp

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -599,6 +599,9 @@ public class LocalLlmEngine implements LlmEngine {
 		if (osArch.contains("aarch64") || osArch.contains("arm64")) {
 			return "aarch64";
 		}
+		if (osArch.equals("x86") || osArch.equals("i386") || osArch.equals("i686")) {
+			return "x86";
+		}
 		return "x86_64";
 	}
 }


### PR DESCRIPTION
## Summary
- Replace Windows/aarch64 with Windows/x86 (32-bit) — llama.cpp doesn't support MSVC for ARM64, and the old JNI library shipped Windows/x86 not aarch64
- Update `detectArch()` to return `x86` for 32-bit JVMs

Final 6 platforms (matching old JNI minus Android):
Mac aarch64/x86_64, Linux aarch64/x86_64, Windows x86_64/x86

## Test plan
- [ ] Merge and trigger `publish-natives`
- [ ] All 6 builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)