### PR TITLE
Drop Windows/x86 build (llama.cpp requires 64-bit)

### DIFF
--- a/.github/workflows/publish-natives.yml
+++ b/.github/workflows/publish-natives.yml
@@ -41,11 +41,6 @@ jobs:
             arch: x86_64
             binary: llama-server.exe
             cmake_extra: ''
-          - os: windows-2022
-            platform: Windows
-            arch: x86
-            binary: llama-server.exe
-            cmake_extra: '-A Win32'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout llama.cpp


### PR DESCRIPTION
## Summary
- llama.cpp b8850 uses 64-bit atomic intrinsics not available in 32-bit MSVC
- The old JNI (b4916) supported 32-bit but modern llama.cpp does not
- Modern Windows servers are all 64-bit

Final 5 platforms: Mac aarch64/x86_64, Linux aarch64/x86_64, Windows x86_64

## Test plan
- [ ] Merge and trigger `publish-natives`
- [ ] All 5 builds succeed and JAR is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)