### PR TITLE
Fix -fa flag for llama.cpp b8850

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -199,6 +199,7 @@ public class LocalLlmEngine implements LlmEngine {
 		command.add("-ngl");
 		command.add("99");
 		command.add("-fa");
+		command.add("on");
 		command.add("-c");
 		command.add("4096");
 		command.add("--log-disable");


### PR DESCRIPTION
## Summary
- In llama.cpp b8850, `--flash-attn` (`-fa`) changed from a boolean flag to requiring an explicit value (`on`/`off`/`auto`)
- Without a value, it consumes the next argument (`-c`) as its value, causing `"unknown value for --flash-attn: '-c'"` and exit code 1
- Fix: pass `-fa on` instead of just `-fa`

## Test plan
- [ ] Deploy omod to standalone, restart
- [ ] Trigger a chart search — llama-server should start and respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)