### PR TITLE
Switch sampler chain from [temperature] to [dry, temperature]

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -468,12 +468,29 @@ public class LocalLlmEngine implements LlmEngine {
 		root.put("stream", stream);
 		// At temperature=0 the decode is greedy (argmax). The default sampler chain
 		// (penalties, dry, top_n_sigma, top_k, typ_p, top_p, min_p, xtc, temperature)
-		// runs every one of those samplers per token, but at greedy they're all no-ops
-		// on the OUTPUT — they still consume CPU. Pinning samplers to ["temperature"]
-		// short-circuits the chain to the only one that matters.
+		// runs every one of those samplers per token. At greedy most are no-ops on
+		// the OUTPUT but still consume CPU, so we pin the chain to the two samplers
+		// that matter: DRY (penalizes multi-token sequence repeats, which is the
+		// failure mode small models exhibit on chart search — verbatim repetition
+		// of date+finding blocks — without penalizing single-token repetition,
+		// which is required for legitimate extraction of dates and identifiers
+		// from the chart) and temperature.
 		ArrayNode samplers = MAPPER.createArrayNode();
+		samplers.add("dry");
 		samplers.add("temperature");
 		root.set("samplers", samplers);
+		// DRY parameters tuned for extractive QA over patient charts: penalize
+		// n-gram repeats of length >= 4 (catastrophic loops are 5+ token sequences
+		// like ", Ovarian cyst, Zika virus disease, Haemoglobin: 15.8 g/dL (HIGH),"
+		// repeated hundreds of times). At allowed_length=2 the penalty fires on
+		// 2-token date prefixes like "2026-02" present in the chart context,
+		// forcing the model to fabricate dates like 2027-02-27 or insert spaces
+		// inside dates ("20 27-02-27") to dodge the penalty. allowed_length=4
+		// catches the long loops while leaving date and identifier n-grams alone.
+		root.put("dry_multiplier", 0.8);
+		root.put("dry_base", 1.75);
+		root.put("dry_allowed_length", 4);
+		root.put("dry_penalty_last_n", -1);
 		// llama.cpp-specific extension. Without it, each request reprocesses the
 		// whole prompt from scratch, so successive queries on the same patient
 		// pay full prefill cost every time. With it set, llama-server reuses

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
@@ -93,15 +93,28 @@ public class LocalLlmEngineTest {
 	}
 
 	@Test
-	public void buildRequestBody_shouldUseGreedySamplerOnly() throws IOException {
+	public void buildRequestBody_shouldPinSamplerChainToDryAndTemperature() throws IOException {
 		String body = engine.buildRequestBody("sys", "usr", false);
 		JsonNode root = MAPPER.readTree(body);
 
 		JsonNode samplers = root.get("samplers");
-		assertEquals(1, samplers.size(),
+		assertEquals(2, samplers.size(),
 				"at temperature=0 the decode is greedy; the default 9-sampler chain is wasted "
-				+ "work per token. Pin samplers to [\"temperature\"] to short-circuit it");
-		assertEquals("temperature", samplers.get(0).asText());
+				+ "work per token. Pin samplers to [\"dry\", \"temperature\"] so the only active "
+				+ "samplers are DRY (breaks degenerate multi-token loops that small models emit "
+				+ "on chart search) and temperature");
+		assertEquals("dry", samplers.get(0).asText());
+		assertEquals("temperature", samplers.get(1).asText());
+
+		assertEquals(4, root.get("dry_allowed_length").asInt(),
+				"dry_allowed_length=4 only penalizes n-gram repeats of 4+ tokens. Shorter "
+				+ "values (2-3) catch legitimate date prefixes like \"2026-02\" in the chart "
+				+ "context and force the model to fabricate dates or insert space tokens "
+				+ "inside dates to dodge the penalty");
+		assertEquals(-1, root.get("dry_penalty_last_n").asInt(),
+				"dry_penalty_last_n=-1 looks at the full sequence for repeats, so a loop "
+				+ "started near the prompt end is still caught after generation grows past "
+				+ "the default window");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Adds the DRY (Don't Repeat Yourself) sampler to the llama-server request and pins the active chain to `[dry, temperature]`. DRY parameters: `dry_multiplier=0.8, dry_base=1.75, dry_allowed_length=4, dry_penalty_last_n=-1`.
- The previous chain `[temperature]` was correct in theory at `temperature=0` but left several small models defenseless against degenerate multi-token loops on chart-search prompts (e.g. Phi-4 Mini 3.8B Q3 looping ~93s; MedGemma 4B Q4/Q6/Q15 looping ~110s each).
- `dry_allowed_length=4` was selected after benchmarking against `dry_allowed_length=2` and `repeat_penalty=1.05/1.1`: smaller values caught legitimate date prefixes like `2026-02` from the chart context and forced the model to fabricate dates (e.g. `2027-02-27`) or insert space tokens inside dates to dodge the penalty.

## Evidence

Benchmarked against a real patient chart (20 questions × 14 local GGUF models). With `[dry, temperature]` at `allowed_length=4`, vs. the prior `[temperature]`-only chain:

- **Catastrophic loops eliminated** on the four loop-prone models (Phi-4 Mini, MedGemma 4B, MedGemma 1.5 4B, Llama 3.2 3B). E.g. MedGemma 1.5 4B Q19 went from 95 fabricated home-visit entries to the correct one-line answer.
- **Q8 (HIV status + test date)** cluster converges to the correct, clinically-precise answer across Llama 3.2 3B, Qwen 2.5 7B, Gemma 2 9B, and Mistral Nemo 12B — the same models where a simpler `repeat_penalty` introduced fabricated test dates as a side effect.
- **Phi-3 Medium 14B Q5/Q15** temporal anchoring preserved (correct date `2026-02-28`) where token-level `repeat_penalty` had drifted to `2023-12-19`.

The remaining failures the sampler change does *not* address (wrong-encounter selection on Q6 for some models; the `2026-02-18` digit drift on Phi-3 Medium 14B and Gemma 4 26B MoE Q9) are layout problems, not sampling problems, and are out of scope for this PR.

## Test plan

- [x] `mvn -pl api test` — 453 tests run, 0 failures, 0 errors.
- [x] Existing `buildRequestBody_shouldUseGreedySamplerOnly` test replaced with `buildRequestBody_shouldPinSamplerChainToDryAndTemperature`, which asserts both the sampler order and the DRY parameter values as the new spec.
- [ ] Local standalone deploy + manual smoke test on a populated demo patient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)