### PR TITLE
fix(RemoteLlmEngine): pin Java HttpClient to HTTP/1.1 (hangs with non-Apache-class HTTP/1.1 LLM servers)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
@@ -206,6 +206,7 @@ public class RemoteLlmEngine implements LlmEngine {
 	private synchronized HttpClient getHttpClient() {
 		if (httpClient == null) {
 			httpClient = HttpClient.newBuilder()
+					.version(HttpClient.Version.HTTP_1_1)
 					.connectTimeout(Duration.ofSeconds(30))
 					.build();
 		}


### PR DESCRIPTION
`RemoteLlmEngine.getHttpClient()` builds the Java HttpClient with no `.version()` call, so it defaults to `HTTP_2` and attempts an `h2c` upgrade on the first plaintext-`http://` request. Against several lightweight HTTP/1.1 LLM servers commonly used with the `remote` engine — notably LM Studio's llama.cpp-derived server, but the same shape applies to `llama-cpp-server`, some `vLLM` configurations, and `text-generation-inference` — the upgrade handshake wedges the client. `HttpClient.send()` parks on its internal CompletableFuture and never completes; `chartsearchai.llm.timeoutSeconds` does not recover because the wedge is before the request actually leaves the client (per-request `.timeout()` only covers in-flight sockets).

Confirmed with a thread dump: `http-nio-*-exec-*` parked at `RemoteLlmEngine.infer:67 → HttpClient.send → CompletableFuture.get`, zero TCP connections in the container's `/proc/net/tcp` to the endpoint, and zero `chat/completions` entries in the server's request log. With this one-line change pinning `HTTP_1_1`, the same setup (LM Studio + gemma-4-e2b-it, a 25k-token chart prompt) streams an answer with citations in ~12s.

`https://` endpoints (OpenAI, Anthropic, etc.) are unaffected — Java's `client.version()` preference is overridden by ALPN, so TLS connections keep negotiating HTTP/2 as before. The change only affects plaintext `http://` endpoints, which is exactly the case where the wedge happens.

CI failures on this PR are the pre-existing `querystore-api:1.0.0-SNAPSHOT` resolution error introduced in `0215d81` — independent of this change.