### PR TITLE
feat(chat): multi-turn chat with frozen-session chart in stable prefix

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -239,6 +239,28 @@ public class ChartSearchAiConstants {
 
 	public static final int DEFAULT_AUDIT_LOG_RETENTION_DAYS = 90;
 
+	public static final String GP_CHAT_MAX_CONTEXT_TOKENS = "chartsearchai.chat.maxContextTokens";
+
+	/**
+	 * Default budget for the multi-turn prompt assembly ({@code system} + prior
+	 * turns + current user message with the patient chart). The chart alone is
+	 * routinely ~10K tokens for a real patient, so this default has to be sized
+	 * to the operator's configured {@link #GP_LLM_CONTEXT_SIZE} (default 32768)
+	 * minus the LLM's expected response width
+	 * ({@link #DEFAULT_LLM_MAX_OUTPUT_TOKENS}, default 1024) and some headroom.
+	 *
+	 * <p>A too-small value here is a silent footgun: {@code ChatMessages.fromTurns}
+	 * drops every prior turn when the chart already exceeds the budget, so every
+	 * "chat" turn becomes effectively single-shot and the assistant ignores the
+	 * conversation. Set this to a small value only when running against a
+	 * deliberately tiny model context.
+	 */
+	public static final int DEFAULT_CHAT_MAX_CONTEXT_TOKENS = 30000;
+
+	public static final String GP_CHAT_RETENTION_DAYS = "chartsearchai.chat.retentionDays";
+
+	public static final int DEFAULT_CHAT_RETENTION_DAYS = 90;
+
 	public static final String GP_LLM_ENGINE = "chartsearchai.llm.engine";
 
 	public static final String LLM_ENGINE_LOCAL = "local";

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/AuditLogPurgeTask.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/AuditLogPurgeTask.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
 import org.openmrs.module.chartsearchai.api.AuditLogService;
+import org.openmrs.module.chartsearchai.api.db.ChatDAO;
 import org.openmrs.scheduler.tasks.AbstractTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,49 @@ public class AuditLogPurgeTask extends AbstractTask {
 		int deleted = service.deleteAuditLogsBefore(cutoffDate);
 		log.info("Audit log purge completed: deleted {} entries older than {} days",
 				deleted, retentionDays);
+
+		// Chat content has its own (typically shorter) retention horizon — it's
+		// clinical-utility, not regulatory audit-of-record. The audit row above
+		// retains the question + answer text for HIPAA-required ~6y retention;
+		// the chat tables drop the conversation thread so the FHIR PHI in free
+		// text doesn't outlive its useful life.
+		int chatRetentionDays = getChatRetentionDays();
+		if (chatRetentionDays <= 0) {
+			log.info("Chat history purge disabled (chat retention days is 0)");
+			return;
+		}
+		ChatDAO chatDAO = Context.getRegisteredComponent(
+				"chartSearchAi.chatDAO", ChatDAO.class);
+		if (chatDAO == null) {
+			// HibernateChatDAO is @Repository-annotated; absence here would mean
+			// a wiring problem, not a degraded mode. Log and skip rather than
+			// crash the scheduler.
+			log.warn("ChatDAO not available, skipping chat history purge");
+			return;
+		}
+		long chatCutoffMs = System.currentTimeMillis()
+				- (chatRetentionDays * 24L * 60L * 60L * 1000L);
+		int chatDeleted = chatDAO.purgeBefore(new Date(chatCutoffMs));
+		log.info("Chat history purge completed: deleted {} rows older than {} days",
+				chatDeleted, chatRetentionDays);
+	}
+
+	int getChatRetentionDays() {
+		String value = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_CHAT_RETENTION_DAYS);
+		return parseChatRetentionDays(value);
+	}
+
+	static int parseChatRetentionDays(String value) {
+		if (value != null && !value.trim().isEmpty()) {
+			try {
+				return Integer.parseInt(value.trim());
+			}
+			catch (NumberFormatException e) {
+				log.warn("Invalid chat history retention value '{}', using default", value);
+			}
+		}
+		return ChartSearchAiConstants.DEFAULT_CHAT_RETENTION_DAYS;
 	}
 
 	int getRetentionDays() {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChatService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChatService.java
@@ -45,6 +45,20 @@ public interface ChatService {
 	ChatSession closeAndStartNew(Patient patient);
 
 	/**
+	 * Rebuilds the chart snapshot for the patient's current active session
+	 * (picking up clinical data entered since the session started) WITHOUT
+	 * touching the conversation transcript. The deliberate counterpart to
+	 * {@link #closeAndStartNew}: same session, same messages, fresh chart.
+	 * Used by REST POST {@code /chat/refresh-chart}.
+	 *
+	 * <p>Rebuilding changes the chart bytes, so the LLM's cached prefix for
+	 * this session is invalidated — the next turn pays one full prefill then
+	 * re-caches. That cost is the explicit price of freshness. If no active
+	 * session exists yet, opens one (nothing to refresh).
+	 */
+	ChatSession refreshChartSnapshot(Patient patient);
+
+	/**
 	 * Returns prior chat messages for a session in chronological order,
 	 * excluding summary rows.
 	 */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChatService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChatService.java
@@ -1,0 +1,102 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
+import org.openmrs.module.chartsearchai.model.ChatSession;
+
+/**
+ * Multi-turn chat orchestration: session lifecycle plus per-turn LLM call
+ * + persistence. Patient-scoped authorization is delegated to the caller
+ * (the REST controller).
+ */
+public interface ChatService {
+
+	/**
+	 * Returns the most-recently-active session for the (patient,
+	 * currently-authenticated user) pair, creating one if none exists.
+	 * Used by REST POST {@code /chat} when the client omits {@code session}.
+	 */
+	ChatSession openOrLoadActiveSession(Patient patient);
+
+	/**
+	 * Loads a session by its client-visible uuid. Returns null when the uuid
+	 * is unknown — the controller is expected to fall back to
+	 * {@link #openOrLoadActiveSession} in that case.
+	 */
+	ChatSession loadByUuid(String uuid);
+
+	/**
+	 * Closes the patient's current active session (if any) and opens a fresh
+	 * one for the authenticated user. Used by REST POST {@code /chat/new}.
+	 */
+	ChatSession closeAndStartNew(Patient patient);
+
+	/**
+	 * Returns prior chat messages for a session in chronological order,
+	 * excluding summary rows.
+	 */
+	List<ChatMessage> getMessages(ChatSession session);
+
+	/**
+	 * Synchronous chat turn: persists the user message, calls the LLM,
+	 * persists the assistant message + audit row in one transaction, and
+	 * returns the ChatAnswer + the session + assistant-message uuids the
+	 * controller surfaces to the client.
+	 */
+	ChatTurnResult chat(ChatSession session, String question);
+
+	/**
+	 * Streaming chat turn — same semantics as {@link #chat} but tokens stream
+	 * to {@code tokenConsumer}. The assistant row is persisted only when the
+	 * upstream stream closes successfully; aborts persist a partial row with
+	 * {@code finish_reason='aborted'} so the next request resumes at the
+	 * correct ordinal.
+	 */
+	ChatTurnResult chatStreaming(ChatSession session, String question,
+			Consumer<String> tokenConsumer);
+
+	/**
+	 * Container for the controller's response: the ChartAnswer (text +
+	 * references + tokens), plus the session uuid and the newly-created
+	 * assistant message uuid for client-side threading.
+	 */
+	class ChatTurnResult {
+
+		private final ChartAnswer answer;
+
+		private final String sessionUuid;
+
+		private final String assistantMessageUuid;
+
+		public ChatTurnResult(ChartAnswer answer, String sessionUuid, String assistantMessageUuid) {
+			this.answer = answer;
+			this.sessionUuid = sessionUuid;
+			this.assistantMessageUuid = assistantMessageUuid;
+		}
+
+		public ChartAnswer getAnswer() {
+			return answer;
+		}
+
+		public String getSessionUuid() {
+			return sessionUuid;
+		}
+
+		public String getAssistantMessageUuid() {
+			return assistantMessageUuid;
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/db/ChatDAO.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/db/ChatDAO.java
@@ -1,0 +1,60 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.db;
+
+import java.util.Date;
+import java.util.List;
+
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
+import org.openmrs.module.chartsearchai.model.ChatSession;
+
+/**
+ * Persistence for multi-turn chat sessions and messages. Audit log entries
+ * (regulatory grain) live in {@link ChartSearchAiDAO}.
+ */
+public interface ChatDAO {
+
+	ChatSession saveSession(ChatSession session);
+
+	ChatSession getSession(Integer sessionId);
+
+	ChatSession getSessionByUuid(String uuid);
+
+	/**
+	 * Returns the most-recently-active session for the (patient, user) pair, or
+	 * null if no such session exists. Used for "open chart → reuse latest thread"
+	 * lookup.
+	 */
+	ChatSession getLatestSession(Patient patient, User user);
+
+	ChatMessage saveMessage(ChatMessage message);
+
+	/**
+	 * List all non-summary messages for a session in ascending ordinal order.
+	 * This is the canonical "rebuild conversation history for the next LLM call"
+	 * query.
+	 */
+	List<ChatMessage> getMessages(ChatSession session);
+
+	/**
+	 * Largest ordinal in the session, or -1 if the session has no messages.
+	 * Callers use {@code lastOrdinal + 1} when persisting the next turn.
+	 */
+	int getLastOrdinal(ChatSession session);
+
+	/**
+	 * Delete chat_message rows older than the given date, and any chat_session
+	 * rows whose newest message is older than the same horizon (orphaned headers).
+	 * Returns total rows deleted across both tables.
+	 */
+	int purgeBefore(Date before);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/db/hibernate/HibernateChatDAO.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/db/hibernate/HibernateChatDAO.java
@@ -1,0 +1,111 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.db.hibernate;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.module.chartsearchai.api.db.ChatDAO;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
+import org.openmrs.module.chartsearchai.model.ChatSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository("chartSearchAi.chatDAO")
+public class HibernateChatDAO implements ChatDAO {
+
+	@Autowired
+	private SessionFactory sessionFactory;
+
+	@Override
+	public ChatSession saveSession(ChatSession session) {
+		sessionFactory.getCurrentSession().saveOrUpdate(session);
+		return session;
+	}
+
+	@Override
+	public ChatSession getSession(Integer sessionId) {
+		return (ChatSession) sessionFactory.getCurrentSession().get(ChatSession.class, sessionId);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public ChatSession getSessionByUuid(String uuid) {
+		List<ChatSession> results = sessionFactory.getCurrentSession()
+				.createQuery("from ChatSession where uuid = :uuid")
+				.setParameter("uuid", uuid)
+				.list();
+		return results.isEmpty() ? null : results.get(0);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public ChatSession getLatestSession(Patient patient, User user) {
+		List<ChatSession> results = sessionFactory.getCurrentSession()
+				.createQuery("from ChatSession where patient = :patient and user = :user "
+						+ "and status = '" + ChatSession.STATUS_ACTIVE + "' "
+						+ "order by lastActivityAt desc")
+				.setParameter("patient", patient)
+				.setParameter("user", user)
+				.setMaxResults(1)
+				.list();
+		return results.isEmpty() ? null : results.get(0);
+	}
+
+	@Override
+	public ChatMessage saveMessage(ChatMessage message) {
+		sessionFactory.getCurrentSession().saveOrUpdate(message);
+		return message;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<ChatMessage> getMessages(ChatSession session) {
+		if (session == null) {
+			return Collections.emptyList();
+		}
+		return sessionFactory.getCurrentSession()
+				.createQuery("from ChatMessage where session = :session and summary = false order by ordinal asc")
+				.setParameter("session", session)
+				.list();
+	}
+
+	@Override
+	public int getLastOrdinal(ChatSession session) {
+		if (session == null) {
+			return -1;
+		}
+		Integer max = (Integer) sessionFactory.getCurrentSession()
+				.createQuery("select max(ordinal) from ChatMessage where session = :session")
+				.setParameter("session", session)
+				.uniqueResult();
+		return max == null ? -1 : max;
+	}
+
+	@Override
+	public int purgeBefore(Date before) {
+		int messages = sessionFactory.getCurrentSession()
+				.createQuery("delete from ChatMessage where createdAt < :before")
+				.setParameter("before", before)
+				.executeUpdate();
+		// Orphaned headers: any session whose lastActivityAt predates the
+		// retention horizon AND has no surviving messages. With the message
+		// rows already gone above, "no surviving messages" is implicit.
+		int sessions = sessionFactory.getCurrentSession()
+				.createQuery("delete from ChatSession where lastActivityAt < :before")
+				.setParameter("before", before)
+				.executeUpdate();
+		return messages + sessions;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartBuildingStrategy.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartBuildingStrategy.java
@@ -126,6 +126,29 @@ class ChartBuildingStrategy {
 		return buildChartWithEmbeddings(patient, question);
 	}
 
+	/**
+	 * Build the FULL patient chart (no retrieval, no pre-filter) regardless of
+	 * the operator's {@code chartsearchai.embedding.preFilter} setting. Used
+	 * by the multi-turn chat path which needs a byte-stable chart prefix
+	 * across all turns of a session — pre-filter pipelines build a different
+	 * chart per question, which would break the LLM's prompt cache and make
+	 * "what about the diabetes?" follow-ups impossible to ground.
+	 *
+	 * <p>Mirrors the no-pre-filter branch of {@link #buildChart} but is
+	 * always full-chart so the caller doesn't have to know about the global
+	 * property. The {@code chartCache} is shared with that branch so a
+	 * session-create within seconds of a single-shot search hits the cache.
+	 */
+	PatientChart buildChartUnfiltered(Patient patient) {
+		PatientChart cached = chartCache.get(patient);
+		if (cached != null) {
+			return cached;
+		}
+		PatientChart chart = chartSerializer.serialize(patient);
+		chartCache.put(patient, chart);
+		return chart;
+	}
+
 	private PatientChart buildChartWithEmbeddings(Patient patient, String question) {
 		// findSimilar returns null when no embeddings exist (needs indexing),
 		// or an empty list when embeddings exist but nothing matched the query.

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChatMessages.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChatMessages.java
@@ -9,9 +9,15 @@
  */
 package org.openmrs.module.chartsearchai.api.impl;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.openmrs.module.chartsearchai.model.ChatMessage;
 
 final class ChatMessages {
 
@@ -20,17 +26,94 @@ final class ChatMessages {
 
 	static ArrayNode systemAndUser(ObjectMapper mapper, String system, String user) {
 		ArrayNode messages = mapper.createArrayNode();
-
-		ObjectNode systemMsg = mapper.createObjectNode();
-		systemMsg.put("role", "system");
-		systemMsg.put("content", system);
-		messages.add(systemMsg);
-
-		ObjectNode userMsg = mapper.createObjectNode();
-		userMsg.put("role", "user");
-		userMsg.put("content", user);
-		messages.add(userMsg);
-
+		appendMessage(messages, mapper, "system", system);
+		appendMessage(messages, mapper, "user", user);
 		return messages;
+	}
+
+	/**
+	 * Assemble a multi-turn OpenAI-compatible {@code messages[]} array with
+	 * the patient chart sitting in the <b>stable prefix position</b>:
+	 *
+	 * <pre>
+	 *   [system, user(chart), ...prior user/assistant pairs (no chart), user(current question)]
+	 * </pre>
+	 *
+	 * <p>This is the cache-friendly shape per Anthropic / OpenAI / llama.cpp
+	 * prompt-caching docs: static content at the top, variable content at
+	 * the end. Provided the caller passes a byte-identical {@code chartText}
+	 * across all turns of a session ({@code chat_session.chart_snapshot}),
+	 * the LLM server's prompt cache will skip re-processing the entire
+	 * chart on follow-ups — only the new question and the (small) prior
+	 * conversation tail get processed fresh.
+	 *
+	 * <p>Trim path: priors are walked newest-backward and dropped in
+	 * user/assistant pairs only when the conversation tail would push past
+	 * the budget. Chart and system are reserved up front; a response budget
+	 * is also reserved so the LLM has room to generate. Token estimation is
+	 * chars/4 — adequate for the budget envelope, since under this design
+	 * the trim path is exercised only by very long conversations.
+	 */
+	static ArrayNode assembleChat(ObjectMapper mapper, String system, String chartText,
+			List<ChatMessage> priorTurns, String currentQuestion, int maxContextTokens,
+			int responseReserveTokens) {
+		ArrayNode messages = mapper.createArrayNode();
+		appendMessage(messages, mapper, "system", system);
+		appendMessage(messages, mapper, "user", chartText);
+
+		int reserved = estimateTokens(system) + estimateTokens(chartText)
+				+ estimateTokens(currentQuestion) + Math.max(0, responseReserveTokens);
+		int remaining = maxContextTokens - reserved;
+
+		List<ChatMessage> kept = new ArrayList<>();
+		int i = priorTurns == null ? -1 : priorTurns.size() - 1;
+		while (i >= 0 && remaining > 0) {
+			ChatMessage last = priorTurns.get(i);
+			ChatMessage secondLast = i >= 1 ? priorTurns.get(i - 1) : null;
+
+			int pairCost;
+			int step;
+			if (secondLast != null
+					&& ChatMessage.ROLE_ASSISTANT.equals(last.getRole())
+					&& ChatMessage.ROLE_USER.equals(secondLast.getRole())) {
+				pairCost = estimateTokens(last.getContent()) + estimateTokens(secondLast.getContent());
+				step = 2;
+			} else {
+				pairCost = estimateTokens(last.getContent());
+				step = 1;
+			}
+
+			if (pairCost > remaining) {
+				break;
+			}
+
+			kept.add(last);
+			if (step == 2) {
+				kept.add(secondLast);
+			}
+			i -= step;
+			remaining -= pairCost;
+		}
+
+		Collections.reverse(kept);
+		for (ChatMessage m : kept) {
+			appendMessage(messages, mapper, m.getRole(), m.getContent());
+		}
+		appendMessage(messages, mapper, "user", currentQuestion);
+		return messages;
+	}
+
+	private static void appendMessage(ArrayNode messages, ObjectMapper mapper, String role, String content) {
+		ObjectNode node = mapper.createObjectNode();
+		node.put("role", role);
+		node.put("content", content);
+		messages.add(node);
+	}
+
+	private static int estimateTokens(String s) {
+		if (s == null || s.isEmpty()) {
+			return 0;
+		}
+		return (int) Math.ceil(s.length() / 4.0);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChatServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChatServiceImpl.java
@@ -91,6 +91,20 @@ public class ChatServiceImpl implements ChatService {
 	}
 
 	@Override
+	public ChatSession refreshChartSnapshot(Patient patient) {
+		User user = Context.getAuthenticatedUser();
+		ChatSession existing = chatDAO.getLatestSession(patient, user);
+		if (existing == null) {
+			// Nothing to refresh — opening a session builds a fresh snapshot anyway.
+			return createSession(patient, user);
+		}
+		// Rebuild only the three chart fields; the transcript (messages) is never
+		// touched — this is the whole contrast with closeAndStartNew.
+		populateChartSnapshot(existing, patient);
+		return chatDAO.saveSession(existing);
+	}
+
+	@Override
 	public List<ChatMessage> getMessages(ChatSession session) {
 		return chatDAO.getMessages(session);
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChatServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChatServiceImpl.java
@@ -1,0 +1,320 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.ChatService;
+import org.openmrs.module.chartsearchai.api.db.ChartSearchAiDAO;
+import org.openmrs.module.chartsearchai.api.db.ChatDAO;
+import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
+import org.openmrs.module.chartsearchai.model.ChatSession;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("chartSearchAi.chatService")
+@Transactional
+public class ChatServiceImpl implements ChatService {
+
+	private static final Logger log = LoggerFactory.getLogger(ChatServiceImpl.class);
+
+	private static final String SEARCH_MODE_CHAT = "chat";
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@Autowired
+	private ChatDAO chatDAO;
+
+	@Autowired
+	private LlmInferenceService llmInferenceService;
+
+	@Autowired
+	private ChartSearchAiDAO auditDAO;
+
+	@Override
+	public ChatSession openOrLoadActiveSession(Patient patient) {
+		User user = Context.getAuthenticatedUser();
+		ChatSession existing = chatDAO.getLatestSession(patient, user);
+		if (existing != null) {
+			return existing;
+		}
+		return createSession(patient, user);
+	}
+
+	@Override
+	public ChatSession loadByUuid(String uuid) {
+		if (uuid == null || uuid.isEmpty()) {
+			return null;
+		}
+		return chatDAO.getSessionByUuid(uuid);
+	}
+
+	@Override
+	public ChatSession closeAndStartNew(Patient patient) {
+		User user = Context.getAuthenticatedUser();
+		ChatSession existing = chatDAO.getLatestSession(patient, user);
+		if (existing != null) {
+			existing.setStatus(ChatSession.STATUS_CLOSED);
+			existing.setEndedAt(new Date());
+			chatDAO.saveSession(existing);
+		}
+		return createSession(patient, user);
+	}
+
+	@Override
+	public List<ChatMessage> getMessages(ChatSession session) {
+		return chatDAO.getMessages(session);
+	}
+
+	@Override
+	public ChatTurnResult chat(ChatSession session, String question) {
+		ensureChartSnapshot(session);
+		String chartEnvelope = session.getChartSnapshot();
+		List<RecordMapping> mappings = deserializeMappings(session.getChartMappingsJson());
+
+		List<ChatMessage> priorTurns = chatDAO.getMessages(session);
+		int nextOrdinal = chatDAO.getLastOrdinal(session) + 1;
+		persistUserMessage(session, question, nextOrdinal);
+
+		long startedMs = System.currentTimeMillis();
+		ChartAnswer answer;
+		try {
+			answer = llmInferenceService.chat(chartEnvelope, mappings, priorTurns, question);
+		}
+		catch (RuntimeException e) {
+			touchSession(session);
+			throw e;
+		}
+		long elapsedMs = System.currentTimeMillis() - startedMs;
+
+		ChatMessage assistant = persistAssistantTurn(session, answer, nextOrdinal + 1,
+				ChatMessage.FINISH_STOP, question, elapsedMs);
+		touchSession(session);
+
+		return new ChatTurnResult(answer, session.getUuid(), assistant.getUuid());
+	}
+
+	@Override
+	public ChatTurnResult chatStreaming(ChatSession session, String question,
+			Consumer<String> tokenConsumer) {
+		ensureChartSnapshot(session);
+		String chartEnvelope = session.getChartSnapshot();
+		List<RecordMapping> mappings = deserializeMappings(session.getChartMappingsJson());
+
+		List<ChatMessage> priorTurns = chatDAO.getMessages(session);
+		int nextOrdinal = chatDAO.getLastOrdinal(session) + 1;
+		persistUserMessage(session, question, nextOrdinal);
+
+		long startedMs = System.currentTimeMillis();
+		ChartAnswer answer;
+		String finishReason = ChatMessage.FINISH_STOP;
+		try {
+			answer = llmInferenceService.chatStreaming(
+					chartEnvelope, mappings, priorTurns, question, tokenConsumer);
+		}
+		catch (RuntimeException e) {
+			finishReason = ChatMessage.FINISH_ABORTED;
+			touchSession(session);
+			throw e;
+		}
+		long elapsedMs = System.currentTimeMillis() - startedMs;
+
+		ChatMessage assistant = persistAssistantTurn(session, answer, nextOrdinal + 1,
+				finishReason, question, elapsedMs);
+		touchSession(session);
+
+		return new ChatTurnResult(answer, session.getUuid(), assistant.getUuid());
+	}
+
+	protected ChatSession createSession(Patient patient, User user) {
+		ChatSession session = new ChatSession();
+		session.setPatient(patient);
+		session.setUser(user);
+		Date now = new Date();
+		session.setStartedAt(now);
+		session.setLastActivityAt(now);
+		session.setStatus(ChatSession.STATUS_ACTIVE);
+		populateChartSnapshot(session, patient);
+		return chatDAO.saveSession(session);
+	}
+
+	/**
+	 * Backfill chart snapshot for legacy sessions (created before
+	 * chartsearchai-008) on first chat() call. Idempotent.
+	 */
+	protected void ensureChartSnapshot(ChatSession session) {
+		if (session.getChartSnapshot() != null) {
+			return;
+		}
+		populateChartSnapshot(session, session.getPatient());
+		chatDAO.saveSession(session);
+	}
+
+	/**
+	 * Build the full chart for the session's patient (bypassing pre-filter)
+	 * and store envelope + mappings on the session row. The byte-stability
+	 * of envelope across all turns is the load-bearing invariant of the
+	 * chat design — the LLM's prompt cache hits on this prefix.
+	 */
+	protected void populateChartSnapshot(ChatSession session, Patient patient) {
+		PatientChart chart = llmInferenceService.buildSessionChart(patient);
+		session.setChartSnapshot(chart.getText());
+		session.setChartMappingsJson(serializeMappings(chart.getMappings()));
+		session.setChartBuiltAt(new Date());
+	}
+
+	/**
+	 * Serialize {@link RecordMapping} list as JSON with epoch-ms dates so
+	 * the round-trip is locale-free and deterministic. {@code RecordMapping}
+	 * lacks a no-arg ctor so we ser/des via plain Map.
+	 */
+	private static String serializeMappings(List<RecordMapping> mappings) {
+		if (mappings == null || mappings.isEmpty()) {
+			return "[]";
+		}
+		List<Map<String, Object>> wire = new ArrayList<>(mappings.size());
+		for (RecordMapping m : mappings) {
+			Map<String, Object> e = new LinkedHashMap<>();
+			e.put("index", m.getIndex());
+			e.put("resourceType", m.getResourceType());
+			e.put("resourceUuid", m.getResourceUuid());
+			e.put("date", m.getDate() == null ? null : m.getDate().getTime());
+			wire.add(e);
+		}
+		try {
+			return MAPPER.writeValueAsString(wire);
+		}
+		catch (IOException ioe) {
+			throw new APIException("Failed to serialize chart mappings: " + ioe.getMessage(), ioe);
+		}
+	}
+
+	static List<RecordMapping> deserializeMappings(String json) {
+		if (json == null || json.isEmpty() || "[]".equals(json)) {
+			return Collections.emptyList();
+		}
+		try {
+			List<Map<String, Object>> wire = MAPPER.readValue(
+					json, new TypeReference<List<Map<String, Object>>>() {});
+			List<RecordMapping> out = new ArrayList<>(wire.size());
+			for (Map<String, Object> e : wire) {
+				int index = ((Number) e.get("index")).intValue();
+				String type = (String) e.get("resourceType");
+				String uuid = (String) e.get("resourceUuid");
+				Number dateMs = (Number) e.get("date");
+				Date d = dateMs == null ? null : new Date(dateMs.longValue());
+				out.add(new RecordMapping(index, type, uuid, d));
+			}
+			return out;
+		}
+		catch (IOException ioe) {
+			throw new APIException("Failed to deserialize chart mappings: " + ioe.getMessage(), ioe);
+		}
+	}
+
+	protected ChatMessage persistUserMessage(ChatSession session, String content, int ordinal) {
+		ChatMessage msg = new ChatMessage();
+		msg.setSession(session);
+		msg.setOrdinal(ordinal);
+		msg.setRole(ChatMessage.ROLE_USER);
+		msg.setContent(content);
+		msg.setCreatedAt(new Date());
+		return chatDAO.saveMessage(msg);
+	}
+
+	protected ChatMessage persistAssistantTurn(ChatSession session, ChartAnswer answer, int ordinal,
+			String finishReason, String questionForAudit, long responseTimeMs) {
+		ChartSearchAuditLog audit = buildAuditRow(session, questionForAudit, answer, responseTimeMs);
+		auditDAO.saveAuditLog(audit);
+
+		ChatMessage msg = new ChatMessage();
+		msg.setSession(session);
+		msg.setOrdinal(ordinal);
+		msg.setRole(ChatMessage.ROLE_ASSISTANT);
+		msg.setContent(answer.getAnswer());
+		msg.setCreatedAt(new Date());
+		msg.setAuditLog(audit);
+		msg.setInputTokens(answer.getInputTokens());
+		msg.setOutputTokens(answer.getOutputTokens());
+		msg.setFinishReason(finishReason);
+		return chatDAO.saveMessage(msg);
+	}
+
+	protected ChatSession touchSession(ChatSession session) {
+		session.setLastActivityAt(new Date());
+		return chatDAO.saveSession(session);
+	}
+
+	private ChartSearchAuditLog buildAuditRow(ChatSession session, String question,
+			ChartAnswer answer, long responseTimeMs) {
+		ChartSearchAuditLog audit = new ChartSearchAuditLog();
+		audit.setUser(session.getUser());
+		audit.setPatient(session.getPatient());
+		audit.setQuestion(question);
+		audit.setAnswer(answer.getAnswer());
+		audit.setReferenceCount(answer.getReferences() == null ? 0 : answer.getReferences().size());
+		audit.setSearchMode(SEARCH_MODE_CHAT);
+		audit.setResponseTimeMs(responseTimeMs);
+		audit.setInputTokens(answer.getInputTokens());
+		audit.setOutputTokens(answer.getOutputTokens());
+		audit.setDateCreated(new Date());
+		return audit;
+	}
+
+	/**
+	 * Retention horizon for chat content rows. The {@link AuditLogPurgeTask}
+	 * reads this to drive purgeBefore.
+	 */
+	public static int getChatRetentionDays() {
+		String value = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_CHAT_RETENTION_DAYS);
+		if (value != null && !value.trim().isEmpty()) {
+			try {
+				int parsed = Integer.parseInt(value.trim());
+				if (parsed > 0) {
+					return parsed;
+				}
+			}
+			catch (NumberFormatException e) {
+				log.warn("Invalid {} value '{}', using default",
+						ChartSearchAiConstants.GP_CHAT_RETENTION_DAYS, value);
+			}
+		}
+		return ChartSearchAiConstants.DEFAULT_CHAT_RETENTION_DAYS;
+	}
+
+	void requireOk(boolean ok, String msg) {
+		if (!ok) {
+			throw new APIException(msg);
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmEngine.java
@@ -11,6 +11,8 @@ package org.openmrs.module.chartsearchai.api.impl;
 
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
 /**
  * Abstraction for LLM inference engines. Implementations handle the actual
  * model invocation (local or remote) while prompt construction and response
@@ -29,6 +31,17 @@ public interface LlmEngine {
 	InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds);
 
 	/**
+	 * Multi-turn variant: takes a prebuilt OpenAI-compatible messages array
+	 * (system + interleaved user/assistant prior turns + current user message).
+	 * Used by the chat path; the single-turn path keeps calling the
+	 * 3-arg form above.
+	 */
+	default InferenceResult infer(ArrayNode messages, int timeoutSeconds) {
+		throw new UnsupportedOperationException(
+				"infer(messages, timeoutSeconds) not implemented on " + getClass().getSimpleName());
+	}
+
+	/**
 	 * Run inference with streaming, calling the consumer for each token fragment.
 	 *
 	 * @param systemPrompt the system prompt
@@ -39,6 +52,16 @@ public interface LlmEngine {
 	 */
 	InferenceResult inferStreaming(String systemPrompt, String userMessage, int timeoutSeconds,
 			Consumer<String> tokenConsumer);
+
+	/**
+	 * Streaming variant of {@link #infer(ArrayNode, int)}.
+	 */
+	default InferenceResult inferStreaming(ArrayNode messages, int timeoutSeconds,
+			Consumer<String> tokenConsumer) {
+		throw new UnsupportedOperationException(
+				"inferStreaming(messages, timeoutSeconds, consumer) not implemented on "
+						+ getClass().getSimpleName());
+	}
 
 	/**
 	 * Prime the engine's prompt cache with the given prefix. Implementations that

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -27,6 +27,7 @@ import org.openmrs.module.chartsearchai.api.impl.LlmProvider.LlmResponse;
 import org.openmrs.module.chartsearchai.embedding.EmbeddingProvider;
 import org.openmrs.module.chartsearchai.embedding.ModelNoiseProfile;
 import org.openmrs.module.chartsearchai.model.ChartEmbedding;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
 import org.openmrs.module.chartsearchai.serializer.PatientRecordLoader.SerializedRecord;
@@ -125,6 +126,60 @@ public class LlmInferenceService implements ChartSearchService {
 
 		return new ChartAnswer(response.getAnswer(),
 				extractCitedReferences(response.getCitations(), chart.getMappings()),
+				response.getInputTokens(), response.getOutputTokens(),
+				response.getCachedTokens());
+	}
+
+	/**
+	 * Build the full, retrieval-free patient chart that the chat path uses
+	 * as its frozen session prefix. Bypasses {@code chartsearchai.embedding.preFilter}
+	 * deliberately — chat needs byte-stability across turns so the LLM's
+	 * prompt cache can hit, which pre-filter's query-dependent chart breaks.
+	 *
+	 * <p>Returned text is the LLM-ready envelope: "Patient records (most
+	 * recent first):\n<numbered records>". Stored on
+	 * {@code chat_session.chart_snapshot} by {@link ChatServiceImpl}.
+	 */
+	public PatientChart buildSessionChart(Patient patient) {
+		PatientChart chart = chartBuildingStrategy.buildChartUnfiltered(patient);
+		String envelope = "Patient records (most recent first):\n"
+				+ (chart.getText() == null || chart.getText().trim().isEmpty()
+						? "This patient has no records." : chart.getText().stripTrailing());
+		return new PatientChart(envelope, chart.getMappings());
+	}
+
+	/**
+	 * Multi-turn chat using a frozen session-scoped chart envelope. The
+	 * envelope and mappings are passed in (by the {@link ChatServiceImpl},
+	 * sourced from {@code chat_session.chart_snapshot} +
+	 * {@code chart_mappings_json}), so consecutive turns of one session
+	 * send the byte-identical chart prefix and the LLM's prompt cache
+	 * hits on follow-ups.
+	 *
+	 * <p>The {@code question} is the raw clinician text — assembleChat
+	 * places it as the trailing user message, separate from the chart
+	 * envelope.
+	 */
+	public ChartAnswer chat(String chartEnvelope, List<RecordMapping> mappings,
+			List<ChatMessage> priorTurns, String question) {
+		LlmResponse response = llmProvider.chat(chartEnvelope, priorTurns, question);
+
+		return new ChartAnswer(response.getAnswer(),
+				extractCitedReferences(response.getCitations(), mappings),
+				response.getInputTokens(), response.getOutputTokens(),
+				response.getCachedTokens());
+	}
+
+	/**
+	 * Streaming variant of {@link #chat}.
+	 */
+	public ChartAnswer chatStreaming(String chartEnvelope, List<RecordMapping> mappings,
+			List<ChatMessage> priorTurns, String question, Consumer<String> tokenConsumer) {
+		LlmResponse response = llmProvider.chatStreaming(
+				chartEnvelope, priorTurns, question, tokenConsumer);
+
+		return new ChartAnswer(response.getAnswer(),
+				extractCitedReferences(response.getCitations(), mappings),
 				response.getInputTokens(), response.getOutputTokens(),
 				response.getCachedTokens());
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -14,8 +14,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
 import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +35,8 @@ import org.springframework.stereotype.Component;
 public class LlmProvider {
 
 	private static final Logger log = LoggerFactory.getLogger(LlmProvider.class);
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	static final String DEFAULT_SYSTEM_PROMPT = "You are a clinical assistant helping a clinician "
 			+ "review a patient's chart. Answer ONLY the specific query. "
@@ -256,6 +262,90 @@ public class LlmProvider {
 				delegate.accept(out.toString());
 			}
 		}
+	}
+
+	/**
+	 * Multi-turn variant: assembles {@code [system, ...priorTurns..., currentUser]}
+	 * with drop-oldest budget trimming via {@link ChatMessages#fromTurns} and
+	 * hands the prebuilt array to the engine.
+	 *
+	 * <p>Note: only the CURRENT user message carries the patient chart. Prior
+	 * user turns store just the original question text (not chart+question), so
+	 * the chart never appears twice in the message array and stale chart copies
+	 * never confuse the LLM if data changed between turns.
+	 */
+	/**
+	 * Multi-turn chat assembly using the stable system+chart prefix design
+	 * ({@link ChatMessages#assembleChat}). The {@code chartEnvelope} is the
+	 * frozen-per-session bytes (typically "Patient records (most recent
+	 * first):\n<numbered records>") and stays byte-identical across all
+	 * turns; the {@code question} is just the raw clinician text; priors
+	 * carry user/assistant pairs (no chart bytes inside).
+	 *
+	 * <p>This produces:
+	 * <pre>
+	 *   [system, user(chartEnvelope), ...priors..., user(question)]
+	 * </pre>
+	 * which hits the LLM server's prompt cache on every follow-up because
+	 * the first two messages are byte-identical across turns of a session.
+	 */
+	public LlmResponse chat(String chartEnvelope, List<ChatMessage> priorTurns, String question) {
+		String systemPrompt = getSystemPrompt();
+		int maxTokens = getMaxContextTokens();
+		int responseReserve = ChartSearchAiConstants.DEFAULT_LLM_MAX_OUTPUT_TOKENS;
+		ArrayNode messages = ChatMessages.assembleChat(
+				MAPPER, systemPrompt, chartEnvelope, priorTurns, question, maxTokens, responseReserve);
+		int includedPriors = messages.size() - 3; // size minus [system, chart_user, current_user]
+		log.debug("chat: priors available={}, included={}, chart_chars={}, budget={} tokens",
+				priorTurns == null ? 0 : priorTurns.size(), Math.max(0, includedPriors),
+				chartEnvelope == null ? 0 : chartEnvelope.length(), maxTokens);
+		LlmEngine.InferenceResult result = getActiveEngine().infer(messages, getTimeoutSeconds());
+		return extractResponse(result.getText(), result.getInputTokens(), result.getOutputTokens(),
+				result.getCachedTokens());
+	}
+
+	/**
+	 * Streaming multi-turn variant. Same assembly contract as
+	 * {@link #chat(String, List, String)}; tokenConsumer receives unwrapped
+	 * answer text via {@link AnswerExtractingConsumer}.
+	 */
+	public LlmResponse chatStreaming(String chartEnvelope, List<ChatMessage> priorTurns,
+			String question, Consumer<String> tokenConsumer) {
+		String systemPrompt = getSystemPrompt();
+		int maxTokens = getMaxContextTokens();
+		int responseReserve = ChartSearchAiConstants.DEFAULT_LLM_MAX_OUTPUT_TOKENS;
+		ArrayNode messages = ChatMessages.assembleChat(
+				MAPPER, systemPrompt, chartEnvelope, priorTurns, question, maxTokens, responseReserve);
+		int includedPriors = messages.size() - 3;
+		log.debug("chatStreaming: priors available={}, included={}, chart_chars={}, budget={} tokens",
+				priorTurns == null ? 0 : priorTurns.size(), Math.max(0, includedPriors),
+				chartEnvelope == null ? 0 : chartEnvelope.length(), maxTokens);
+
+		AnswerExtractingConsumer filter = new AnswerExtractingConsumer(tokenConsumer);
+
+		LlmEngine.InferenceResult result = getActiveEngine().inferStreaming(
+				messages, getTimeoutSeconds(), filter);
+
+		return extractResponse(result.getText(), result.getInputTokens(), result.getOutputTokens(),
+				result.getCachedTokens());
+	}
+
+	protected int getMaxContextTokens() {
+		String value = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_CHAT_MAX_CONTEXT_TOKENS);
+		if (value != null && !value.trim().isEmpty()) {
+			try {
+				int parsed = Integer.parseInt(value.trim());
+				if (parsed > 0) {
+					return parsed;
+				}
+				log.warn("chartsearchai.chat.maxContextTokens must be positive, got '{}', using default", parsed);
+			}
+			catch (NumberFormatException e) {
+				log.warn("Invalid chartsearchai.chat.maxContextTokens '{}', using default", value);
+			}
+		}
+		return ChartSearchAiConstants.DEFAULT_CHAT_MAX_CONTEXT_TOKENS;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -108,9 +108,15 @@ public class LocalLlmEngine implements LlmEngine {
 	@Override
 	public synchronized InferenceResult infer(String systemPrompt, String userMessage,
 			int timeoutSeconds) {
+		return infer(ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage), timeoutSeconds);
+	}
+
+	@Override
+	public synchronized InferenceResult infer(ArrayNode messages, int timeoutSeconds) {
 		ensureServerRunning();
 
-		String requestBody = buildRequestBody(systemPrompt, userMessage, false);
+		String requestBody = buildRequestBody(messages, false,
+				ChartSearchAiConstants.DEFAULT_LLM_MAX_OUTPUT_TOKENS);
 
 		HttpRequest request = HttpRequest.newBuilder()
 				.uri(URI.create(getCompletionsUrl()))
@@ -151,9 +157,17 @@ public class LocalLlmEngine implements LlmEngine {
 	@Override
 	public synchronized InferenceResult inferStreaming(String systemPrompt, String userMessage,
 			int timeoutSeconds, Consumer<String> tokenConsumer) {
+		return inferStreaming(ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage),
+				timeoutSeconds, tokenConsumer);
+	}
+
+	@Override
+	public synchronized InferenceResult inferStreaming(ArrayNode messages, int timeoutSeconds,
+			Consumer<String> tokenConsumer) {
 		ensureServerRunning();
 
-		String requestBody = buildRequestBody(systemPrompt, userMessage, true);
+		String requestBody = buildRequestBody(messages, true,
+				ChartSearchAiConstants.DEFAULT_LLM_MAX_OUTPUT_TOKENS);
 
 		HttpRequest request = HttpRequest.newBuilder()
 				.uri(URI.create(getCompletionsUrl()))
@@ -462,6 +476,11 @@ public class LocalLlmEngine implements LlmEngine {
 
 	String buildRequestBody(String systemPrompt, String userMessage, boolean stream,
 			int maxTokens) {
+		return buildRequestBody(ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage),
+				stream, maxTokens);
+	}
+
+	String buildRequestBody(ArrayNode messages, boolean stream, int maxTokens) {
 		ObjectNode root = MAPPER.createObjectNode();
 		root.put("temperature", 0.0);
 		root.put("max_tokens", maxTokens);
@@ -509,7 +528,7 @@ public class LocalLlmEngine implements LlmEngine {
 		}
 
 		root.set("response_format", ChartAnswerResponseFormat.build(MAPPER));
-		root.set("messages", ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage));
+		root.set("messages", messages);
 
 		try {
 			return MAPPER.writeValueAsString(root);

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.function.Consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.openmrs.api.APIException;
@@ -47,11 +48,16 @@ public class RemoteLlmEngine implements LlmEngine {
 
 	@Override
 	public InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds) {
+		return infer(ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage), timeoutSeconds);
+	}
+
+	@Override
+	public InferenceResult infer(ArrayNode messages, int timeoutSeconds) {
 		String endpointUrl = getRequiredGlobalProperty(ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL);
 		String apiKey = getOptionalRuntimeProperty(ChartSearchAiConstants.RP_LLM_REMOTE_API_KEY);
 		String modelName = getRequiredGlobalProperty(ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME);
 
-		String requestBody = buildRequestBody(systemPrompt, userMessage, modelName, false);
+		String requestBody = buildRequestBody(messages, modelName, false);
 
 		HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
 				.uri(URI.create(endpointUrl))
@@ -90,11 +96,18 @@ public class RemoteLlmEngine implements LlmEngine {
 	@Override
 	public InferenceResult inferStreaming(String systemPrompt, String userMessage,
 			int timeoutSeconds, Consumer<String> tokenConsumer) {
+		return inferStreaming(ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage),
+				timeoutSeconds, tokenConsumer);
+	}
+
+	@Override
+	public InferenceResult inferStreaming(ArrayNode messages, int timeoutSeconds,
+			Consumer<String> tokenConsumer) {
 		String endpointUrl = getRequiredGlobalProperty(ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL);
 		String apiKey = getOptionalRuntimeProperty(ChartSearchAiConstants.RP_LLM_REMOTE_API_KEY);
 		String modelName = getRequiredGlobalProperty(ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME);
 
-		String requestBody = buildRequestBody(systemPrompt, userMessage, modelName, true);
+		String requestBody = buildRequestBody(messages, modelName, true);
 
 		HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
 				.uri(URI.create(endpointUrl))
@@ -152,6 +165,11 @@ public class RemoteLlmEngine implements LlmEngine {
 
 	String buildRequestBody(String systemPrompt, String userMessage, String modelName,
 			boolean stream) {
+		return buildRequestBody(ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage),
+				modelName, stream);
+	}
+
+	String buildRequestBody(ArrayNode messages, String modelName, boolean stream) {
 		ObjectNode root = MAPPER.createObjectNode();
 		root.put("model", modelName);
 		// Anthropic's compat endpoint rejects temperature/top_p on Opus 4.7; top_k=1 is the only greedy-decoding lever it still accepts.
@@ -169,7 +187,7 @@ public class RemoteLlmEngine implements LlmEngine {
 		}
 
 		root.set("response_format", ChartAnswerResponseFormat.build(MAPPER));
-		root.set("messages", ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage));
+		root.set("messages", messages);
 
 		try {
 			return MAPPER.writeValueAsString(root);

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/ChatMessage.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/ChatMessage.java
@@ -1,0 +1,167 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * One message within a {@link ChatSession}. Ordinal gives linear-history sort;
+ * parent_message_id is reserved for future branching (regenerate-answer UX).
+ * The audit_log_id link on assistant messages bridges back to the existing
+ * {@link ChartSearchAuditLog} regulatory-audit row.
+ */
+public class ChatMessage implements Serializable {
+
+	public static final String ROLE_SYSTEM = "system";
+
+	public static final String ROLE_USER = "user";
+
+	public static final String ROLE_ASSISTANT = "assistant";
+
+	public static final String FINISH_STOP = "stop";
+
+	public static final String FINISH_LENGTH = "length";
+
+	public static final String FINISH_ABORTED = "aborted";
+
+	private static final long serialVersionUID = 1L;
+
+	private Integer messageId;
+
+	private String uuid = UUID.randomUUID().toString();
+
+	private ChatSession session;
+
+	private ChatMessage parentMessage;
+
+	private Integer ordinal;
+
+	private String role;
+
+	private String content;
+
+	private Date createdAt;
+
+	private ChartSearchAuditLog auditLog;
+
+	private Integer inputTokens;
+
+	private Integer outputTokens;
+
+	private boolean summary;
+
+	private String finishReason;
+
+	public Integer getMessageId() {
+		return messageId;
+	}
+
+	public void setMessageId(Integer messageId) {
+		this.messageId = messageId;
+	}
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public ChatSession getSession() {
+		return session;
+	}
+
+	public void setSession(ChatSession session) {
+		this.session = session;
+	}
+
+	public ChatMessage getParentMessage() {
+		return parentMessage;
+	}
+
+	public void setParentMessage(ChatMessage parentMessage) {
+		this.parentMessage = parentMessage;
+	}
+
+	public Integer getOrdinal() {
+		return ordinal;
+	}
+
+	public void setOrdinal(Integer ordinal) {
+		this.ordinal = ordinal;
+	}
+
+	public String getRole() {
+		return role;
+	}
+
+	public void setRole(String role) {
+		this.role = role;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+
+	public Date getCreatedAt() {
+		return createdAt;
+	}
+
+	public void setCreatedAt(Date createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	public ChartSearchAuditLog getAuditLog() {
+		return auditLog;
+	}
+
+	public void setAuditLog(ChartSearchAuditLog auditLog) {
+		this.auditLog = auditLog;
+	}
+
+	public Integer getInputTokens() {
+		return inputTokens;
+	}
+
+	public void setInputTokens(Integer inputTokens) {
+		this.inputTokens = inputTokens;
+	}
+
+	public Integer getOutputTokens() {
+		return outputTokens;
+	}
+
+	public void setOutputTokens(Integer outputTokens) {
+		this.outputTokens = outputTokens;
+	}
+
+	public boolean isSummary() {
+		return summary;
+	}
+
+	public void setSummary(boolean summary) {
+		this.summary = summary;
+	}
+
+	public String getFinishReason() {
+		return finishReason;
+	}
+
+	public void setFinishReason(String finishReason) {
+		this.finishReason = finishReason;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/ChatSession.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/ChatSession.java
@@ -1,0 +1,166 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.UUID;
+
+import org.openmrs.Patient;
+import org.openmrs.User;
+
+/**
+ * Header row for one multi-turn chat conversation between a user and the assistant
+ * about a specific patient chart. Conversation content lives in {@link ChatMessage}
+ * rows; this row carries the (patient, user) scope plus thread-level lifecycle.
+ */
+public class ChatSession implements Serializable {
+
+	public static final String STATUS_ACTIVE = "active";
+
+	public static final String STATUS_CLOSED = "closed";
+
+	public static final String STATUS_EXPIRED = "expired";
+
+	private static final long serialVersionUID = 1L;
+
+	private Integer sessionId;
+
+	private String uuid = UUID.randomUUID().toString();
+
+	private Patient patient;
+
+	private User user;
+
+	private Date startedAt;
+
+	private Date lastActivityAt;
+
+	private Date endedAt;
+
+	private String title;
+
+	private String status = STATUS_ACTIVE;
+
+	/**
+	 * Patient chart text snapshot, frozen at session create. Replayed verbatim
+	 * as the first user message on every turn of this session so the LLM's
+	 * prompt cache hits on a stable system+chart prefix. Null only on rows
+	 * created before changeset chartsearchai-008 or when the chart-building
+	 * pipeline returned an empty chart (deferred to lazy build on first chat).
+	 */
+	private String chartSnapshot;
+
+	/**
+	 * JSON-serialized list of {@link org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping}
+	 * captured alongside {@link #chartSnapshot}. Holds index → (resourceType,
+	 * resourceUuid, date) so citations like [57] in the LLM's answer can be
+	 * resolved without rebuilding the chart. Null on legacy rows.
+	 */
+	private String chartMappingsJson;
+
+	private Date chartBuiltAt;
+
+	public Integer getSessionId() {
+		return sessionId;
+	}
+
+	public void setSessionId(Integer sessionId) {
+		this.sessionId = sessionId;
+	}
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public Patient getPatient() {
+		return patient;
+	}
+
+	public void setPatient(Patient patient) {
+		this.patient = patient;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	public Date getStartedAt() {
+		return startedAt;
+	}
+
+	public void setStartedAt(Date startedAt) {
+		this.startedAt = startedAt;
+	}
+
+	public Date getLastActivityAt() {
+		return lastActivityAt;
+	}
+
+	public void setLastActivityAt(Date lastActivityAt) {
+		this.lastActivityAt = lastActivityAt;
+	}
+
+	public Date getEndedAt() {
+		return endedAt;
+	}
+
+	public void setEndedAt(Date endedAt) {
+		this.endedAt = endedAt;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getChartSnapshot() {
+		return chartSnapshot;
+	}
+
+	public void setChartSnapshot(String chartSnapshot) {
+		this.chartSnapshot = chartSnapshot;
+	}
+
+	public String getChartMappingsJson() {
+		return chartMappingsJson;
+	}
+
+	public void setChartMappingsJson(String chartMappingsJson) {
+		this.chartMappingsJson = chartMappingsJson;
+	}
+
+	public Date getChartBuiltAt() {
+		return chartBuiltAt;
+	}
+
+	public void setChartBuiltAt(Date chartBuiltAt) {
+		this.chartBuiltAt = chartBuiltAt;
+	}
+}

--- a/api/src/main/resources/ChatMessage.hbm.xml
+++ b/api/src/main/resources/ChatMessage.hbm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.chartsearchai.model">
+
+	<class name="ChatMessage" table="chartsearchai_chat_message">
+
+		<id name="messageId" column="message_id" type="int">
+			<generator class="native"/>
+		</id>
+
+		<property name="uuid" column="uuid" type="string" length="38" not-null="true" unique="true"/>
+
+		<many-to-one name="session" class="ChatSession" column="session_id" not-null="true"/>
+
+		<many-to-one name="parentMessage" class="ChatMessage" column="parent_message_id"/>
+
+		<property name="ordinal" column="ordinal" type="int" not-null="true"/>
+
+		<property name="role" column="role" type="string" length="16" not-null="true"/>
+
+		<property name="content" column="content" type="text" not-null="true"/>
+
+		<property name="createdAt" column="created_at" type="timestamp" not-null="true"/>
+
+		<many-to-one name="auditLog" class="ChartSearchAuditLog" column="audit_log_id"/>
+
+		<property name="inputTokens" column="input_tokens" type="java.lang.Integer"/>
+
+		<property name="outputTokens" column="output_tokens" type="java.lang.Integer"/>
+
+		<property name="summary" column="is_summary" type="boolean" not-null="true"/>
+
+		<property name="finishReason" column="finish_reason" type="string" length="20"/>
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/ChatSession.hbm.xml
+++ b/api/src/main/resources/ChatSession.hbm.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.chartsearchai.model">
+
+	<class name="ChatSession" table="chartsearchai_chat_session">
+
+		<id name="sessionId" column="session_id" type="int">
+			<generator class="native"/>
+		</id>
+
+		<property name="uuid" column="uuid" type="string" length="38" not-null="true" unique="true"/>
+
+		<many-to-one name="patient" class="org.openmrs.Patient" column="patient_id" not-null="true"/>
+
+		<many-to-one name="user" class="org.openmrs.User" column="user_id" not-null="true"/>
+
+		<property name="startedAt" column="started_at" type="timestamp" not-null="true"/>
+
+		<property name="lastActivityAt" column="last_activity_at" type="timestamp" not-null="true"/>
+
+		<property name="endedAt" column="ended_at" type="timestamp"/>
+
+		<property name="title" column="title" type="string" length="200"/>
+
+		<property name="status" column="status" type="string" length="20" not-null="true"/>
+
+		<property name="chartSnapshot" column="chart_snapshot" type="text"/>
+
+		<property name="chartMappingsJson" column="chart_mappings_json" type="text"/>
+
+		<property name="chartBuiltAt" column="chart_built_at" type="timestamp"/>
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -124,4 +124,131 @@
 		</update>
 	</changeSet>
 
+	<changeSet id="chartsearchai-007" author="openmrs">
+		<comment>
+			Multi-turn chat history. Two tables — a session header and the message rows.
+			Existing chartsearchai_audit_log is intentionally untouched: it remains the
+			regulatory audit-of-record (long retention). chartsearchai_chat_message holds
+			conversation content (shorter clinical-utility retention) and links to the
+			audit row via a nullable assistant-side FK.
+
+			Columns reserved for future capability without future migrations:
+			  - chat_message.parent_message_id  → branching / regenerate-answer
+			  - chat_message.is_summary         → context-window summarization
+			  - chat_message.finish_reason      → honest partial-stream / abort rows
+			  - chat_session.title              → LLM-generated thread titles
+			  - chat_session.status             → idle-close policy (POC default: persistent)
+		</comment>
+		<createTable tableName="chartsearchai_chat_session">
+			<column name="session_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true"
+						uniqueConstraintName="uk_chartsearchai_chat_session_uuid"/>
+			</column>
+			<column name="patient_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="user_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="started_at" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+			<column name="last_activity_at" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+			<column name="ended_at" type="datetime"/>
+			<column name="title" type="varchar(200)"/>
+			<column name="status" type="varchar(20)" defaultValue="active">
+				<constraints nullable="false"/>
+			</column>
+		</createTable>
+		<addForeignKeyConstraint baseTableName="chartsearchai_chat_session" baseColumnNames="patient_id"
+				referencedTableName="patient" referencedColumnNames="patient_id"
+				constraintName="fk_chartsearchai_chat_session_patient"/>
+		<addForeignKeyConstraint baseTableName="chartsearchai_chat_session" baseColumnNames="user_id"
+				referencedTableName="users" referencedColumnNames="user_id"
+				constraintName="fk_chartsearchai_chat_session_user"/>
+		<createIndex tableName="chartsearchai_chat_session" indexName="idx_chartsearchai_chat_session_lookup">
+			<column name="patient_id"/>
+			<column name="user_id"/>
+			<column name="last_activity_at"/>
+		</createIndex>
+
+		<createTable tableName="chartsearchai_chat_message">
+			<column name="message_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true"
+						uniqueConstraintName="uk_chartsearchai_chat_message_uuid"/>
+			</column>
+			<column name="session_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="parent_message_id" type="int"/>
+			<column name="ordinal" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="role" type="varchar(16)">
+				<constraints nullable="false"/>
+			</column>
+			<column name="content" type="mediumtext">
+				<constraints nullable="false"/>
+			</column>
+			<column name="created_at" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+			<column name="audit_log_id" type="int"/>
+			<column name="input_tokens" type="int"/>
+			<column name="output_tokens" type="int"/>
+			<column name="is_summary" type="boolean" defaultValueBoolean="false">
+				<constraints nullable="false"/>
+			</column>
+			<column name="finish_reason" type="varchar(20)"/>
+		</createTable>
+		<addForeignKeyConstraint baseTableName="chartsearchai_chat_message" baseColumnNames="session_id"
+				referencedTableName="chartsearchai_chat_session" referencedColumnNames="session_id"
+				constraintName="fk_chartsearchai_chat_message_session"/>
+		<addForeignKeyConstraint baseTableName="chartsearchai_chat_message" baseColumnNames="parent_message_id"
+				referencedTableName="chartsearchai_chat_message" referencedColumnNames="message_id"
+				constraintName="fk_chartsearchai_chat_message_parent"/>
+		<addForeignKeyConstraint baseTableName="chartsearchai_chat_message" baseColumnNames="audit_log_id"
+				referencedTableName="chartsearchai_audit_log" referencedColumnNames="audit_log_id"
+				constraintName="fk_chartsearchai_chat_message_audit"/>
+		<addUniqueConstraint tableName="chartsearchai_chat_message" columnNames="session_id,ordinal"
+				constraintName="uk_chartsearchai_chat_message_ordinal"/>
+		<createIndex tableName="chartsearchai_chat_message" indexName="idx_chartsearchai_chat_message_session">
+			<column name="session_id"/>
+			<column name="created_at"/>
+		</createIndex>
+	</changeSet>
+
+	<changeSet id="chartsearchai-008" author="openmrs">
+		<comment>
+			Add the per-session frozen chart snapshot. Multi-turn chat needs a
+			byte-stable patient-chart prefix across every turn of a session so
+			the LLM's prompt cache hits (Anthropic / OpenAI / llama.cpp all
+			converge on "static content at top, variable at end" for caching).
+			Today the chart sits in the variable-tail current-user message and
+			is rebuilt per question; this makes the cache miss and, more
+			importantly, prevents the LLM from seeing any prior turns when the
+			chart alone fills the budget.
+
+			The snapshot is taken once on session create (full chart, bypassing
+			usePreFilter — chat ignores the pre-filter setting). It's also
+			rewritten when the operator clicks "New chat" (closeAndStartNew).
+			chart_mappings_json carries the citation lookup table so [N] in the
+			LLM's answer can be resolved to a record uuid without rebuilding
+			the chart at every turn.
+		</comment>
+		<addColumn tableName="chartsearchai_chat_session">
+			<column name="chart_snapshot" type="mediumtext"/>
+			<column name="chart_mappings_json" type="mediumtext"/>
+			<column name="chart_built_at" type="datetime"/>
+		</addColumn>
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChatServiceRefreshTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChatServiceRefreshTest.java
@@ -1,0 +1,100 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.api.ChatService;
+import org.openmrs.module.chartsearchai.api.db.ChatDAO;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
+import org.openmrs.module.chartsearchai.model.ChatSession;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Lifecycle contract for chat sessions, exercised through the real
+ * {@link ChatService} + {@link ChatDAO} + chart serialization against a real
+ * patient (no mocks — module rule).
+ *
+ * <p>The load-bearing contrast: {@code refreshChartSnapshot} rebuilds the chart
+ * while KEEPING the transcript (same session, same messages, fresh chart);
+ * {@code closeAndStartNew} clears it (new session, empty transcript). Asserting
+ * both in one suite is the whole point — a refresh that accidentally behaved
+ * like new-chat would silently lose the clinician's conversation.
+ */
+public class ChatServiceRefreshTest extends BaseModuleContextSensitiveTest {
+
+	@Autowired
+	private ChatService chatService;
+
+	@Autowired
+	private ChatDAO chatDAO;
+
+	private Patient patient;
+
+	@BeforeEach
+	public void setUp() {
+		patient = Context.getPatientService().getPatient(2);
+		assertNotNull(patient, "standard test patient 2 must exist");
+	}
+
+	private void addTurn(ChatSession session, int ordinal, String role, String content) {
+		ChatMessage m = new ChatMessage();
+		m.setSession(session);
+		m.setOrdinal(ordinal);
+		m.setRole(role);
+		m.setContent(content);
+		m.setCreatedAt(new Date());
+		chatDAO.saveMessage(m);
+	}
+
+	@Test
+	public void refreshChartSnapshot_rebuildsChartButKeepsTranscriptAndSession() {
+		ChatSession session = chatService.openOrLoadActiveSession(patient);
+		String originalUuid = session.getUuid();
+		assertNotNull(session.getChartSnapshot(), "a session opens with a chart snapshot");
+		addTurn(session, 0, ChatMessage.ROLE_USER, "What medications is this patient on?");
+		addTurn(session, 1, ChatMessage.ROLE_ASSISTANT, "Lisinopril 10mg [2]");
+		Context.flushSession();
+		assertEquals(2, chatService.getMessages(session).size(), "precondition: 2 turns persisted");
+
+		ChatSession refreshed = chatService.refreshChartSnapshot(patient);
+
+		assertEquals(originalUuid, refreshed.getUuid(), "refresh keeps the same session");
+		assertEquals(2, chatService.getMessages(refreshed).size(),
+				"refresh must NOT clear the transcript");
+		assertNotNull(refreshed.getChartSnapshot(), "refresh leaves a chart snapshot in place");
+		assertNotNull(refreshed.getChartBuiltAt(), "refresh stamps chartBuiltAt");
+	}
+
+	@Test
+	public void closeAndStartNew_clearsTranscriptAndOpensNewSession() {
+		ChatSession session = chatService.openOrLoadActiveSession(patient);
+		String originalUuid = session.getUuid();
+		addTurn(session, 0, ChatMessage.ROLE_USER, "q");
+		addTurn(session, 1, ChatMessage.ROLE_ASSISTANT, "a");
+		Context.flushSession();
+		assertEquals(2, chatService.getMessages(session).size(), "precondition: 2 turns persisted");
+
+		ChatSession fresh = chatService.closeAndStartNew(patient);
+
+		assertNotEquals(originalUuid, fresh.getUuid(), "new chat opens a different session");
+		assertEquals(0, chatService.getMessages(fresh).size(),
+				"new chat starts with an empty transcript");
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/MessagesArrayShapeTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/MessagesArrayShapeTest.java
@@ -1,0 +1,237 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
+
+/**
+ * Contract tests for {@link ChatMessages#assembleChat} — the new multi-turn
+ * message-array builder that puts the patient chart in a stable prefix
+ * position (between the system message and the variable conversation tail).
+ *
+ * <p>The load-bearing property under test: the first two messages of the
+ * produced array are byte-identical across all calls with the same system
+ * prompt + chart envelope, regardless of priors or current question. That
+ * byte-identity is what makes the LLM server's prompt cache hit on
+ * follow-up turns (Anthropic, OpenAI, llama.cpp all converge on this
+ * static-at-top / variable-at-end rule). If this regresses, every chat
+ * follow-up will re-process the entire chart from scratch (~8s observed
+ * on a 32K-context Gemma) and the cache layer is wasted.
+ */
+public class MessagesArrayShapeTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private static final String SYSTEM = "You are a clinical assistant.";
+
+	private static final String CHART = "Patient records (most recent first):\n"
+			+ "Patient: 47-year-old Female\n\n"
+			+ "[1] (2026-04-05) Diagnosis: Hypertension\n"
+			+ "[2] (2026-04-05) Medication: Lisinopril 10mg\n"
+			+ "[3] (2026-03-20) Allergy: Penicillin";
+
+	private static final int LARGE_BUDGET = 100_000;
+
+	private static final int RESPONSE_RESERVE = 1024;
+
+	@Test
+	public void emptyPriorsShouldProduceSystemChartCurrentUserOnly() {
+		ArrayNode out = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, CHART, Collections.emptyList(),
+				"What meds is she on?", LARGE_BUDGET, RESPONSE_RESERVE);
+
+		assertEquals(3, out.size(),
+				"expected [system, user(chart), user(question)]; got " + out);
+		assertRole(out, 0, "system", SYSTEM);
+		assertRole(out, 1, "user", CHART);
+		assertRole(out, 2, "user", "What meds is she on?");
+	}
+
+	@Test
+	public void priorsShouldSitBetweenChartAndCurrentQuestion() {
+		List<ChatMessage> prior = Arrays.asList(
+				turn(ChatMessage.ROLE_USER, "What meds is she on?"),
+				turn(ChatMessage.ROLE_ASSISTANT, "Lisinopril 10mg [2]"));
+
+		ArrayNode out = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, CHART, prior,
+				"And her allergies?", LARGE_BUDGET, RESPONSE_RESERVE);
+
+		assertEquals(5, out.size(),
+				"expected [system, user(chart), user(Q1), assistant(A1), user(Q2)]; got " + out);
+		assertRole(out, 0, "system", SYSTEM);
+		assertRole(out, 1, "user", CHART);
+		assertRole(out, 2, "user", "What meds is she on?");
+		assertRole(out, 3, "assistant", "Lisinopril 10mg [2]");
+		assertRole(out, 4, "user", "And her allergies?");
+	}
+
+	@Test
+	public void firstTwoMessagesByteIdenticalAcrossTurns_loadBearingForCacheHits() {
+		// Turn 1 — no priors yet
+		ArrayNode turn1 = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, CHART, Collections.emptyList(),
+				"first question", LARGE_BUDGET, RESPONSE_RESERVE);
+
+		// Turn 2 — one prior pair, different question
+		List<ChatMessage> prior = Arrays.asList(
+				turn(ChatMessage.ROLE_USER, "first question"),
+				turn(ChatMessage.ROLE_ASSISTANT, "first answer"));
+		ArrayNode turn2 = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, CHART, prior,
+				"second question entirely different", LARGE_BUDGET, RESPONSE_RESERVE);
+
+		// Turn 3 — two prior pairs, a third question
+		List<ChatMessage> prior2 = Arrays.asList(
+				turn(ChatMessage.ROLE_USER, "first question"),
+				turn(ChatMessage.ROLE_ASSISTANT, "first answer"),
+				turn(ChatMessage.ROLE_USER, "second question entirely different"),
+				turn(ChatMessage.ROLE_ASSISTANT, "second answer"));
+		ArrayNode turn3 = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, CHART, prior2,
+				"third", LARGE_BUDGET, RESPONSE_RESERVE);
+
+		// The cache-eligible prefix: system + chart-user-message. Bytes must
+		// match exactly across all three turns; if this fails, the LLM
+		// server's prompt cache will never hit.
+		String prefix1 = turn1.get(0).toString() + turn1.get(1).toString();
+		String prefix2 = turn2.get(0).toString() + turn2.get(1).toString();
+		String prefix3 = turn3.get(0).toString() + turn3.get(1).toString();
+
+		assertEquals(prefix1, prefix2,
+				"turn 2's [system, chart] prefix must match turn 1's byte-for-byte");
+		assertEquals(prefix2, prefix3,
+				"turn 3's [system, chart] prefix must match turn 2's byte-for-byte");
+	}
+
+	@Test
+	public void chartShouldNeverAppearInsidePriorMessages() {
+		// Adversarial: a prior message that contains chart-like text. The
+		// produced array's index-1 entry must be the CHART parameter, exact.
+		// Priors (index 2+) must NOT contain "Lisinopril 10mg" (which is in
+		// the chart) UNLESS the prior content itself contains that text.
+		List<ChatMessage> prior = Arrays.asList(
+				turn(ChatMessage.ROLE_USER, "tell me about her diabetes"),
+				turn(ChatMessage.ROLE_ASSISTANT, "There is no diabetes diagnosis in the chart."));
+
+		ArrayNode out = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, CHART, prior, "what about hypertension?", LARGE_BUDGET, RESPONSE_RESERVE);
+
+		assertEquals(CHART, out.get(1).get("content").asText(),
+				"chart envelope must appear verbatim at index 1");
+
+		// Walk priors (index 2..size-2): no chart content
+		for (int i = 2; i < out.size() - 1; i++) {
+			String content = out.get(i).get("content").asText();
+			assertFalse(content.contains("Lisinopril 10mg"),
+					"prior at index " + i + " must not contain chart bytes; got: " + content);
+			assertFalse(content.startsWith("Patient records"),
+					"prior at index " + i + " must not contain chart envelope prefix");
+		}
+	}
+
+	@Test
+	public void systemMessageAlwaysAtIndexZero_evenUnderTightBudget() {
+		List<ChatMessage> prior = Arrays.asList(
+				turn(ChatMessage.ROLE_USER, "long prior question " + "x".repeat(2000)),
+				turn(ChatMessage.ROLE_ASSISTANT, "long prior answer " + "y".repeat(2000)));
+
+		// Budget=0 forces every prior to be dropped, but system must survive.
+		ArrayNode out = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, CHART, prior, "current", 0, 0);
+
+		assertTrue(out.size() >= 3, "at minimum [system, chart, current_user]");
+		assertRole(out, 0, "system", SYSTEM);
+		assertRole(out, 1, "user", CHART);
+		assertRole(out, out.size() - 1, "user", "current");
+	}
+
+	@Test
+	public void overBudgetShouldDropOldestPairsKeepingNewest() {
+		// Build N pairs of small priors plus a small current and a tiny chart;
+		// configure budget so only ~2 pairs fit.
+		String filler = "x".repeat(200); // ~50 tokens per node
+		List<ChatMessage> prior = Arrays.asList(
+				turn(ChatMessage.ROLE_USER, "OLDEST-user-" + filler),
+				turn(ChatMessage.ROLE_ASSISTANT, "OLDEST-assist-" + filler),
+				turn(ChatMessage.ROLE_USER, "MID-user-" + filler),
+				turn(ChatMessage.ROLE_ASSISTANT, "MID-assist-" + filler),
+				turn(ChatMessage.ROLE_USER, "NEWEST-user-" + filler),
+				turn(ChatMessage.ROLE_ASSISTANT, "NEWEST-assist-" + filler));
+
+		// Budget: system (~6 tokens, 24 chars) + tiny-chart (~6) + current (~2)
+		// + ~120 tokens = enough for 1 pair (~108 tokens). Drops OLDEST and MID.
+		String tinyChart = "Patient: test";
+		ArrayNode out = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, tinyChart, prior, "current", 130, 0);
+
+		String body = out.toString();
+		assertTrue(body.contains("NEWEST-user-") && body.contains("NEWEST-assist-"),
+				"newest pair must be retained; got " + body);
+		assertFalse(body.contains("OLDEST-user-") || body.contains("OLDEST-assist-"),
+				"oldest pair must be dropped under budget pressure; got " + body);
+
+		// System at top, chart at index 1, current question at tail
+		assertEquals("system", out.get(0).get("role").asText());
+		assertEquals(tinyChart, out.get(1).get("content").asText());
+		assertEquals("current", out.get(out.size() - 1).get("content").asText());
+		assertEquals("user", out.get(out.size() - 1).get("role").asText());
+	}
+
+	@Test
+	public void responseReserveShouldShrinkAvailablePriorBudget() {
+		String pad = "x".repeat(400); // ~100 tokens each
+		List<ChatMessage> prior = Arrays.asList(
+				turn(ChatMessage.ROLE_USER, "OLDEST " + pad),
+				turn(ChatMessage.ROLE_ASSISTANT, "old-ans " + pad),
+				turn(ChatMessage.ROLE_USER, "NEWEST " + pad),
+				turn(ChatMessage.ROLE_ASSISTANT, "new-ans " + pad));
+
+		// Without reserve: large budget, both pairs fit
+		ArrayNode withoutReserve = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, "tiny", prior, "q", 1000, 0);
+
+		// With reserve: same budget minus 800 reserved for response → only one pair fits
+		ArrayNode withReserve = ChatMessages.assembleChat(
+				MAPPER, SYSTEM, "tiny", prior, "q", 1000, 800);
+
+		assertTrue(withoutReserve.size() > withReserve.size(),
+				"response reserve must reduce prior count; got "
+						+ withoutReserve.size() + " vs " + withReserve.size());
+	}
+
+	private static ChatMessage turn(String role, String content) {
+		ChatMessage m = new ChatMessage();
+		m.setRole(role);
+		m.setContent(content);
+		return m;
+	}
+
+	private static void assertRole(ArrayNode arr, int index, String role, String content) {
+		JsonNode node = arr.get(index);
+		assertEquals(role, node.get("role").asText(),
+				"role mismatch at index " + index + " in " + arr);
+		assertEquals(content, node.get("content").asText(),
+				"content mismatch at index " + index + " in " + arr);
+	}
+}

--- a/api/src/test/resources/chartsearchai-hibernate.cfg.xml
+++ b/api/src/test/resources/chartsearchai-hibernate.cfg.xml
@@ -6,5 +6,7 @@
 	<session-factory>
 		<mapping resource="ChartEmbedding.hbm.xml"/>
 		<mapping resource="ChartSearchAuditLog.hbm.xml"/>
+		<mapping resource="ChatSession.hbm.xml"/>
+		<mapping resource="ChatMessage.hbm.xml"/>
 	</session-factory>
 </hibernate-configuration>

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -850,6 +850,32 @@ public class ChartSearchAiRestController {
 	}
 
 	/**
+	 * Rebuild the patient's current session's chart snapshot in place, keeping
+	 * the conversation. The deliberate counterpart to {@code /chat/new}: that
+	 * returns {@code messages:[]} to signal a wipe; this omits {@code messages}
+	 * entirely and returns the new {@code chartBuiltAt} to signal "same chat,
+	 * fresher chart". Access is gated by {@code resolvePatient} → canAccess.
+	 */
+	@RequestMapping(value = "/chat/refresh-chart", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Object> chatRefreshChart(@RequestBody Map<String, String> body) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+
+		PatientResolution resolved = resolvePatient(body.get("patient"));
+		if (resolved.hasError()) {
+			return new ResponseEntity<Object>(
+					errorResponse(resolved.errorMessage), resolved.errorStatus);
+		}
+
+		ChatSession session = chatService.refreshChartSnapshot(resolved.patient);
+		Map<String, Object> response = new LinkedHashMap<String, Object>();
+		response.put("session", session.getUuid());
+		response.put("chartBuiltAt",
+				session.getChartBuiltAt() != null ? session.getChartBuiltAt().getTime() : null);
+		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	/**
 	 * Hydrate the SPA on mount: returns the current (patient, user) session
 	 * (creating one if none exists) and its prior messages in chronological
 	 * order. Empty {@code messages[]} on a freshly-created session.
@@ -881,6 +907,8 @@ public class ChartSearchAiRestController {
 
 		Map<String, Object> response = new LinkedHashMap<String, Object>();
 		response.put("session", session.getUuid());
+		response.put("chartBuiltAt",
+				session.getChartBuiltAt() != null ? session.getChartBuiltAt().getTime() : null);
 		response.put("messages", out);
 		return new ResponseEntity<Object>(response, HttpStatus.OK);
 	}

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -36,9 +36,13 @@ import org.openmrs.module.chartsearchai.api.ChartTooLargeException;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 import org.openmrs.module.chartsearchai.api.AuditLogService;
+import org.openmrs.module.chartsearchai.api.ChatService;
+import org.openmrs.module.chartsearchai.api.ChatService.ChatTurnResult;
 import org.openmrs.module.chartsearchai.api.PatientAccessCheck;
 import org.openmrs.module.chartsearchai.api.impl.WarmupExecutor;
 import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
+import org.openmrs.module.chartsearchai.model.ChatMessage;
+import org.openmrs.module.chartsearchai.model.ChatSession;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -110,6 +114,10 @@ public class ChartSearchAiRestController {
 	@Autowired
 	@Qualifier("chartSearchAi.warmupExecutor")
 	private WarmupExecutor warmupExecutor;
+
+	@Autowired
+	@Qualifier("chartSearchAi.chatService")
+	private ChatService chatService;
 
 	@RequestMapping(value = "/search", method = RequestMethod.POST)
 	@ResponseBody
@@ -549,6 +557,348 @@ public class ChartSearchAiRestController {
 		Map<String, Object> response = new HashMap<String, Object>();
 		response.put("success", true);
 		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	// ============================================================================
+	// Multi-turn chat endpoints. The {@code /search} family above is single-shot;
+	// these maintain a per-(patient, user) ChatSession that carries prior turns
+	// into each LLM call. Persistence is handled by {@link ChatService}.
+	// ============================================================================
+
+	/**
+	 * Streaming chat turn. Reuses the (patient, user) session if {@code session}
+	 * is provided AND resolves to an active session; otherwise opens-or-loads the
+	 * latest active session for the user. Surfaces the session uuid via the
+	 * {@code X-ChartSearchAi-Session} response header before the SSE stream opens
+	 * so the client can pin subsequent posts to the same conversation.
+	 *
+	 * <pre>
+	 * POST /ws/rest/v1/chartsearchai/chat/stream
+	 * { "patient": "uuid", "session": "uuid?" , "question": "..." }
+	 * </pre>
+	 */
+	@RequestMapping(value = "/chat/stream", method = RequestMethod.POST)
+	public void chatStream(@RequestBody Map<String, String> body,
+			HttpServletResponse response) throws IOException {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+
+		String patientUuid = body.get("patient");
+		String sessionUuid = body.get("session");
+		String question = body.get("question");
+
+		if (patientUuid == null || patientUuid.trim().isEmpty()) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "patient is required");
+			return;
+		}
+		if (question == null || question.trim().isEmpty()) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "question is required");
+			return;
+		}
+		if (question.length() > MAX_QUESTION_LENGTH) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST,
+					"question exceeds maximum length of " + MAX_QUESTION_LENGTH + " characters");
+			return;
+		}
+
+		String sanitizedQuestion = CONTROL_CHARS.matcher(question).replaceAll("");
+		if (sanitizedQuestion.trim().isEmpty()) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "question is required");
+			return;
+		}
+		String sanitizationError = validateQuestion(sanitizedQuestion);
+		if (sanitizationError != null) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, sanitizationError);
+			return;
+		}
+
+		Patient patient = Context.getPatientService().getPatientByUuid(patientUuid);
+		if (patient == null) {
+			writeJsonError(response, HttpServletResponse.SC_NOT_FOUND, "Patient not found");
+			return;
+		}
+
+		User user = Context.getAuthenticatedUser();
+		if (!patientAccessCheck.canAccess(user, patient)) {
+			writeJsonError(response, HttpServletResponse.SC_FORBIDDEN,
+					"You do not have access to this patient's chart");
+			return;
+		}
+
+		ResponseEntity<Object> rateLimitError = checkRateLimit(user);
+		if (rateLimitError != null) {
+			writeJsonError(response, 429, "Rate limit exceeded");
+			return;
+		}
+
+		ChatSession session = resolveOrOpenSession(patient, sessionUuid);
+
+		// Unwrap any response wrappers that buffer the body (kills SSE liveness).
+		HttpServletResponse unwrapped = response;
+		while (unwrapped instanceof HttpServletResponseWrapper) {
+			javax.servlet.ServletResponse inner =
+					((HttpServletResponseWrapper) unwrapped).getResponse();
+			if (inner instanceof HttpServletResponse) {
+				unwrapped = (HttpServletResponse) inner;
+			} else {
+				break;
+			}
+		}
+
+		response.setContentType("text/event-stream");
+		response.setCharacterEncoding("UTF-8");
+		response.setHeader("Cache-Control", "no-cache");
+		response.setHeader("X-Accel-Buffering", "no");
+		response.setHeader("Connection", "keep-alive");
+		// Surface the session uuid BEFORE the stream opens — the client uses
+		// it to pin all subsequent posts in this conversation.
+		response.setHeader("X-ChartSearchAi-Session", session.getUuid());
+		unwrapped.setBufferSize(0);
+
+		final OutputStream out = unwrapped.getOutputStream();
+		unwrapped.flushBuffer();
+
+		try {
+			ChatTurnResult result = chatService.chatStreaming(
+					session, sanitizedQuestion, new java.util.function.Consumer<String>() {
+						@Override
+						public void accept(String token) {
+							try {
+								writeSseEvent(out, "token", token);
+							}
+							catch (IOException e) {
+								log.debug("Client disconnected during chat streaming");
+								throw new RuntimeException("Client disconnected", e);
+							}
+						}
+					});
+
+			ChartAnswer answer = result.getAnswer();
+			Map<String, Object> doneData = new LinkedHashMap<String, Object>();
+			doneData.put("answer", answer.getAnswer());
+			doneData.put("disclaimer", DISCLAIMER);
+
+			List<Map<String, Object>> refs = new ArrayList<Map<String, Object>>();
+			for (RecordReference ref : answer.getReferences()) {
+				Map<String, Object> refMap = new LinkedHashMap<String, Object>();
+				refMap.put("index", ref.getIndex());
+				refMap.put("resourceType", ref.getResourceType());
+				refMap.put("resourceUuid", ref.getResourceUuid());
+				refMap.put("date", formatDate(ref.getDate()));
+				refs.add(refMap);
+			}
+			doneData.put("references", refs);
+			doneData.put("session", result.getSessionUuid());
+			doneData.put("messageId", result.getAssistantMessageUuid());
+
+			writeSseEvent(out, "done", new ObjectMapper().writeValueAsString(doneData));
+		}
+		catch (ChartTooLargeException e) {
+			log.warn("Chart too large for chat streaming for patient [id={}]: {}",
+					patient.getPatientId(), e.getMessage());
+			try {
+				writeSseEvent(out, "error",
+						"This patient's chart is too large to process. "
+								+ "Contact your administrator to increase the LLM context size.");
+			}
+			catch (IOException ioe) {
+				log.debug("Could not send too-large error event, client likely disconnected");
+			}
+		}
+		catch (IllegalStateException e) {
+			log.error("Chat configuration error during streaming", e);
+			try {
+				writeSseEvent(out, "error",
+						"Chart search is not properly configured. Contact your administrator.");
+			}
+			catch (IOException ioe) {
+				log.debug("Could not send config error event, client likely disconnected");
+			}
+		}
+		catch (Exception e) {
+			if (e.getCause() instanceof IOException) {
+				log.debug("Chat streaming ended due to client disconnect");
+			} else {
+				log.error("Chat streaming failed for patient [id={}]", patient.getPatientId(), e);
+				try {
+					writeSseEvent(out, "error",
+							"Chart search failed. Please try again or contact your administrator.");
+				}
+				catch (IOException ioe) {
+					log.debug("Could not send error event, client likely disconnected");
+				}
+			}
+		}
+
+		try {
+			out.flush();
+		}
+		catch (IOException e) {
+			log.debug("Could not flush chat SSE stream, client likely disconnected");
+		}
+	}
+
+	/**
+	 * Synchronous chat (non-streaming) — convenience for callers that don't need
+	 * SSE. Same persistence semantics as {@link #chatStream}; the session uuid is
+	 * returned in the JSON body (no SSE header).
+	 */
+	@RequestMapping(value = "/chat", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Object> chat(@RequestBody Map<String, String> body) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+
+		String patientUuid = body.get("patient");
+		String sessionUuid = body.get("session");
+		String question = body.get("question");
+
+		PatientResolution resolved = resolvePatient(patientUuid);
+		if (resolved.hasError()) {
+			return new ResponseEntity<Object>(
+					errorResponse(resolved.errorMessage), resolved.errorStatus);
+		}
+		Patient patient = resolved.patient;
+
+		if (question == null || question.trim().isEmpty()) {
+			return new ResponseEntity<Object>(
+					errorResponse("question is required"), HttpStatus.BAD_REQUEST);
+		}
+		if (question.length() > MAX_QUESTION_LENGTH) {
+			return new ResponseEntity<Object>(
+					errorResponse("question exceeds maximum length of "
+							+ MAX_QUESTION_LENGTH + " characters"),
+					HttpStatus.BAD_REQUEST);
+		}
+		question = CONTROL_CHARS.matcher(question).replaceAll("");
+		if (question.trim().isEmpty()) {
+			return new ResponseEntity<Object>(
+					errorResponse("question is required"), HttpStatus.BAD_REQUEST);
+		}
+		String sanitizationError = validateQuestion(question);
+		if (sanitizationError != null) {
+			return new ResponseEntity<Object>(
+					errorResponse(sanitizationError), HttpStatus.BAD_REQUEST);
+		}
+
+		User user = Context.getAuthenticatedUser();
+		ResponseEntity<Object> rateLimitError = checkRateLimit(user);
+		if (rateLimitError != null) {
+			return rateLimitError;
+		}
+
+		ChatSession session = resolveOrOpenSession(patient, sessionUuid);
+
+		ChatTurnResult result;
+		try {
+			result = chatService.chat(session, question);
+		}
+		catch (ChartTooLargeException e) {
+			log.warn("Chart too large for chat for patient [id={}]: {}",
+					patient.getPatientId(), e.getMessage());
+			return new ResponseEntity<Object>(
+					errorResponse("This patient's chart is too large to process. "
+							+ "Contact your administrator to increase the LLM context size."),
+					HttpStatus.PAYLOAD_TOO_LARGE);
+		}
+		catch (Exception e) {
+			log.error("Chat failed for patient [id={}]", patient.getPatientId(), e);
+			return new ResponseEntity<Object>(
+					errorResponse("Chart search failed. Please try again or contact your administrator."),
+					HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+
+		ChartAnswer answer = result.getAnswer();
+		Map<String, Object> response = new LinkedHashMap<String, Object>();
+		response.put("answer", answer.getAnswer());
+		response.put("disclaimer", DISCLAIMER);
+
+		List<Map<String, Object>> refs = new ArrayList<Map<String, Object>>();
+		for (RecordReference ref : answer.getReferences()) {
+			Map<String, Object> refMap = new LinkedHashMap<String, Object>();
+			refMap.put("index", ref.getIndex());
+			refMap.put("resourceType", ref.getResourceType());
+			refMap.put("resourceUuid", ref.getResourceUuid());
+			refMap.put("date", formatDate(ref.getDate()));
+			refs.add(refMap);
+		}
+		response.put("references", refs);
+		response.put("session", result.getSessionUuid());
+		response.put("messageId", result.getAssistantMessageUuid());
+
+		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	/**
+	 * Close the current active session for the (patient, user) pair and open
+	 * a fresh one. Returns the new session uuid + empty messages.
+	 */
+	@RequestMapping(value = "/chat/new", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Object> chatNew(@RequestBody Map<String, String> body) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+
+		PatientResolution resolved = resolvePatient(body.get("patient"));
+		if (resolved.hasError()) {
+			return new ResponseEntity<Object>(
+					errorResponse(resolved.errorMessage), resolved.errorStatus);
+		}
+
+		ChatSession session = chatService.closeAndStartNew(resolved.patient);
+		Map<String, Object> response = new LinkedHashMap<String, Object>();
+		response.put("session", session.getUuid());
+		response.put("messages", new ArrayList<Map<String, Object>>());
+		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	/**
+	 * Hydrate the SPA on mount: returns the current (patient, user) session
+	 * (creating one if none exists) and its prior messages in chronological
+	 * order. Empty {@code messages[]} on a freshly-created session.
+	 */
+	@RequestMapping(value = "/chat", method = RequestMethod.GET)
+	@ResponseBody
+	public ResponseEntity<Object> chatHistory(
+			@RequestParam(value = "patient") String patientUuid) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+
+		PatientResolution resolved = resolvePatient(patientUuid);
+		if (resolved.hasError()) {
+			return new ResponseEntity<Object>(
+					errorResponse(resolved.errorMessage), resolved.errorStatus);
+		}
+
+		ChatSession session = chatService.openOrLoadActiveSession(resolved.patient);
+		List<ChatMessage> messages = chatService.getMessages(session);
+
+		List<Map<String, Object>> out = new ArrayList<Map<String, Object>>();
+		for (ChatMessage m : messages) {
+			Map<String, Object> entry = new LinkedHashMap<String, Object>();
+			entry.put("messageId", m.getUuid());
+			entry.put("role", m.getRole());
+			entry.put("content", m.getContent());
+			entry.put("createdAt", m.getCreatedAt() != null ? m.getCreatedAt().getTime() : null);
+			out.add(entry);
+		}
+
+		Map<String, Object> response = new LinkedHashMap<String, Object>();
+		response.put("session", session.getUuid());
+		response.put("messages", out);
+		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	/**
+	 * Look up an existing session by uuid (loadByUuid); fall back to
+	 * openOrLoadActive when the uuid is missing or stale (e.g. expired).
+	 * Always returns a non-null session.
+	 */
+	private ChatSession resolveOrOpenSession(Patient patient, String sessionUuid) {
+		if (sessionUuid != null && !sessionUuid.trim().isEmpty()) {
+			ChatSession existing = chatService.loadByUuid(sessionUuid.trim());
+			if (existing != null && patient.equals(existing.getPatient())
+					&& ChatSession.STATUS_ACTIVE.equals(existing.getStatus())) {
+				return existing;
+			}
+		}
+		return chatService.openOrLoadActiveSession(patient);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -27,6 +27,8 @@
 	<mappingFiles>
 		ChartEmbedding.hbm.xml
 		ChartSearchAuditLog.hbm.xml
+		ChatSession.hbm.xml
+		ChatMessage.hbm.xml
 	</mappingFiles>
 
 	<!-- Privileges -->


### PR DESCRIPTION
## Summary

Adds a server-side multi-turn chat path to chartsearchai so the AI panel can carry conversation context across turns. Existing `/search` endpoints stay single-shot and unchanged; `/chat` is new.

The design follows the prompt-cache rule that Anthropic, OpenAI, and llama.cpp all converge on in their caching docs: **static content at the top of the prompt, variable content at the end.** The patient chart is the large per-session static block, so it lives in a stable prefix (byte-identical every turn of a session) rather than the variable tail:

```
[ system,
  user(chart envelope — frozen on session create),
  ...prior user/assistant pairs...,
  user(current question) ]
```

A naive design that puts the chart in the current-user message would both miss the cache on every turn AND would force priors to be stripped of the chart to avoid duplication, which breaks the LLM's view of the conversation. This shape avoids both failure modes — verified against LM Studio (`cache_prompt=true`): turn 3's "how many medications did you list?" answered "11" only by reading turn 1's assistant message, with backend logs showing priors flowing and `chart_chars` byte-stable across turns.

## What's new

**Schema** (two changesets — kept separate for already-deployed downstream instances):
- `chartsearchai-007`: `chartsearchai_chat_session` + `chartsearchai_chat_message` tables. Per-`(patient, user)` thread header; ordered turns with `parent_message_id` + `is_summary` reserved for future branching / summarization; assistant rows link back to the existing `chartsearchai_audit_log` via `audit_log_id`.
- `chartsearchai-008`: `chart_snapshot` + `chart_mappings_json` + `chart_built_at` columns on `chat_session`. Chart is built once on session create (or first `chat()` call on legacy sessions) and replayed verbatim every subsequent turn.

**REST**:
- `POST /ws/rest/v1/chartsearchai/chat` — sync, body `{patient, session?, question}`; returns `{answer, references, session, messageId}`.
- `POST /chat/stream` — SSE variant; emits `X-ChartSearchAi-Session` response header before the stream opens so SPA clients can pin subsequent posts to the same conversation.
- `POST /chat/new?patient=...` — closes current active session, opens fresh one (clinician's "New chat" affordance).
- `GET /chat?patient=...` — hydrate the SPA on mount; returns the active session uuid + ordered message list.

**Code**:
- `ChartBuildingStrategy.buildChartUnfiltered(Patient)` — full chart, bypasses `chartsearchai.embedding.preFilter`. Pre-filter remains the right behavior for `/search` single-shot, but in chat the per-question chart variation would break the prefix-cache contract.
- `LlmInferenceService.buildSessionChart(Patient)` produces the LLM-ready envelope ChatService stores on the session row.
- `LlmInferenceService.chat / chatStreaming` take `chartEnvelope` + `mappings` parameters (sourced from `chat_session.chart_snapshot` / `chart_mappings_json`). No per-turn build.
- `ChatMessages.assembleChat` builds the four-section message array with drop-oldest pair trim on the conversation tail only (chart + system reserved up front along with a response budget).
- `LlmEngine` gains `infer(ArrayNode, int)` / `inferStreaming` overloads for prebuilt messages; existing `(systemPrompt, userMessage)` forms delegate so the search path is unchanged.
- `AuditLogPurgeTask` extended to purge `chartsearchai_chat_message` rows older than the new `chartsearchai.chat.retentionDays` GP (default 90).

**Config (new global properties)**:
- `chartsearchai.chat.maxContextTokens` (default 30000). Caps the assembled prompt. The default suits typical chartsearchai deployments using LARGE-context models (default `chartsearchai.llm.contextSize` is already 32768). A too-small value here is a silent footgun — javadoc on the constant documents the failure mode.
- `chartsearchai.chat.retentionDays` (default 90). Clinical-utility retention for chat content; separate from the audit-of-record (`chartsearchai_audit_log`).

## Trade-off

Chat sessions don't pick up new lab results mid-session — the chart snapshot is frozen until the clinician clicks "New chat". This is the deliberate cost of cache-eligibility, and matches the user-facing model (opening a new chat = a fresh context view). Documented in the `ChatService.openOrLoadActiveSession` / `populateChartSnapshot` Javadocs.

## Tests

- `MessagesArrayShapeTest` (7 cases) covers:
  - empty priors → 3-message shape
  - priors sit between chart and current question
  - **first-two-messages byte-identical across turns** (the load-bearing cache-hit invariant)
  - chart never leaks into prior content
  - system always at index 0 even under tight budget
  - drop-oldest pair trim respects budget + response reserve
- RED verified by stubbing `assembleChat` to single-shot — 7/7 fail including the byte-identity test. GREEN restored.
- Full api suite stays at 463 pass.

## Test plan

- [ ] Liquibase changesets 007 + 008 run cleanly against a fresh DB
- [ ] `POST /chat` with no session uuid → creates session, persists user + assistant rows, returns session uuid
- [ ] `POST /chat` with existing session uuid → reuses session, replays priors
- [ ] `POST /chat/stream` emits `X-ChartSearchAi-Session` header before SSE body
- [ ] `GET /chat?patient=` hydrates an existing session
- [ ] `POST /chat/new` closes current session (`status='closed'`, `ended_at` set), opens fresh
- [ ] `AuditLogPurgeTask` purges chat-history rows past retention without affecting audit log rows
- [ ] Multi-turn referential question (e.g. "how many medications did you list?") returns a number derived from the prior assistant turn — proves priors reach the LLM
- [ ] `chart_chars` log line shows byte-stable count across turns of one session — proves prefix-cache eligibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Added — refresh chart snapshot (a89b33d)

`POST /chat/refresh-chart` rebuilds the frozen chart snapshot for the active session — picking up clinical data entered since it opened — **without** clearing the transcript (the deliberate counterpart to `/chat/new`). `GET /chat` now also returns `chartBuiltAt` so the SPA can offer "refresh" vs "new chat". Rebuilding changes the chart bytes, invalidating the session prefix cache — the explicit price of freshness. Covered by `ChatServiceRefreshTest` (real ChatService + ChatDAO + a real patient, no mocks).