### PR TITLE
feat(model-switch): probe LM Studio /api/v1/models with OpenAI fallback

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ModelSwitchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ModelSwitchService.java
@@ -57,8 +57,97 @@ public class ModelSwitchService {
 	private HttpClient httpClient;
 
 	/**
+	 * One model entry as surfaced to the picker. When the source is LM Studio's
+	 * /api/v1/models, all fields are populated; when the source is the
+	 * OpenAI-compat /v1/models fallback, only {@code id}/{@code displayName}
+	 * are meaningful, {@code type} defaults to "llm", {@code loaded} to false,
+	 * and {@code maxContextLength} to null.
+	 */
+	public static final class ModelEntry {
+
+		private final String id;
+
+		private final String displayName;
+
+		private final String type;
+
+		private final boolean loaded;
+
+		private final Long maxContextLength;
+
+		public ModelEntry(String id, String displayName, String type, boolean loaded,
+				Long maxContextLength) {
+			this.id = id;
+			this.displayName = displayName;
+			this.type = type;
+			this.loaded = loaded;
+			this.maxContextLength = maxContextLength;
+		}
+
+		/**
+		 * Hydrate a {@link ModelEntry} from just an OpenAI-compat /v1/models
+		 * `id` string, with safe defaults for unknown fields.
+		 */
+		public static ModelEntry fromOpenAiId(String id) {
+			return new ModelEntry(id, id, "llm", false, null);
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public String getDisplayName() {
+			return displayName;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public boolean isLoaded() {
+			return loaded;
+		}
+
+		public Long getMaxContextLength() {
+			return maxContextLength;
+		}
+	}
+
+	/**
+	 * Result of the /v1/models probe-and-fallback dispatch. Carries the
+	 * provider tag the REST response surfaces to the picker (used for
+	 * sub-category grouping) and the per-entry list.
+	 */
+	public static final class AvailableModels {
+
+		private final String provider;
+
+		private final List<ModelEntry> entries;
+
+		public AvailableModels(String provider, List<ModelEntry> entries) {
+			this.provider = provider;
+			this.entries = entries == null ? Collections.emptyList()
+					: Collections.unmodifiableList(new ArrayList<>(entries));
+		}
+
+		public String getProvider() {
+			return provider;
+		}
+
+		public List<ModelEntry> getEntries() {
+			return entries;
+		}
+	}
+
+	/**
 	 * Snapshot of available models + current selection. Returned as an
 	 * immutable value object; the REST controller maps it to JSON.
+	 *
+	 * <p>The {@code available} field is the legacy List&lt;String&gt; view
+	 * (back-compat for older consumers + the existing parseModelIds test
+	 * contract). The {@code entries} + {@code provider} fields carry the
+	 * richer per-model info (loaded state, display name, max context length)
+	 * needed by the picker to render a grouped view with per-entry state.
 	 */
 	public static final class ModelListResponse {
 
@@ -70,13 +159,25 @@ public class ModelSwitchService {
 
 		private final String endpointUrl;
 
+		private final String provider;
+
+		private final List<ModelEntry> entries;
+
 		public ModelListResponse(String engine, String current, List<String> available,
 				String endpointUrl) {
+			this(engine, current, available, endpointUrl, null, null);
+		}
+
+		public ModelListResponse(String engine, String current, List<String> available,
+				String endpointUrl, String provider, List<ModelEntry> entries) {
 			this.engine = engine;
 			this.current = current;
 			this.available = available == null ? Collections.emptyList()
 					: Collections.unmodifiableList(new ArrayList<>(available));
 			this.endpointUrl = endpointUrl;
+			this.provider = provider;
+			this.entries = entries == null ? Collections.emptyList()
+					: Collections.unmodifiableList(new ArrayList<>(entries));
 		}
 
 		public String getEngine() {
@@ -93,6 +194,14 @@ public class ModelSwitchService {
 
 		public String getEndpointUrl() {
 			return endpointUrl;
+		}
+
+		public String getProvider() {
+			return provider;
+		}
+
+		public List<ModelEntry> getEntries() {
+			return entries;
 		}
 	}
 
@@ -123,10 +232,99 @@ public class ModelSwitchService {
 			throw new APIException("Cannot list models: "
 					+ ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL + " is not set.");
 		}
-		String modelsUrl = deriveModelsUrl(chatUrl);
 
-		List<String> available = fetchModelIds(modelsUrl);
-		return new ModelListResponse(engine, current, available, chatUrl);
+		// Probe LM Studio /api/v1/models first, fall back to OpenAI-compat
+		// /v1/models. Picker reads `provider` for sub-category grouping and
+		// per-entry `loaded` for the "(not loaded)" affix.
+		AvailableModels probed = fetchAvailable(chatUrl);
+		List<String> ids = new ArrayList<>();
+		for (ModelEntry entry : probed.getEntries()) {
+			ids.add(entry.getId());
+		}
+		return new ModelListResponse(engine, current, ids, chatUrl,
+				probed.getProvider(), probed.getEntries());
+	}
+
+	/**
+	 * Request that the upstream LM Studio server pre-load the named model
+	 * into memory. Used by the picker's "select-not-loaded" flow so the user
+	 * pays the load latency at pick-time (with a spinner) rather than on
+	 * their first chat turn (with an opaque pause).
+	 *
+	 * <p>Only meaningful when the active provider is LM Studio (the OpenAI-
+	 * compat /v1/chat/completions has no equivalent load endpoint; servers
+	 * either JIT-load on first chat call or require pre-load via their own
+	 * REST API). Returns silently if the active provider is not LM Studio —
+	 * the next /v1/chat/completions will JIT-load anyway.
+	 *
+	 * @throws APIException when the LM Studio load endpoint returns non-2xx
+	 */
+	public void requestModelLoad(String modelName) {
+		if (modelName == null || modelName.trim().isEmpty()) {
+			throw new IllegalArgumentException("modelName is required");
+		}
+		String engine = getGlobalProperty(ChartSearchAiConstants.GP_LLM_ENGINE);
+		if (!ChartSearchAiConstants.LLM_ENGINE_REMOTE.equalsIgnoreCase(engine)) {
+			throw new APIException("Model load is only supported for the remote engine; "
+					+ "active engine is '" + engine + "'.");
+		}
+		String chatUrl = getGlobalProperty(ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL);
+		if (chatUrl == null || chatUrl.isEmpty()) {
+			throw new APIException("Cannot load model: "
+					+ ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL + " is not set.");
+		}
+		// Re-derive against the same host the picker probed. If we can't reach
+		// /api/v1, the provider isn't LM Studio — return silently rather than
+		// erroring (the next chat completion will JIT-load anyway).
+		AvailableModels probed = fetchAvailable(chatUrl);
+		if (!"lm-studio".equals(probed.getProvider())) {
+			log.info("Pre-load requested but active provider is {} ({}); skipping",
+					probed.getProvider(), chatUrl);
+			return;
+		}
+		String loadUrl = deriveLmStudioV1ModelsUrl(chatUrl) + "/load";
+		String apiKey = getOptionalRuntimeProperty(ChartSearchAiConstants.RP_LLM_REMOTE_API_KEY);
+		String body = "{\"model\":\"" + modelName.trim().replace("\"", "\\\"") + "\"}";
+		try {
+			httpPostJson(loadUrl, body, apiKey);
+		}
+		catch (RuntimeException e) {
+			throw new APIException("Failed to pre-load model '" + modelName + "' via "
+					+ loadUrl + ": " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Test-seam: execute an HTTP POST with a JSON body. Throws
+	 * {@link RuntimeException} on non-2xx or transport error. Tests override
+	 * to assert the call shape without spinning up an HTTP server.
+	 */
+	protected String httpPostJson(String url, String body, String apiKey) {
+		HttpRequest.Builder builder = HttpRequest.newBuilder()
+				.uri(URI.create(url))
+				.timeout(Duration.ofMinutes(2)) // model loads can take a minute on slow disks
+				.header("Content-Type", "application/json")
+				.POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
+		if (apiKey != null) {
+			builder.header("Authorization", "Bearer " + apiKey);
+		}
+		HttpRequest request = builder.build();
+		try {
+			HttpResponse<String> response = getHttpClient().send(request,
+					HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+			if (response.statusCode() < 200 || response.statusCode() >= 300) {
+				throw new RuntimeException("HTTP " + response.statusCode() + ": "
+						+ truncateForLog(response.body()));
+			}
+			return response.body();
+		}
+		catch (IOException e) {
+			throw new RuntimeException("IO error: " + e.getMessage(), e);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("interrupted", e);
+		}
 	}
 
 	/**
@@ -161,6 +359,192 @@ public class ModelSwitchService {
 				ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME, trimmed);
 		log.info("Active LLM model set to '{}'", trimmed);
 		return trimmed;
+	}
+
+	/**
+	 * Derive LM Studio's {@code /api/v1/models} URL from the configured
+	 * chat-completions URL. Strips the OpenAI-compat path suffix (the
+	 * {@code /v1/...} part) and appends {@code /api/v1/models} on the host.
+	 *
+	 * <p>Examples:
+	 * <pre>
+	 *   http://host.docker.internal:1234/v1/chat/completions
+	 *     → http://host.docker.internal:1234/api/v1/models
+	 *   http://localhost:1234
+	 *     → http://localhost:1234/api/v1/models
+	 *   http://host:1234/v1/
+	 *     → http://host:1234/api/v1/models
+	 * </pre>
+	 */
+	static String deriveLmStudioV1ModelsUrl(String chatUrl) {
+		String stripped = chatUrl;
+		// Strip the OpenAI-compat path (anything from /v1 onward).
+		int v1Idx = stripped.indexOf("/v1");
+		if (v1Idx >= 0) {
+			stripped = stripped.substring(0, v1Idx);
+		}
+		// Tolerate trailing slash.
+		while (stripped.endsWith("/")) {
+			stripped = stripped.substring(0, stripped.length() - 1);
+		}
+		return stripped + "/api/v1/models";
+	}
+
+	/**
+	 * Heuristic: does this response body look like LM Studio's
+	 * {@code /api/v1/models} shape (top-level {@code models} array)? The
+	 * OpenAI-compat shape uses {@code data} instead, and arbitrary HTML / 404
+	 * bodies have neither.
+	 */
+	static boolean looksLikeLmStudioV1Response(String body) {
+		if (body == null || body.isEmpty()) {
+			return false;
+		}
+		try {
+			JsonNode root = MAPPER.readTree(body);
+			JsonNode models = root.get("models");
+			return models != null && models.isArray();
+		}
+		catch (IOException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Parse LM Studio v1's {@code GET /api/v1/models} response into a list
+	 * of {@link ModelEntry}. Filters to {@code type=="llm"} (embedding-only
+	 * models are excluded — selecting one for chat would 400). Skips entries
+	 * missing a textual {@code key} field.
+	 *
+	 * <p>Loaded vs not-loaded comes from the {@code loaded_instances} array
+	 * (empty → not loaded; populated → loaded).
+	 */
+	static List<ModelEntry> parseLmStudioV1Models(String body) {
+		List<ModelEntry> entries = new ArrayList<>();
+		try {
+			JsonNode root = MAPPER.readTree(body);
+			JsonNode models = root.get("models");
+			if (models != null && models.isArray()) {
+				for (JsonNode entry : models) {
+					JsonNode keyNode = entry.get("key");
+					if (keyNode == null || !keyNode.isTextual()) {
+						continue;
+					}
+					String id = keyNode.asText().trim();
+					if (id.isEmpty()) {
+						continue;
+					}
+					String type = textOrNull(entry.get("type"));
+					if (!"llm".equalsIgnoreCase(type)) {
+						continue;
+					}
+					String displayName = textOrNull(entry.get("display_name"));
+					if (displayName == null || displayName.isEmpty()) {
+						displayName = id;
+					}
+					JsonNode loadedInstances = entry.get("loaded_instances");
+					boolean loaded = loadedInstances != null
+							&& loadedInstances.isArray() && loadedInstances.size() > 0;
+					JsonNode mctx = entry.get("max_context_length");
+					Long maxContext = (mctx != null && mctx.isIntegralNumber())
+							? Long.valueOf(mctx.asLong()) : null;
+					entries.add(new ModelEntry(id, displayName, type, loaded, maxContext));
+				}
+			}
+		}
+		catch (IOException e) {
+			throw new APIException("Failed to parse /api/v1/models response: " + e.getMessage(), e);
+		}
+		return entries;
+	}
+
+	private static String textOrNull(JsonNode node) {
+		if (node == null || !node.isTextual()) {
+			return null;
+		}
+		return node.asText();
+	}
+
+	/**
+	 * Probe-and-fallback dispatch. Tries LM Studio's {@code /api/v1/models}
+	 * first; if the response is a recognizable v1 shape, returns the enriched
+	 * entries with {@code provider="lm-studio"}. Otherwise falls back to the
+	 * OpenAI-compat {@code /v1/models} list and returns entries hydrated from
+	 * just IDs with {@code provider="generic-openai-compat"}.
+	 *
+	 * <p>HTTP errors on the v1 probe (404, connection refused, malformed JSON)
+	 * are non-fatal — they trigger the fallback. Errors on the OpenAI-compat
+	 * fallback propagate as {@link APIException} matching today's behavior.
+	 *
+	 * @param chatUrl the configured chat-completions URL (the same value the
+	 *                {@code chartsearchai.llm.remote.endpointUrl} GP holds).
+	 */
+	public AvailableModels fetchAvailable(String chatUrl) {
+		String apiKey = getOptionalRuntimeProperty(ChartSearchAiConstants.RP_LLM_REMOTE_API_KEY);
+
+		// 1. Try LM Studio v1.
+		String v1Url = deriveLmStudioV1ModelsUrl(chatUrl);
+		try {
+			String v1Body = httpGet(v1Url, apiKey);
+			if (looksLikeLmStudioV1Response(v1Body)) {
+				return new AvailableModels("lm-studio", parseLmStudioV1Models(v1Body));
+			}
+		}
+		catch (RuntimeException e) {
+			// Probe failure (404, conn refused, etc.) is non-fatal — fall back.
+			log.debug("LM Studio /api/v1/models probe failed for {}: {}; falling back to /v1/models",
+					v1Url, e.getMessage());
+		}
+
+		// 2. Fall back to OpenAI-compat /v1/models.
+		String openaiUrl = deriveModelsUrl(chatUrl);
+		String openaiBody;
+		try {
+			openaiBody = httpGet(openaiUrl, apiKey);
+		}
+		catch (RuntimeException e) {
+			throw new APIException("Failed to fetch model list from " + openaiUrl + ": "
+					+ e.getMessage(), e);
+		}
+		List<String> ids = parseModelIds(openaiBody);
+		List<ModelEntry> entries = new ArrayList<>();
+		for (String id : ids) {
+			entries.add(ModelEntry.fromOpenAiId(id));
+		}
+		return new AvailableModels("generic-openai-compat", entries);
+	}
+
+	/**
+	 * Test-seam: execute an HTTP GET and return the response body. Throws a
+	 * {@link RuntimeException} on non-2xx, connection failures, or interrupt.
+	 * Tests override this to inject canned responses without spinning up an
+	 * actual HTTP server.
+	 */
+	protected String httpGet(String url, String apiKey) {
+		HttpRequest.Builder builder = HttpRequest.newBuilder()
+				.uri(URI.create(url))
+				.timeout(Duration.ofSeconds(30))
+				.GET();
+		if (apiKey != null) {
+			builder.header("Authorization", "Bearer " + apiKey);
+		}
+		HttpRequest request = builder.build();
+		try {
+			HttpResponse<String> response = getHttpClient().send(request,
+					HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+			if (response.statusCode() < 200 || response.statusCode() >= 300) {
+				throw new RuntimeException("HTTP " + response.statusCode() + ": "
+						+ truncateForLog(response.body()));
+			}
+			return response.body();
+		}
+		catch (IOException e) {
+			throw new RuntimeException("IO error: " + e.getMessage(), e);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("interrupted", e);
+		}
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ModelSwitchServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ModelSwitchServiceTest.java
@@ -10,11 +10,16 @@
 package org.openmrs.module.chartsearchai.api.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.api.impl.ModelSwitchService.AvailableModels;
+import org.openmrs.module.chartsearchai.api.impl.ModelSwitchService.ModelEntry;
 
 public class ModelSwitchServiceTest {
 
@@ -73,5 +78,232 @@ public class ModelSwitchServiceTest {
 				+ "{\"id\":42}"
 				+ "]}";
 		assertEquals(List.of("good"), ModelSwitchService.parseModelIds(body));
+	}
+
+	// --- LM Studio /api/v1/models support ---------------------------------
+	// These tests pin the shape of LM Studio's v1 REST API per
+	// specs/artifacts/planning/lm-studio-api-reference.md. The picker uses
+	// this shape to render an "LM Studio" sub-category with per-entry
+	// loaded-vs-not-loaded state, and to filter out embedding-only models
+	// that would 400 from /v1/chat/completions.
+
+	@Test
+	public void parseLmStudioV1Models_extractsKeyAndLoadedFromV1Shape() {
+		// Real-shape sample from GET /api/v1/models on LM Studio 0.4.x:
+		//   models[i].key             = identifier used in /v1/chat/completions
+		//   models[i].loaded_instances = empty array if not loaded; populated if loaded
+		//   models[i].type            = "llm" | "embedding"
+		String body = "{\"models\":[{"
+				+ "\"key\":\"google/gemma-3-12b\","
+				+ "\"type\":\"llm\","
+				+ "\"publisher\":\"google\","
+				+ "\"display_name\":\"Gemma 3 12B\","
+				+ "\"params_string\":\"12B\","
+				+ "\"max_context_length\":131072,"
+				+ "\"loaded_instances\":[{\"instance_id\":\"abc\"}]"
+				+ "}]}";
+		List<ModelEntry> entries = ModelSwitchService.parseLmStudioV1Models(body);
+		assertEquals(1, entries.size());
+		ModelEntry e = entries.get(0);
+		assertEquals("google/gemma-3-12b", e.getId());
+		assertEquals("Gemma 3 12B", e.getDisplayName());
+		assertEquals("llm", e.getType());
+		assertTrue(e.isLoaded(), "loaded_instances non-empty → loaded=true");
+		assertEquals(Long.valueOf(131072L), e.getMaxContextLength());
+	}
+
+	@Test
+	public void parseLmStudioV1Models_emptyLoadedInstancesMeansNotLoaded() {
+		String body = "{\"models\":[{"
+				+ "\"key\":\"foo\",\"type\":\"llm\","
+				+ "\"display_name\":\"Foo\","
+				+ "\"loaded_instances\":[]"
+				+ "}]}";
+		assertFalse(ModelSwitchService.parseLmStudioV1Models(body).get(0).isLoaded(),
+				"empty loaded_instances → loaded=false");
+	}
+
+	@Test
+	public void parseLmStudioV1Models_filtersOutEmbeddingType() {
+		// The picker is for chat completion. Embedding models surface in
+		// /api/v1/models too; selecting one returns 400 from
+		// /v1/chat/completions. Filter at parse time.
+		String body = "{\"models\":["
+				+ "{\"key\":\"chat-model\",\"type\":\"llm\",\"display_name\":\"Chat\",\"loaded_instances\":[]},"
+				+ "{\"key\":\"emb-model\",\"type\":\"embedding\",\"display_name\":\"Emb\",\"loaded_instances\":[]}"
+				+ "]}";
+		List<ModelEntry> entries = ModelSwitchService.parseLmStudioV1Models(body);
+		assertEquals(1, entries.size(), "embedding entry must be filtered out");
+		assertEquals("chat-model", entries.get(0).getId());
+	}
+
+	@Test
+	public void parseLmStudioV1Models_skipsEntriesMissingKey() {
+		// Defensive: any entry without a textual key is ignored.
+		String body = "{\"models\":["
+				+ "{\"key\":\"good\",\"type\":\"llm\",\"loaded_instances\":[]},"
+				+ "{\"type\":\"llm\",\"loaded_instances\":[]},"
+				+ "{\"key\":42,\"type\":\"llm\"}"
+				+ "]}";
+		List<ModelEntry> entries = ModelSwitchService.parseLmStudioV1Models(body);
+		assertEquals(1, entries.size());
+		assertEquals("good", entries.get(0).getId());
+	}
+
+	@Test
+	public void parseLmStudioV1Models_returnsEmptyOnMissingModelsArray() {
+		// Some error responses or older versions may not include `models`.
+		// Caller treats empty list as "no models available via v1".
+		assertEquals(0, ModelSwitchService.parseLmStudioV1Models("{}").size());
+		assertEquals(0, ModelSwitchService.parseLmStudioV1Models("{\"models\":null}").size());
+	}
+
+	@Test
+	public void deriveLmStudioV1ModelsUrl_replacesV1ChatCompletionsWithApiV1Models() {
+		// chartsearchai's standard LM Studio chat URL → corresponding v1
+		// models endpoint at /api/v1/models on the same host.
+		assertEquals(
+				"http://host.docker.internal:1234/api/v1/models",
+				ModelSwitchService.deriveLmStudioV1ModelsUrl(
+						"http://host.docker.internal:1234/v1/chat/completions"));
+	}
+
+	@Test
+	public void deriveLmStudioV1ModelsUrl_handlesRootHostUrl() {
+		// Operator pointing at a bare host (no /v1 prefix in the endpoint URL).
+		assertEquals(
+				"http://localhost:1234/api/v1/models",
+				ModelSwitchService.deriveLmStudioV1ModelsUrl("http://localhost:1234"));
+	}
+
+	@Test
+	public void deriveLmStudioV1ModelsUrl_tolerantOfTrailingSlash() {
+		assertEquals(
+				"http://host:1234/api/v1/models",
+				ModelSwitchService.deriveLmStudioV1ModelsUrl("http://host:1234/v1/"));
+	}
+
+	@Test
+	public void looksLikeLmStudioV1Response_detectsModelsArrayKey() {
+		assertTrue(ModelSwitchService.looksLikeLmStudioV1Response("{\"models\":[]}"));
+		assertTrue(ModelSwitchService.looksLikeLmStudioV1Response("{\"models\":[{\"key\":\"x\"}]}"));
+	}
+
+	@Test
+	public void looksLikeLmStudioV1Response_rejectsOpenAiDataShape() {
+		// OpenAI-compat /v1/models uses `data` at the root, not `models`.
+		assertFalse(ModelSwitchService.looksLikeLmStudioV1Response("{\"data\":[],\"object\":\"list\"}"));
+		assertFalse(ModelSwitchService.looksLikeLmStudioV1Response("{}"));
+		assertFalse(ModelSwitchService.looksLikeLmStudioV1Response("not json"));
+	}
+
+	@Test
+	public void fetchAvailable_usesLmStudioV1WhenProbeSucceeds() {
+		// Probe-and-fallback dispatch: when /api/v1/models returns a recognizable
+		// v1 shape, use it and tag provider="lm-studio".
+		ModelSwitchService svc = new ModelSwitchService() {
+			@Override
+			protected String httpGet(String url, String apiKey) {
+				if (url.endsWith("/api/v1/models")) {
+					return "{\"models\":[{"
+							+ "\"key\":\"foo\",\"type\":\"llm\","
+							+ "\"display_name\":\"Foo\","
+							+ "\"loaded_instances\":[{\"instance_id\":\"i\"}]"
+							+ "}]}";
+				}
+				throw new AssertionError("Should not call OpenAI-compat fallback: " + url);
+			}
+		};
+		AvailableModels result = svc.fetchAvailable(
+				"http://host.docker.internal:1234/v1/chat/completions");
+		assertEquals("lm-studio", result.getProvider());
+		assertEquals(1, result.getEntries().size());
+		assertEquals("foo", result.getEntries().get(0).getId());
+		assertTrue(result.getEntries().get(0).isLoaded());
+	}
+
+	@Test
+	public void fetchAvailable_fallsBackToOpenAiCompatWhenV1ProbeFails() {
+		// When the v1 probe returns non-recognizable content (404, generic
+		// OpenAI-compat endpoint, Anthropic API), fall back to /v1/models.
+		// provider remains null (or "generic-openai-compat") since we can't
+		// distinguish loaded state.
+		ModelSwitchService svc = new ModelSwitchService() {
+			@Override
+			protected String httpGet(String url, String apiKey) {
+				if (url.endsWith("/api/v1/models")) {
+					throw new RuntimeException("simulated 404");
+				}
+				// OpenAI-compat /v1/models
+				return "{\"data\":[{\"id\":\"bar\"}],\"object\":\"list\"}";
+			}
+		};
+		AvailableModels result = svc.fetchAvailable(
+				"https://api.example.com/v1/chat/completions");
+		assertEquals("generic-openai-compat", result.getProvider());
+		assertEquals(1, result.getEntries().size());
+		ModelEntry only = result.getEntries().get(0);
+		assertEquals("bar", only.getId());
+		assertFalse(only.isLoaded(),
+				"OpenAI-compat /v1/models doesn't expose load state; default false");
+	}
+
+	@Test
+	public void fetchAvailable_fallsBackOnV1NotJson() {
+		// Some servers return HTML/plain-text for unknown paths. The probe
+		// must not crash on non-JSON bodies.
+		ModelSwitchService svc = new ModelSwitchService() {
+			@Override
+			protected String httpGet(String url, String apiKey) {
+				if (url.endsWith("/api/v1/models")) {
+					return "<html>Not Found</html>";
+				}
+				return "{\"data\":[{\"id\":\"only\"}]}";
+			}
+		};
+		AvailableModels result = svc.fetchAvailable("http://host:1234/v1/chat/completions");
+		assertEquals("generic-openai-compat", result.getProvider());
+		assertEquals(List.of("only"),
+				result.getEntries().stream().map(ModelEntry::getId).toList());
+	}
+
+	@Test
+	public void modelEntry_fromOpenAiId_setsSensibleDefaults() {
+		// When the only signal we have is the model ID from /v1/models,
+		// ModelEntry.fromOpenAiId hydrates the rest with safe defaults.
+		ModelEntry entry = ModelEntry.fromOpenAiId("some-model");
+		assertEquals("some-model", entry.getId());
+		assertEquals("some-model", entry.getDisplayName());
+		assertEquals("llm", entry.getType());
+		assertFalse(entry.isLoaded());
+		assertNull(entry.getMaxContextLength());
+	}
+
+	@Test
+	public void deriveLmStudioLoadUrl_appendsLoadSuffix() {
+		// The /load endpoint sits directly under /api/v1/models. Pinned here
+		// so requestModelLoad doesn't drift if deriveLmStudioV1ModelsUrl changes.
+		assertEquals(
+				"http://host:1234/api/v1/models/load",
+				ModelSwitchService.deriveLmStudioV1ModelsUrl("http://host:1234/v1/chat/completions")
+						+ "/load");
+	}
+
+	@Test
+	public void modelListResponse_carriesProviderAndEntriesAlongsideAvailable() {
+		// Back-compat: existing consumers read `available` (List<String>).
+		// New consumers read `entries` (List<ModelEntry>) + `provider`.
+		// Constructor MUST accept both so the REST controller can serialize
+		// both views in the same JSON response.
+		ModelEntry e = new ModelEntry("k1", "Display 1", "llm", true, 8192L);
+		ModelSwitchService.ModelListResponse r = new ModelSwitchService.ModelListResponse(
+				"remote", "k1", List.of("k1"),
+				"http://lm:1234/v1/chat/completions",
+				"lm-studio", List.of(e));
+		assertEquals("lm-studio", r.getProvider());
+		assertNotNull(r.getEntries());
+		assertEquals(1, r.getEntries().size());
+		assertEquals("k1", r.getEntries().get(0).getId());
+		assertEquals(List.of("k1"), r.getAvailable());
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -341,7 +341,59 @@ public class ChartSearchAiRestController {
 		response.put("current", snapshot.getCurrent());
 		response.put("available", snapshot.getAvailable());
 		response.put("endpointUrl", snapshot.getEndpointUrl());
+		// Enriched fields — populated when LM Studio /api/v1/models probe
+		// succeeded; null/empty otherwise. The picker reads `provider` for
+		// sub-category grouping and `entries[].loaded` for the per-entry
+		// state affix. Older SPA builds ignore these fields.
+		if (snapshot.getProvider() != null) {
+			response.put("provider", snapshot.getProvider());
+		}
+		if (snapshot.getEntries() != null && !snapshot.getEntries().isEmpty()) {
+			List<Map<String, Object>> entries = new ArrayList<Map<String, Object>>();
+			for (org.openmrs.module.chartsearchai.api.impl.ModelSwitchService.ModelEntry e
+					: snapshot.getEntries()) {
+				Map<String, Object> row = new LinkedHashMap<String, Object>();
+				row.put("id", e.getId());
+				row.put("displayName", e.getDisplayName());
+				row.put("type", e.getType());
+				row.put("loaded", e.isLoaded());
+				if (e.getMaxContextLength() != null) {
+					row.put("maxContextLength", e.getMaxContextLength());
+				}
+				entries.add(row);
+			}
+			response.put("entries", entries);
+		}
 		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	/**
+	 * Request that the upstream LM Studio server pre-load the named model
+	 * into memory. Returns 200 on success (model loaded; subsequent chat
+	 * completion will be fast), 400 for blank input, 503 when the active
+	 * engine is local or no LM Studio v1 endpoint is reachable.
+	 *
+	 * <p>Body: {@code {"modelName": "<id>"}}. Same gate as {@code /model}.
+	 */
+	@RequestMapping(value = "/model/load", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Object> loadModel(@RequestBody Map<String, String> body) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+		String requested = body == null ? null : body.get("modelName");
+		try {
+			modelSwitchService.requestModelLoad(requested);
+			Map<String, Object> response = new LinkedHashMap<String, Object>();
+			response.put("loaded", requested == null ? "" : requested.trim());
+			return new ResponseEntity<Object>(response, HttpStatus.OK);
+		}
+		catch (IllegalArgumentException e) {
+			return new ResponseEntity<Object>(errorResponse(e.getMessage()),
+					HttpStatus.BAD_REQUEST);
+		}
+		catch (org.openmrs.api.APIException e) {
+			return new ResponseEntity<Object>(errorResponse(e.getMessage()),
+					HttpStatus.SERVICE_UNAVAILABLE);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Probe LM Studio's `/api/v1/models` (REST v1) first; fall back to OpenAI-compat `/v1/models` for any other endpoint. Surfaces per-entry loaded state + display name + max context length, filters `type=embedding` out.

Stacks on #22; base set to `feat/model-switch-service`. Will rebase onto main after #22 merges.

Adds:
- `ModelEntry` + `AvailableModels` types; `ModelListResponse` gets optional `provider` + `entries[]` (back-compat)
- `deriveLmStudioV1ModelsUrl`, `looksLikeLmStudioV1Response`, `parseLmStudioV1Models`, `fetchAvailable`, `requestModelLoad`
- New `POST /model/load` REST endpoint (pre-load on picker select)
- Protected test seams: `httpGet`, `httpPostJson`

Tests: 16 new in `ModelSwitchServiceTest` (22 total). Full API suite green. TDD: red → green.

Paired frontend PR follows on `openmrs-esm-chartsearchai`.