### PR TITLE
Harden the LLM reasoning-field slice: stream-decode escapes, fix stale docs

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmAnswerExtractor.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmAnswerExtractor.java
@@ -29,8 +29,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * (answer text + citation indices). Handles three response shapes the
  * model may emit, in priority order:
  *
+ * <p>The schema emits a leading {@code "reasoning"} field (the model's chain-of-thought) before
+ * {@code answer}; it is the model's scratchpad and is ignored here — only {@code answer} and
+ * {@code citations} are read.</p>
+ *
  * <ol>
- *   <li>Clean JSON: {@code {"answer":"...","citations":[1,2]}}.</li>
+ *   <li>Clean JSON: {@code {"reasoning":"...","answer":"...","citations":[1,2]}}.</li>
  *   <li>Markdown-fenced JSON: a {@code ```json\n...\n```} wrapper that
  *       some models (e.g. Gemma) add even when constrained.</li>
  *   <li>Truncated/malformed JSON: regex fallback that pulls the

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -148,9 +148,14 @@ public class LlmProvider {
 	 * A streaming token consumer that buffers the raw JSON tokens from the LLM
 	 * and only forwards text content from inside the {@code "answer"} value.
 	 *
-	 * <p>The LLM is prompted to produce {@code {"answer": "...", "citations": [...]}}.
-	 * This consumer processes each character through a simple state machine and only
-	 * forwards characters that belong to the answer string value.</p>
+	 * <p>The LLM is prompted to produce
+	 * {@code {"reasoning": "...", "answer": "...", "citations": [...]}}. The {@code reasoning}
+	 * field is emitted FIRST (the model's chain-of-thought) and must NOT reach the client: the
+	 * state machine scans for the {@code "answer"} key and forwards only its value, so the
+	 * leading reasoning tokens are silently consumed. (Trade-off: the visible answer starts
+	 * streaming only after reasoning finishes generating.) This consumer processes each
+	 * character through a simple state machine and only forwards characters that belong to the
+	 * answer string value.</p>
 	 */
 	static class AnswerExtractingConsumer implements Consumer<String> {
 
@@ -176,6 +181,14 @@ public class LlmProvider {
 
 		/** Whether the next character in the answer value is escaped. */
 		private boolean escaped;
+
+		/** When > 0, we are partway through a {@code \\uXXXX} escape and this many hex digits
+		 *  remain. Held as a field (not a local) because the 4 digits can arrive across separate
+		 *  streaming chunks. */
+		private int unicodeRemaining;
+
+		/** Accumulated value of the {@code \\uXXXX} hex digits seen so far. */
+		private int unicodeValue;
 
 		AnswerExtractingConsumer(Consumer<String> delegate) {
 			this.delegate = delegate;
@@ -254,6 +267,21 @@ public class LlmProvider {
 			StringBuilder out = new StringBuilder();
 			for (int i = 0; i < text.length(); i++) {
 				char c = text.charAt(i);
+				if (unicodeRemaining > 0) {
+					int digit = Character.digit(c, 16);
+					if (digit < 0) {
+						// Malformed \\uXXXX (a grammar-constrained model shouldn't emit this) —
+						// emit the marker literally rather than crash, then handle c normally.
+						out.append("\\u");
+						unicodeRemaining = 0;
+					} else {
+						unicodeValue = (unicodeValue << 4) | digit;
+						if (--unicodeRemaining == 0) {
+							out.append((char) unicodeValue);
+						}
+						continue;
+					}
+				}
 				if (escaped) {
 					switch (c) {
 						case 'n':
@@ -261,6 +289,15 @@ public class LlmProvider {
 							break;
 						case 't':
 							out.append('\t');
+							break;
+						case 'r':
+							out.append('\r');
+							break;
+						case 'b':
+							out.append('\b');
+							break;
+						case 'f':
+							out.append('\f');
 							break;
 						case '"':
 							out.append('"');
@@ -270,6 +307,13 @@ public class LlmProvider {
 							break;
 						case '/':
 							out.append('/');
+							break;
+						case 'u':
+							// Begin a \\uXXXX escape; the 4 hex digits follow (possibly in the
+							// next chunk). Mirrors Jackson's decoding on the non-streaming path so
+							// streamed and non-streamed answers render identically.
+							unicodeRemaining = 4;
+							unicodeValue = 0;
 							break;
 						default:
 							out.append('\\').append(c);

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 
@@ -118,6 +120,73 @@ public class LlmProviderTest {
 		assertTrue(LlmProvider.DEFAULT_SYSTEM_PROMPT.contains("\"reasoning\":"),
 				"Few-shot demo answers must include a \"reasoning\" field so the demonstrated "
 				+ "format matches the response schema");
+	}
+
+	/** Feeds {@code json} to a fresh AnswerExtractingConsumer in the given chunk sizes and
+	 *  returns what reached the client. chunkSize 0 means feed the whole string at once. */
+	private static String streamThrough(String json, int chunkSize) {
+		StringBuilder out = new StringBuilder();
+		Consumer<String> delegate = out::append;
+		LlmProvider.AnswerExtractingConsumer consumer = new LlmProvider.AnswerExtractingConsumer(delegate);
+		if (chunkSize <= 0) {
+			consumer.accept(json);
+		} else {
+			for (int i = 0; i < json.length(); i += chunkSize) {
+				consumer.accept(json.substring(i, Math.min(i + chunkSize, json.length())));
+			}
+		}
+		return out.toString();
+	}
+
+	@Test
+	public void streamingConsumer_shouldNotLeakLeadingReasoningField() {
+		// The schema emits "reasoning" FIRST, before "answer". The streaming path (/search/stream)
+		// must forward only the answer value to the clinician — never the model's reasoning
+		// scratchpad. Exercised both as one chunk and char-by-char (real token streams arrive in
+		// arbitrary fragments, so the state machine must skip reasoning across chunk boundaries).
+		String json = "{\"reasoning\": \"Hearing Loss is an ear-related condition, so record [89] "
+				+ "is relevant to the query about ears.\", \"answer\": \"Hearing Loss [89].\", "
+				+ "\"citations\": [89]}";
+		assertEquals("Hearing Loss [89].", streamThrough(json, 0),
+				"whole-string: only the answer value must reach the client, not reasoning");
+		assertEquals("Hearing Loss [89].", streamThrough(json, 1),
+				"char-by-char: reasoning must be skipped across token boundaries too");
+		assertEquals("Hearing Loss [89].", streamThrough(json, 7),
+				"7-char chunks: reasoning must be skipped regardless of fragment alignment");
+	}
+
+	@Test
+	public void streamingConsumer_shouldDecodeUnicodeEscapes() {
+		// The non-streaming path decodes \\uXXXX via Jackson (see
+		// extractResponse_shouldDecodeUnicodeEscapes); the streaming consumer must match, or a
+		// streamed clinical value like "38.9°C" reaches the clinician as literal "38.9\\u00b0C".
+		// The 4 hex digits must also decode when they straddle streaming-chunk boundaries.
+		String json = "{\"reasoning\": \"unit conversion\", \"answer\": \"Temperature is "
+				+ "38.9\\u00b0C\", \"citations\": [1]}";
+		assertEquals("Temperature is 38.9°C", streamThrough(json, 0),
+				"whole-string: streamed answer must decode \\uXXXX like the non-streaming path");
+		assertEquals("Temperature is 38.9°C", streamThrough(json, 1),
+				"char-by-char: \\uXXXX must decode even when its hex digits span chunk boundaries");
+	}
+
+	@Test
+	public void streamingConsumer_shouldDecodeControlCharEscapes() {
+		// JSON control-char escapes (\r, \b, \f) must decode like Jackson on the non-streaming
+		// path — otherwise a streamed answer with one shows the literal backslash sequence.
+		String json = "{\"reasoning\": \"x\", \"answer\": \"line1\\r\\nline2\\tend\", \"citations\": []}";
+		assertEquals("line1\r\nline2\tend", streamThrough(json, 0));
+		assertEquals("line1\r\nline2\tend", streamThrough(json, 1));
+	}
+
+	@Test
+	public void streamingConsumer_reasoningMentioningAnswerWordShouldNotFalseTrigger() {
+		// Adversarial: the reasoning text itself contains the escaped word \"answer\". An escaped
+		// quote inside the reasoning value must NOT be mistaken for the real "answer" key, or the
+		// client would see reasoning text. Only the genuine answer value may be forwarded.
+		String json = "{\"reasoning\": \"The query literally says \\\"answer\\\" but I judge by "
+				+ "meaning.\", \"answer\": \"No relevant records.\", \"citations\": []}";
+		assertEquals("No relevant records.", streamThrough(json, 0));
+		assertEquals("No relevant records.", streamThrough(json, 1));
 	}
 
 	@Test

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -553,7 +553,7 @@ Patient: 45-year-old Male
 [4] (2025-09-15) HbA1c: 8.2%
 ```
 
-The system prompt instructs the LLM to cite record numbers in brackets and respond with a JSON object. A strict JSON-schema constraint (`response_format: json_schema`, built by `LocalLlmEngine.buildJsonSchemaResponseFormat()` and enforced by llama-server via a derived GBNF grammar) forces the LLM output to the exact shape `{"answer": "...", "citations": [1, 2]}`, making it structurally impossible for the LLM to produce malformed citations. The `citations` array is parsed directly as structured data — no regex parsing of free text is needed.
+The system prompt instructs the LLM to cite record numbers in brackets and respond with a JSON object. A strict JSON-schema constraint (`response_format: json_schema`, built by `LocalLlmEngine.buildJsonSchemaResponseFormat()` and enforced by llama-server via a derived GBNF grammar) forces the LLM output to the exact shape `{"reasoning": "...", "answer": "...", "citations": [1, 2]}`, making it structurally impossible for the LLM to produce malformed citations. The leading `reasoning` field is a deliberate chain-of-thought slot (the grammar emits properties in order, so the model thinks before it answers — without it the small local model abstains on queries whose wording differs from the record, e.g. "ear problems" vs a "Hearing Loss" record); it is the model's scratchpad and is ignored by the parser. The `answer` and `citations` are parsed directly as structured data — no regex parsing of free text is needed.
 
 Example LLM output:
 ```json

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -85,7 +85,7 @@ public class ChartSearchAiRestController {
 	// Defense-in-depth: catches common prompt injection phrases. This is a blocklist
 	// and can be bypassed with paraphrasing. The primary defense is the structured-output
 	// constraint (response_format: json_schema, used by both engines) which forces LLM
-	// output into a fixed {answer, citations} shape regardless of prompt content.
+	// output into a fixed {reasoning, answer, citations} shape regardless of prompt content.
 	private static final Pattern PROMPT_INJECTION = Pattern.compile(
 			"(?i)(ignore\\s+(previous|above|all)\\s+(instructions|prompts|rules)"
 			+ "|disregard\\s+(your|the|all)\\s+(instructions|rules|prompt)"


### PR DESCRIPTION
Follow-up hardening to #27 (the reasoning-field fix), produced via a `/harden` review+polish pass.

## Correctness
The streaming consumer (`AnswerExtractingConsumer`, used by `/search/stream`) decoded only `\n \t \" \\ \/` in the answer value — it was missing **`\uXXXX`, `\r`, `\b`, `\f`**. So a streamed clinical value like `38.9°C` reached the clinician as the literal `38.9°C`, while the non-streaming path (Jackson) rendered it correctly. The streaming path is now at full parity with Jackson; the `\uXXXX` hex digits are accumulated across streaming-chunk boundaries.

## Tests
The streaming consumer had **no direct test** — and reasoning-first (from #27) is the path real clinicians hit. Added:
- reasoning must never leak to the client (whole-string, char-by-char, adversarial reasoning containing an escaped `"answer"`),
- `\uXXXX` and control-char (`\r \t`) decoding.

## Docs/comments
Updated the now-stale `{answer, citations}` shape references (`LlmAnswerExtractor` Javadoc, `AnswerExtractingConsumer` Javadoc, the ADR, and the REST prompt-injection-defence comment) to `{reasoning, answer, citations}`.

## Known follow-up (deferred)
The `LlmAnswerExtractor` **regex fallback** — reached only on truncated/malformed JSON — still doesn't decode `\uXXXX`. Pre-existing and rare (needs truncation *and* a unicode char); safely fixing the `.replace()` chain is a separate focused change.

All 71 affected unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)