### PR TITLE
Stream the model's reasoning as a "thinking" SSE event

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -44,6 +44,24 @@ public interface ChartSearchService {
 	ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer);
 
 	/**
+	 * Streaming variant that additionally forwards the model's reasoning (chain-of-thought) to
+	 * {@code reasoningConsumer} as it is generated, so a caller can surface it as a live "thinking"
+	 * indicator. The answer stream to {@code tokenConsumer} is unchanged. Default implementation
+	 * ignores reasoning and delegates to the three-arg variant, so existing implementations and
+	 * callers are unaffected.
+	 *
+	 * @param patient the patient whose chart to query
+	 * @param question the clinician's natural language question
+	 * @param tokenConsumer called with each answer-text fragment as it is generated
+	 * @param reasoningConsumer called with each reasoning-text fragment as it is generated
+	 * @return the complete answer with source references
+	 */
+	default ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer,
+			Consumer<String> reasoningConsumer) {
+		return searchStreaming(patient, question, tokenConsumer);
+	}
+
+	/**
 	 * Pre-warm any patient-specific caches (serialized chart, LLM prompt cache) so the
 	 * first real query on this patient does not pay cold-start cost. Implementations
 	 * that don't support warmup may return immediately. Callers should treat this as

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
@@ -75,6 +75,12 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 	@Override
 	public ChartAnswer searchStreaming(Patient patient, String question,
 			Consumer<String> tokenConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, chunk -> { });
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
 		int ttlMinutes = getCacheTtlMinutes();
 
 		if (ttlMinutes > 0) {
@@ -82,16 +88,19 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 			ChartAnswer cached = getCachedAnswer(cacheKey, ttlMinutes);
 			if (cached != null) {
 				log.debug("Cache hit for patient [id={}] (streaming)", patient.getPatientId());
+				// Cache hit: the answer is returned instantly with no LLM call, so there is no
+				// live reasoning to stream — only replay the cached answer.
 				tokenConsumer.accept(cached.getAnswer());
 				return cached;
 			}
 
-			ChartAnswer answer = llmService.searchStreaming(patient, question, tokenConsumer);
+			ChartAnswer answer = llmService.searchStreaming(patient, question, tokenConsumer,
+					reasoningConsumer);
 			putCache(cacheKey, answer);
 			return answer;
 		}
 
-		return llmService.searchStreaming(patient, question, tokenConsumer);
+		return llmService.searchStreaming(patient, question, tokenConsumer, reasoningConsumer);
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -217,6 +217,12 @@ public class LlmInferenceService implements ChartSearchService {
 	@Override
 	public ChartAnswer searchStreaming(Patient patient, String question,
 			Consumer<String> tokenConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, chunk -> { });
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
 		// LOG FORMAT — stable contract: same field set as search() with op=searchStreaming
 		// in the log tag. Streaming is the path the frontend actually uses by default, so
 		// this is what demo operators see in their logs. try/finally so exceptions still
@@ -233,7 +239,8 @@ public class LlmInferenceService implements ChartSearchService {
 
 			long llmStart = System.currentTimeMillis();
 			LlmResponse response = llmProvider.searchStreaming(
-					chartTextOrPlaceholder(chart), chart.getFocusIndices(), question, tokenConsumer);
+					chartTextOrPlaceholder(chart), chart.getFocusIndices(), question, tokenConsumer,
+					reasoningConsumer);
 			llmMs = System.currentTimeMillis() - llmStart;
 			inputTokens = response.getInputTokens();
 			cachedTokens = response.getCachedTokens();

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -129,16 +129,34 @@ public class LlmProvider {
 	/** Focus-hint variant of {@link #searchStreaming}. See {@link #search(String, List, String)}. */
 	public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices, String question,
 			Consumer<String> tokenConsumer) {
+		return searchStreaming(numberedRecords, focusIndices, question, tokenConsumer, chunk -> { });
+	}
+
+	/**
+	 * Reasoning-aware streaming variant. Forwards the model's leading {@code "reasoning"} value to
+	 * {@code reasoningConsumer} (so a caller can surface it as a live "thinking" indicator) and the
+	 * {@code "answer"} value to {@code tokenConsumer}, as each is generated. Two independent
+	 * field-scanning {@link AnswerExtractingConsumer}s split the single engine token stream;
+	 * reasoning is emitted first (schema order: reasoning precedes answer). The reasoning channel is
+	 * purely additive — the answer stream is byte-identical to the non-reasoning overload.
+	 */
+	public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
 		String systemPrompt = getSystemPrompt();
 		String userMessage = buildUserMessage(numberedRecords, focusIndices, question);
 		int timeoutSeconds = getTimeoutSeconds();
 
-		// Wrap the consumer to extract only the "answer" value from the JSON
-		// envelope the LLM generates, so the UI sees clean text instead of raw JSON.
-		AnswerExtractingConsumer filter = new AnswerExtractingConsumer(tokenConsumer);
+		// Extract the "answer" value (shown to the clinician) and the "reasoning" value (the
+		// model's chain-of-thought) from the JSON envelope, each on its own channel.
+		AnswerExtractingConsumer answerFilter = new AnswerExtractingConsumer("answer", tokenConsumer);
+		AnswerExtractingConsumer reasoningFilter = new AnswerExtractingConsumer("reasoning", reasoningConsumer);
+		Consumer<String> tee = chunk -> {
+			reasoningFilter.accept(chunk);
+			answerFilter.accept(chunk);
+		};
 
 		LlmEngine.InferenceResult result = getActiveEngine().inferStreaming(
-				systemPrompt, userMessage, timeoutSeconds, filter);
+				systemPrompt, userMessage, timeoutSeconds, tee);
 
 		return extractResponse(result.getText(), result.getInputTokens(), result.getOutputTokens(),
 				result.getCachedTokens());
@@ -174,9 +192,12 @@ public class LlmProvider {
 
 		private State state = State.BEFORE_KEY;
 
-		private static final String ANSWER_KEY = "\"answer\"";
+		/** The quoted JSON key whose string value this instance extracts, e.g. {@code "answer"}
+		 *  or {@code "reasoning"}. Two instances (one per key) split the single token stream into
+		 *  the answer and the reasoning ("thinking") channels. */
+		private final String key;
 
-		/** How many characters of ANSWER_KEY we have matched so far. */
+		/** How many characters of {@link #key} we have matched so far. */
 		private int keyMatchPos;
 
 		/** Whether the next character in the answer value is escaped. */
@@ -191,6 +212,12 @@ public class LlmProvider {
 		private int unicodeValue;
 
 		AnswerExtractingConsumer(Consumer<String> delegate) {
+			this("answer", delegate);
+		}
+
+		/** Extracts the string value of {@code fieldName} (e.g. {@code answer} or {@code reasoning}). */
+		AnswerExtractingConsumer(String fieldName, Consumer<String> delegate) {
+			this.key = "\"" + fieldName + "\"";
 			this.delegate = delegate;
 		}
 
@@ -201,7 +228,7 @@ public class LlmProvider {
 			}
 
 			if (state == State.IN_VALUE) {
-				forwardAnswerContent(token);
+				forwardValueContent(token);
 				return;
 			}
 
@@ -210,21 +237,21 @@ public class LlmProvider {
 				char c = token.charAt(i);
 				switch (state) {
 					case BEFORE_KEY:
-						if (c == ANSWER_KEY.charAt(0)) {
+						if (c == key.charAt(0)) {
 							keyMatchPos = 1;
 							state = State.IN_KEY;
 						}
 						break;
 					case IN_KEY:
-						if (c == ANSWER_KEY.charAt(keyMatchPos)) {
+						if (c == key.charAt(keyMatchPos)) {
 							keyMatchPos++;
-							if (keyMatchPos == ANSWER_KEY.length()) {
+							if (keyMatchPos == key.length()) {
 								state = State.AFTER_KEY;
 							}
 						} else {
 							// Mismatch — restart. Check if current char starts a new match.
 							state = State.BEFORE_KEY;
-							if (c == ANSWER_KEY.charAt(0)) {
+							if (c == key.charAt(0)) {
 								keyMatchPos = 1;
 								state = State.IN_KEY;
 							}
@@ -244,9 +271,9 @@ public class LlmProvider {
 							state = State.IN_VALUE;
 							// Forward remainder of this token as answer content
 							if (i + 1 < token.length()) {
-								forwardAnswerContent(token.substring(i + 1));
+								forwardValueContent(token.substring(i + 1));
 							}
-							return; // rest of token handled by forwardAnswerContent
+							return; // rest of token handled by forwardValueContent
 						} else if (c != ' ') {
 							// Value isn't a string, reset
 							state = State.BEFORE_KEY;
@@ -263,7 +290,7 @@ public class LlmProvider {
 		 * Forward characters from {@code text} that are part of the answer
 		 * string value, stopping at the unescaped closing double-quote.
 		 */
-		private void forwardAnswerContent(String text) {
+		private void forwardValueContent(String text) {
 			StringBuilder out = new StringBuilder();
 			for (int i = 0; i < text.length(); i++) {
 				char c = text.charAt(i);

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
@@ -138,6 +138,39 @@ public class LlmProviderTest {
 		return out.toString();
 	}
 
+	/** Splits {@code json} into the (reasoning, answer) channels the streaming path uses: two
+	 *  field-scanning consumers fed the same stream, exactly as LlmProvider.searchStreaming tees. */
+	private static String[] streamSplit(String json, int chunkSize) {
+		StringBuilder reasoning = new StringBuilder();
+		StringBuilder answer = new StringBuilder();
+		LlmProvider.AnswerExtractingConsumer r = new LlmProvider.AnswerExtractingConsumer("reasoning", reasoning::append);
+		LlmProvider.AnswerExtractingConsumer a = new LlmProvider.AnswerExtractingConsumer("answer", answer::append);
+		Consumer<String> tee = chunk -> { r.accept(chunk); a.accept(chunk); };
+		if (chunkSize <= 0) {
+			tee.accept(json);
+		} else {
+			for (int i = 0; i < json.length(); i += chunkSize) {
+				tee.accept(json.substring(i, Math.min(i + chunkSize, json.length())));
+			}
+		}
+		return new String[] { reasoning.toString(), answer.toString() };
+	}
+
+	@Test
+	public void streamingConsumer_shouldSplitReasoningAndAnswerOntoSeparateChannels() {
+		// The "thinking" feature: the reasoning channel must receive ONLY the reasoning value and
+		// the answer channel ONLY the answer value — no cross-leak — even when the stream arrives
+		// char-by-char. Reasoning contains a quoted span and [n] markers to stress the scanner.
+		String json = "{\"reasoning\": \"The query is about ears; record [89] is 'Hearing Loss', an "
+				+ "ear problem.\", \"answer\": \"Hearing Loss [89].\", \"citations\": [89]}";
+		String expReasoning = "The query is about ears; record [89] is 'Hearing Loss', an ear problem.";
+		for (int chunk : new int[] { 0, 1, 5 }) {
+			String[] ra = streamSplit(json, chunk);
+			assertEquals(expReasoning, ra[0], "reasoning channel must get the full reasoning value (chunk=" + chunk + ")");
+			assertEquals("Hearing Loss [89].", ra[1], "answer channel must get only the answer (chunk=" + chunk + ")");
+		}
+	}
+
 	@Test
 	public void streamingConsumer_shouldNotLeakLeadingReasoningField() {
 		// The schema emits "reasoning" FIRST, before "answer". The streaming path (/search/stream)

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -262,6 +262,8 @@ public class ChartSearchAiRestController {
 	 *
 	 * <p>SSE event types:</p>
 	 * <ul>
+	 *   <li>{@code thinking} — a chunk of the model's reasoning (chain-of-thought), emitted
+	 *       before the answer; render distinctly (e.g. a collapsible panel), not as the answer</li>
 	 *   <li>{@code token} — a chunk of the answer text</li>
 	 *   <li>{@code done} — final JSON with answer, references, and disclaimer</li>
 	 *   <li>{@code error} — an error message if something goes wrong</li>
@@ -366,6 +368,21 @@ public class ChartSearchAiRestController {
 							}
 							catch (IOException e) {
 								log.debug("Client disconnected during streaming");
+								throw new RuntimeException("Client disconnected", e);
+							}
+						}
+					}, new java.util.function.Consumer<String>() {
+						// The model's reasoning (chain-of-thought) is emitted before the answer.
+						// Stream it on a separate "thinking" event so the UI can show live progress
+						// (and the rationale) instead of a dead spinner. It is NOT the answer and
+						// must be rendered distinctly (e.g. a collapsible "thinking" panel).
+						@Override
+						public void accept(String reasoning) {
+							try {
+								writeSseEvent(out, "thinking", reasoning);
+							}
+							catch (IOException e) {
+								log.debug("Client disconnected during streaming (reasoning)");
 								throw new RuntimeException("Client disconnected", e);
 							}
 						}


### PR DESCRIPTION
## Why
The reasoning field (#27) is intrinsic decode-bound latency that can't be safely cut (brevity #29 regressed accuracy → reverted) and can't be sped up losslessly here (GPU offload already maxed; speculative decoding measured byte-identical but ~0 gain on this mostly-novel-prose output). The accuracy-safe lever is **perceived** latency: the reasoning was generated and then *discarded* by the streaming consumer, so the clinician saw a dead spinner for ~1s.

## What
Stream the reasoning on a separate **`thinking`** SSE event (before the `token` answer events). The answer stream is **byte-identical**; the reasoning channel is purely additive. Bonus for a clinical tool: the clinician sees *why* the model concluded what it did.

## How
- `AnswerExtractingConsumer` parameterized by JSON field name → two instances split the one engine stream (`reasoning`→thinking, `answer`→token).
- Backward-compatible `default searchStreaming(…, reasoningConsumer)` threads the channel through `ChartSearchService` → router → service → provider; controller emits `thinking`.
- Frontend (separate ESM repo) should render `thinking` distinctly (e.g. a collapsible panel), never as the answer.

## Validated
- Unit: `streamingConsumer_shouldSplitReasoningAndAnswerOntoSeparateChannels` (whole/char-by-char, no cross-leak) + existing streaming/escape tests green (35).
- Live `/search/stream` on the standalone: 64 `thinking` + 21 `token` events; answer + grounded references unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)