### PR TITLE
Harden the thinking-stream slice: docs + SSE dedup + adversarial test

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -163,29 +163,30 @@ public class LlmProvider {
 	}
 
 	/**
-	 * A streaming token consumer that buffers the raw JSON tokens from the LLM
-	 * and only forwards text content from inside the {@code "answer"} value.
+	 * A streaming token consumer that buffers the raw JSON tokens from the LLM and forwards the
+	 * decoded text content of <em>one</em> configured string field — its {@link #key} — to its
+	 * delegate, character by character as it arrives.
 	 *
 	 * <p>The LLM is prompted to produce
-	 * {@code {"reasoning": "...", "answer": "...", "citations": [...]}}. The {@code reasoning}
-	 * field is emitted FIRST (the model's chain-of-thought) and must NOT reach the client: the
-	 * state machine scans for the {@code "answer"} key and forwards only its value, so the
-	 * leading reasoning tokens are silently consumed. (Trade-off: the visible answer starts
-	 * streaming only after reasoning finishes generating.) This consumer processes each
-	 * character through a simple state machine and only forwards characters that belong to the
-	 * answer string value.</p>
+	 * {@code {"reasoning": "...", "answer": "...", "citations": [...]}}. Two instances split this
+	 * single stream onto two channels: one with {@code key="answer"} feeds the clinician-facing
+	 * answer, and one with {@code key="reasoning"} feeds the live "thinking" indicator (the model's
+	 * chain-of-thought, emitted first). An instance scans for its key, forwards only that field's
+	 * value, and ignores everything else (other fields, punctuation, the citations array). JSON
+	 * string escapes (including {@code \\uXXXX}, possibly split across chunks) are decoded so the
+	 * streamed text matches the non-streaming path.</p>
 	 */
 	static class AnswerExtractingConsumer implements Consumer<String> {
 
 		private final Consumer<String> delegate;
 
 		/**
-		 * Character-level state machine:
-		 * BEFORE_KEY   — scanning for the start of {@code "answer"}
-		 * IN_KEY       — matching characters of {@code "answer"}
+		 * Character-level state machine ({@link #key} is the target field, e.g. {@code "answer"}):
+		 * BEFORE_KEY   — scanning for the start of {@link #key}
+		 * IN_KEY       — matching characters of {@link #key}
 		 * AFTER_KEY    — matched key, looking for {@code :}
 		 * AFTER_COLON  — found {@code :}, looking for opening {@code "}
-		 * IN_VALUE     — inside the answer string, forwarding content
+		 * IN_VALUE     — inside the field's string value, forwarding content
 		 * DONE         — found closing quote, ignoring remaining tokens
 		 */
 		private enum State { BEFORE_KEY, IN_KEY, AFTER_KEY, AFTER_COLON, IN_VALUE, DONE }
@@ -200,7 +201,7 @@ public class LlmProvider {
 		/** How many characters of {@link #key} we have matched so far. */
 		private int keyMatchPos;
 
-		/** Whether the next character in the answer value is escaped. */
+		/** Whether the next character in the field's value is escaped. */
 		private boolean escaped;
 
 		/** When > 0, we are partway through a {@code \\uXXXX} escape and this many hex digits
@@ -232,7 +233,7 @@ public class LlmProvider {
 				return;
 			}
 
-			// Process character by character until we enter the answer value
+			// Process character by character until we enter the field's value
 			for (int i = 0; i < token.length(); i++) {
 				char c = token.charAt(i);
 				switch (state) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
@@ -172,6 +172,20 @@ public class LlmProviderTest {
 	}
 
 	@Test
+	public void streamingConsumer_answerWordInReasoningMustNotLeakToAnswerChannel() {
+		// Adversarial: the reasoning value itself contains the word "answer". The answer channel
+		// must extract ONLY the real "answer" field — it must not latch onto the word inside the
+		// reasoning value (it can't: once in the reasoning value the scanner forwards content
+		// without re-matching keys, and only the quoted "answer": key triggers the answer channel).
+		String json = "{\"reasoning\": \"To answer this I checked record [89] for ear conditions.\", "
+				+ "\"answer\": \"Hearing Loss [89].\", \"citations\": [89]}";
+		String[] ra = streamSplit(json, 1);
+		assertEquals("To answer this I checked record [89] for ear conditions.", ra[0]);
+		assertEquals("Hearing Loss [89].", ra[1],
+				"the word 'answer' inside reasoning must not leak into or truncate the answer channel");
+	}
+
+	@Test
 	public void streamingConsumer_shouldNotLeakLeadingReasoningField() {
 		// The schema emits "reasoning" FIRST, before "answer". The streaming path (/search/stream)
 		// must forward only the answer value to the clinician — never the model's reasoning

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -359,34 +359,15 @@ public class ChartSearchAiRestController {
 		try {
 			long startTime = System.currentTimeMillis();
 
+			// Two channels: "token" carries the answer; "thinking" carries the model's reasoning
+			// (chain-of-thought), which is emitted first so the UI can show live progress and the
+			// rationale instead of a dead spinner. The frontend must render "thinking" distinctly
+			// (e.g. a collapsible panel), never as the answer. Both unwind on client disconnect via
+			// writeSseEventOrThrow.
 			ChartAnswer chartAnswer = chartSearchService.searchStreaming(
-					patient, sanitizedQuestion, new java.util.function.Consumer<String>() {
-						@Override
-						public void accept(String token) {
-							try {
-								writeSseEvent(out, "token", token);
-							}
-							catch (IOException e) {
-								log.debug("Client disconnected during streaming");
-								throw new RuntimeException("Client disconnected", e);
-							}
-						}
-					}, new java.util.function.Consumer<String>() {
-						// The model's reasoning (chain-of-thought) is emitted before the answer.
-						// Stream it on a separate "thinking" event so the UI can show live progress
-						// (and the rationale) instead of a dead spinner. It is NOT the answer and
-						// must be rendered distinctly (e.g. a collapsible "thinking" panel).
-						@Override
-						public void accept(String reasoning) {
-							try {
-								writeSseEvent(out, "thinking", reasoning);
-							}
-							catch (IOException e) {
-								log.debug("Client disconnected during streaming (reasoning)");
-								throw new RuntimeException("Client disconnected", e);
-							}
-						}
-					});
+					patient, sanitizedQuestion,
+					token -> writeSseEventOrThrow(out, "token", token),
+					reasoning -> writeSseEventOrThrow(out, "thinking", reasoning));
 
 			long responseTimeMs = System.currentTimeMillis() - startTime;
 
@@ -752,6 +733,21 @@ public class ChartSearchAiRestController {
 		sb.append('\n');
 		out.write(sb.toString().getBytes("UTF-8"));
 		out.flush();
+	}
+
+	/**
+	 * Writes an SSE event, converting a client-disconnect {@link IOException} into the
+	 * {@link RuntimeException} the streaming loop unwinds on. Shared by the answer ({@code token})
+	 * and reasoning ({@code thinking}) channels so both handle a mid-stream disconnect identically.
+	 */
+	private void writeSseEventOrThrow(OutputStream out, String event, String data) {
+		try {
+			writeSseEvent(out, event, data);
+		}
+		catch (IOException e) {
+			log.debug("Client disconnected during streaming ({})", event);
+			throw new RuntimeException("Client disconnected", e);
+		}
 	}
 
 	private void writeJsonError(HttpServletResponse response, int status, String message)


### PR DESCRIPTION
`/harden` follow-up to #31 (stream reasoning as a `thinking` SSE event). No behavior change.

- **Docs:** fixed stale invariants my parameterization falsified — the `AnswerExtractingConsumer` Javadoc/state-enum/inline comments said it "only forwards the answer" and reasoning "must NOT reach the client / silently consumed"; it's now parameterized by field name and reasoning is streamed to the client.
- **Dedup:** the controller's answer + reasoning consumers had identical try/catch/disconnect handling → extracted `writeSseEventOrThrow(out, event, data)` (consistent disconnect handling across both channels); anonymous classes → lambdas.
- **Test:** `streamingConsumer_answerWordInReasoningMustNotLeakToAnswerChannel` — reasoning containing the word "answer" must not leak into/truncate the answer channel.

Phase-1 re-derive + a parallel correctness/integration agent both confirmed the two-machine tee is sound (byte-identical answer, no cross-leak, correct ordering, per-instance escape/unicode state, disconnect + cache-hit + no-reasoning all handled). `LlmProviderTest` 36 green; api+omod build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)