### PR TITLE
Fix the citation-wiring stub to override the 5-arg searchStreaming

### DIFF
--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceCitationWiringTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceCitationWiringTest.java
@@ -124,7 +124,7 @@ public class LlmInferenceServiceCitationWiringTest {
 
 		@Override
 		public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices,
-				String question, Consumer<String> tokenConsumer) {
+				String question, Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
 			return canned();
 		}
 	}


### PR DESCRIPTION
## Problem

The "Build with Maven" CI job has been failing on `main` since PR #31 (`c9a9a2b`). `LlmInferenceServiceCitationWiringTest.searchStreaming_shouldResolveInlineOnlyCitationToReference` errors on Java 11/17/21:

```
Tests run: 495, Errors: 1, BUILD FAILURE
```

## Root cause

PR #31 added a `reasoning` `Consumer` to `LlmProvider.searchStreaming`, so `LlmInferenceService.searchStreaming` now calls the new **5-arg** overload `searchStreaming(String, List<Integer>, String, Consumer, Consumer)`. The test's `StubProvider` still overrode the old **4-arg** signature, so production bypassed the stub, fell through to the real engine path, and the test errored because no LLM backend is available in CI.

## Fix

Point the `StubProvider.searchStreaming` override at the 5-arg signature production now calls (a one-line signature change; the stub body is unchanged). No production code touched, no assertions weakened — the test exercises the same wiring contract it always did.

## Verification

```
mvn -pl api test -Dtest=LlmInferenceServiceCitationWiringTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0  — BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)