### PR TITLE
Citation grounding verification for chart-search answers

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -298,13 +298,26 @@ public class ChartSearchAiConstants {
 
 	/**
 	 * Minimum cosine similarity between a cited record's text and the answer
-	 * sentence that cites it for the citation to count as grounded. Tunable
-	 * because the right floor depends on the embedding model. The default is
-	 * deliberately permissive: this Tier-1 check is meant to catch grossly
-	 * off-topic citations (a record about blood pressure cited for a diabetes
-	 * claim), not subtle subject/negation flips ("patient has X" vs "mother had
-	 * X"), which embedding cosine cannot reliably separate and which need an
-	 * entailment/NLI second pass.
+	 * sentence that cites it for the citation to count as grounded. This Tier-1
+	 * check catches grossly off-topic citations (a blood-pressure record cited
+	 * for a diabetes claim), not subtle subject/negation flips ("patient has X"
+	 * vs "mother had X") — those need the Tier-2 entailment pass.
+	 *
+	 * <p><strong>The right floor depends on the embedding model — tune it.</strong>
+	 * The {@link #DEFAULT_GROUNDING_MIN_COSINE} of {@value #DEFAULT_GROUNDING_MIN_COSINE}
+	 * suits a wide-spread model like all-MiniLM-L6-v2 (chartsearchai's own default).
+	 * It is far too low for <em>e5</em> — the model querystore uses, which the
+	 * grounding verifier reuses when {@code chartsearchai.querystore.enabled=true}.
+	 * Measured e5 cosines (mean-pooled, no prefix): supported pairs ~0.83–0.96,
+	 * unrelated pairs ~0.75–0.80. So on an e5/querystore deployment set this to
+	 * <strong>~0.82</strong>; at {@value #DEFAULT_GROUNDING_MIN_COSINE} e5 marks
+	 * essentially everything grounded (no discrimination).
+	 *
+	 * <p>Note the e5 supported-vs-unrelated gap is narrow (~0.03), so Tier-1 alone
+	 * is a weak discriminator there — enable {@link #GP_GROUNDING_ENTAILMENT_ENABLED}
+	 * for reliable grounding on e5. Erring high is the safer direction: an
+	 * over-flagged citation ("unsupported") prompts a clinician to verify, whereas
+	 * an under-flagged one ("verified") gives false assurance.
 	 */
 	public static final String GP_GROUNDING_MIN_COSINE = "chartsearchai.grounding.minCosine";
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -283,6 +283,55 @@ public class ChartSearchAiConstants {
 
 	public static final String GP_WARMUP_ENABLED = "chartsearchai.warmupEnabled";
 
+	/**
+	 * When {@code true}, every cited record is checked for grounding after the
+	 * LLM answers: the record's text must be semantically close enough to the
+	 * answer sentence(s) that cite it, otherwise the citation is flagged as
+	 * unverified. Index validation alone (does {@code [N]} map to a real
+	 * retrieved record?) cannot catch the dangerous case of a real record cited
+	 * for a claim it does not actually support. Default {@code false} so the
+	 * feature is opt-in. See {@code CitationGroundingVerifier}.
+	 */
+	public static final String GP_GROUNDING_ENABLED = "chartsearchai.grounding.enabled";
+
+	public static final boolean DEFAULT_GROUNDING_ENABLED = false;
+
+	/**
+	 * Minimum cosine similarity between a cited record's text and the answer
+	 * sentence that cites it for the citation to count as grounded. Tunable
+	 * because the right floor depends on the embedding model. The default is
+	 * deliberately permissive: this Tier-1 check is meant to catch grossly
+	 * off-topic citations (a record about blood pressure cited for a diabetes
+	 * claim), not subtle subject/negation flips ("patient has X" vs "mother had
+	 * X"), which embedding cosine cannot reliably separate and which need an
+	 * entailment/NLI second pass.
+	 */
+	public static final String GP_GROUNDING_MIN_COSINE = "chartsearchai.grounding.minCosine";
+
+	public static final double DEFAULT_GROUNDING_MIN_COSINE = 0.40;
+
+	/**
+	 * When {@code true} (and {@link #GP_GROUNDING_ENABLED} is also on), the
+	 * Tier-1 cosine verdict is confirmed by a Tier-2 entailment check: a short
+	 * yes/no LLM call asking whether the cited record actually supports the
+	 * answer sentence. This is what catches high-overlap-but-false citations
+	 * ("patient has X [5]" where record 5 says a relative had X, or the record
+	 * negates X) that cosine similarity cannot separate. Costs one extra LLM
+	 * call per cited reference, so it is a separate opt-in from the cheap
+	 * Tier-1 pass. Default {@code false}. See {@code CitationGroundingVerifier}.
+	 */
+	public static final String GP_GROUNDING_ENTAILMENT_ENABLED = "chartsearchai.grounding.entailment.enabled";
+
+	public static final boolean DEFAULT_GROUNDING_ENTAILMENT_ENABLED = false;
+
+	/**
+	 * Upper bound on Tier-2 entailment LLM calls per answer, so a heavily-cited
+	 * answer cannot trigger an unbounded number of round-trips. References
+	 * beyond this many keep their Tier-1 verdict; the verifier logs once when
+	 * the cap is hit (no silent truncation).
+	 */
+	public static final int GROUNDING_ENTAILMENT_MAX_CHECKS = 16;
+
 	// Resource type identifiers used in embeddings and citations
 	public static final String RESOURCE_TYPE_OBS = "obs";
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.openmrs.Concept;
 import org.openmrs.ConceptSet;
@@ -38,6 +39,14 @@ import org.slf4j.LoggerFactory;
 public class ChartSearchAiUtils {
 
 	private static final Logger log = LoggerFactory.getLogger(ChartSearchAiUtils.class);
+
+	/**
+	 * Matches an inline {@code [N]} citation marker in LLM answer prose. The
+	 * single source of truth for citation-marker parsing, shared by citation
+	 * extraction ({@code LlmInferenceService}) and grounding
+	 * ({@code CitationGroundingVerifier}) so the two cannot drift apart.
+	 */
+	public static final Pattern INLINE_CITATION = Pattern.compile("\\[(\\d{1,9})\\]");
 
 	/**
 	 * Builds a composite key from a resource type and resource UUID.
@@ -476,6 +485,71 @@ public class ChartSearchAiUtils {
 		String value = org.openmrs.api.context.Context.getAdministrationService()
 				.getGlobalProperty(GP_QUERYSTORE_ENABLED, "false");
 		return "true".equalsIgnoreCase(value.trim());
+	}
+
+	/**
+	 * @return true when post-answer citation grounding is enabled via
+	 *         {@link ChartSearchAiConstants#GP_GROUNDING_ENABLED}.
+	 *         Fails safe to {@code false} when no admin service is available.
+	 */
+	public static boolean isGroundingEnabled() {
+		try {
+			String value = org.openmrs.api.context.Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_GROUNDING_ENABLED,
+							String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_ENABLED));
+			return "true".equalsIgnoreCase(value.trim());
+		}
+		catch (RuntimeException e) {
+			// No admin service (e.g. context not started) -> treat grounding as
+			// off rather than breaking the search path. Grounding is an opt-in
+			// annotation; its absence is always safe.
+			return false;
+		}
+	}
+
+	/**
+	 * @return true when the Tier-2 entailment confirmation is enabled via
+	 *         {@link ChartSearchAiConstants#GP_GROUNDING_ENTAILMENT_ENABLED}.
+	 *         Fails safe to {@code false} when no admin service is available.
+	 */
+	public static boolean isGroundingEntailmentEnabled() {
+		try {
+			String value = org.openmrs.api.context.Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_GROUNDING_ENTAILMENT_ENABLED,
+							String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_ENTAILMENT_ENABLED));
+			return "true".equalsIgnoreCase(value.trim());
+		}
+		catch (RuntimeException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * @return the cosine floor below which a citation is treated as ungrounded,
+	 *         read from {@link ChartSearchAiConstants#GP_GROUNDING_MIN_COSINE},
+	 *         falling back to {@link ChartSearchAiConstants#DEFAULT_GROUNDING_MIN_COSINE}
+	 *         when unset or unparseable
+	 */
+	public static double getGroundingMinCosine() {
+		try {
+			String value = org.openmrs.api.context.Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE, "");
+			if (value != null && !value.trim().isEmpty()) {
+				return Double.parseDouble(value.trim());
+			}
+		}
+		catch (NumberFormatException e) {
+			log.warn("Invalid {} value, using default {}",
+					ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE,
+					ChartSearchAiConstants.DEFAULT_GROUNDING_MIN_COSINE);
+		}
+		catch (RuntimeException e) {
+			// No admin service (e.g. context not started) -> use default.
+			log.warn("Could not read {} (admin service unavailable); using default {}",
+					ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE,
+					ChartSearchAiConstants.DEFAULT_GROUNDING_MIN_COSINE);
+		}
+		return ChartSearchAiConstants.DEFAULT_GROUNDING_MIN_COSINE;
 	}
 
 	private ChartSearchAiUtils() {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -139,11 +139,18 @@ public interface ChartSearchService {
 
 		private final Date date;
 
+		private final Boolean grounded;
+
 		public RecordReference(int index, String resourceType, String resourceUuid, Date date) {
+			this(index, resourceType, resourceUuid, date, null);
+		}
+
+		public RecordReference(int index, String resourceType, String resourceUuid, Date date, Boolean grounded) {
 			this.index = index;
 			this.resourceType = resourceType;
 			this.resourceUuid = resourceUuid;
 			this.date = date;
+			this.grounded = grounded;
 		}
 
 		public int getIndex() {
@@ -160,6 +167,26 @@ public interface ChartSearchService {
 
 		public Date getDate() {
 			return date;
+		}
+
+		/**
+		 * Whether the cited record was found to actually support the answer
+		 * sentence(s) that cite it. {@code TRUE}/{@code FALSE} when grounding
+		 * verification ran (see {@code chartsearchai.grounding.enabled});
+		 * {@code null} when verification was disabled or could not run for this
+		 * reference (e.g. the record carried no text to compare against). A
+		 * {@code null} verdict must be rendered as "unverified", never as
+		 * "verified".
+		 */
+		public Boolean getGrounded() {
+			return grounded;
+		}
+
+		/**
+		 * @return a copy of this reference carrying the given grounding verdict
+		 */
+		public RecordReference withGrounded(Boolean verdict) {
+			return new RecordReference(index, resourceType, resourceUuid, date, verdict);
 		}
 	}
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
@@ -99,25 +99,32 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 		llmService.warmup(patient);
 	}
 
+	/**
+	 * Test seam: resolves a global property. Overridable so {@link #buildCacheKey} can be unit-tested
+	 * (which GPs are folded into the key) without standing up an OpenMRS context.
+	 */
+	protected String gp(String property, String defaultValue) {
+		return Context.getAdministrationService().getGlobalProperty(property, defaultValue);
+	}
+
 	protected String buildCacheKey(Patient patient, String question) {
-		String preFilter = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_EMBEDDING_PRE_FILTER, "false");
-		String pipeline = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_RETRIEVAL_PIPELINE,
-						ChartSearchAiConstants.PIPELINE_EMBEDDING);
-		String topK = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_EMBEDDING_TOP_K, "");
-		String similarityRatio = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_EMBEDDING_SIMILARITY_RATIO, "");
-		String keywordWeight = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_EMBEDDING_KEYWORD_WEIGHT, "");
-		String scoreGapMultiplier = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_EMBEDDING_SCORE_GAP_MULTIPLIER, "");
-		String minScoreGap = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_EMBEDDING_MIN_SCORE_GAP, "");
-		String gapValidationCosine = Context.getAdministrationService()
-				.getGlobalProperty(
-						ChartSearchAiConstants.GP_EMBEDDING_GAP_VALIDATION_COSINE_THRESHOLD, "");
+		String preFilter = gp(ChartSearchAiConstants.GP_EMBEDDING_PRE_FILTER, "false");
+		String pipeline = gp(ChartSearchAiConstants.GP_RETRIEVAL_PIPELINE,
+				ChartSearchAiConstants.PIPELINE_EMBEDDING);
+		String topK = gp(ChartSearchAiConstants.GP_EMBEDDING_TOP_K, "");
+		String similarityRatio = gp(ChartSearchAiConstants.GP_EMBEDDING_SIMILARITY_RATIO, "");
+		String keywordWeight = gp(ChartSearchAiConstants.GP_EMBEDDING_KEYWORD_WEIGHT, "");
+		String scoreGapMultiplier = gp(ChartSearchAiConstants.GP_EMBEDDING_SCORE_GAP_MULTIPLIER, "");
+		String minScoreGap = gp(ChartSearchAiConstants.GP_EMBEDDING_MIN_SCORE_GAP, "");
+		String gapValidationCosine = gp(
+				ChartSearchAiConstants.GP_EMBEDDING_GAP_VALIDATION_COSINE_THRESHOLD, "");
+		// Grounding GPs change the answer's per-citation `grounded` verdict, so
+		// they must be part of the key — otherwise toggling grounding (or its
+		// floor / entailment flag) while caching is on would serve answers whose
+		// verdicts no longer match the current configuration.
+		String grounding = gp(ChartSearchAiConstants.GP_GROUNDING_ENABLED, "");
+		String groundingMinCosine = gp(ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE, "");
+		String groundingEntailment = gp(ChartSearchAiConstants.GP_GROUNDING_ENTAILMENT_ENABLED, "");
 		return patient.getUuid() + "::" + preFilter.trim().toLowerCase()
 				+ "::" + pipeline.trim().toLowerCase()
 				+ "::" + topK.trim()
@@ -126,6 +133,9 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 				+ "::" + scoreGapMultiplier.trim()
 				+ "::" + minScoreGap.trim()
 				+ "::" + gapValidationCosine.trim()
+				+ "::" + grounding.trim().toLowerCase()
+				+ "::" + groundingMinCosine.trim()
+				+ "::" + groundingEntailment.trim().toLowerCase()
 				+ "::" + question.trim().toLowerCase();
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
@@ -92,6 +92,60 @@ public class CitationGroundingVerifier {
 		this.llmProvider = llmProvider;
 	}
 
+	/** Embeds text to a vector — abstracts over which module's provider is used. */
+	interface TextEmbedder {
+
+		float[] embed(String text);
+	}
+
+	/**
+	 * Resolves the embedding provider for a grounding run. When querystore is the
+	 * retrieval backend ({@code chartsearchai.querystore.enabled=true}), grounding
+	 * reuses querystore's configured provider (the same e5/ONNX model that built
+	 * the index) so the verifier embeds with the same model as retrieval — and so
+	 * no separate chartsearchai embedding model has to be installed. Falls back to
+	 * chartsearchai's own {@link EmbeddingProvider} when querystore is absent,
+	 * disabled, or its provider can't be resolved. Never throws.
+	 *
+	 * <p>querystore is a {@code provided}-scope (optional) dependency, so its
+	 * {@code EmbeddingProvider} type may be absent at runtime — the
+	 * {@code LinkageError} catch covers {@code NoClassDefFoundError}, mirroring
+	 * {@code QueryStoreChartBuilder}'s guard.
+	 */
+	TextEmbedder resolveEmbedder() {
+		try {
+			if (ChartSearchAiUtils.isQueryStoreEnabled()) {
+				org.openmrs.module.querystore.embedding.EmbeddingProvider qs =
+						org.openmrs.api.context.Context.getRegisteredComponent(
+								"querystore.embedding.dispatcher",
+								org.openmrs.module.querystore.embedding.EmbeddingProvider.class);
+				if (qs != null) {
+					return qs::embed;
+				}
+			}
+		}
+		catch (RuntimeException | LinkageError e) {
+			log.warn("Grounding: querystore embedding provider unavailable ({}); "
+					+ "falling back to chartsearchai's own embedding model", e.toString());
+		}
+		return embeddingProvider == null ? null : embeddingProvider::embed;
+	}
+
+	/** Accumulates embedding failures across a run so they are logged once, not per citation. */
+	private static final class GroundingStats {
+
+		int embedFailures;
+
+		String firstError;
+
+		void recordFailure(Throwable t) {
+			embedFailures++;
+			if (firstError == null) {
+				firstError = t.getClass().getSimpleName() + ": " + t.getMessage();
+			}
+		}
+	}
+
 	/**
 	 * Returns a copy of {@code references} with each entry's grounding verdict
 	 * set. A reference is grounded when its record's text is at least
@@ -141,11 +195,13 @@ public class CitationGroundingVerifier {
 		}
 
 		List<Sentence> sentences = splitIntoCitedSentences(answer);
+		TextEmbedder embedder = resolveEmbedder();
 
 		// Embedding caches: each record and each sentence is embedded at most
 		// once per call, even when an index is cited by several sentences.
 		Map<Integer, float[]> recordVectors = new HashMap<Integer, float[]>();
 		Map<Integer, float[]> sentenceVectors = new HashMap<Integer, float[]>();
+		GroundingStats stats = new GroundingStats();
 
 		int entailmentBudget = ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS;
 		int cappedCount = 0;
@@ -153,7 +209,7 @@ public class CitationGroundingVerifier {
 		List<RecordReference> annotated = new ArrayList<RecordReference>(references.size());
 		for (RecordReference reference : references) {
 			Tier1Result tier1 = verdictTier1(reference.getIndex(), textByIndex, sentences,
-					floor, recordVectors, sentenceVectors);
+					floor, recordVectors, sentenceVectors, embedder, stats);
 			Boolean verdict = tier1.verdict;
 
 			// Tier-2: only meaningful when Tier-1 reached a definite verdict and
@@ -177,6 +233,16 @@ public class CitationGroundingVerifier {
 			log.info("Tier-2 entailment cap ({}) reached; {} citation(s) kept their Tier-1 verdict only",
 					ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS, cappedCount);
 		}
+		// One summary line instead of a per-citation stacktrace: the usual cause is a
+		// misconfigured/absent embedding model, which would otherwise spam the log once
+		// per citation and bury the root cause.
+		if (stats.embedFailures > 0) {
+			log.warn("Citation grounding: could not verify {} of {} citation(s) — embedding provider "
+					+ "failed ({}); those citations are left unverified. If querystore is the backend, "
+					+ "ensure its embedding model is configured; otherwise set "
+					+ "chartsearchai.embedding.modelFilePath.",
+					stats.embedFailures, references.size(), stats.firstError);
+		}
 		return annotated;
 	}
 
@@ -187,13 +253,14 @@ public class CitationGroundingVerifier {
 	 */
 	private Tier1Result verdictTier1(int index, Map<Integer, String> textByIndex,
 			List<Sentence> sentences, double floor,
-			Map<Integer, float[]> recordVectors, Map<Integer, float[]> sentenceVectors) {
+			Map<Integer, float[]> recordVectors, Map<Integer, float[]> sentenceVectors,
+			TextEmbedder embedder, GroundingStats stats) {
 		String recordText = textByIndex.get(index);
 		if (recordText == null || recordText.trim().isEmpty()) {
 			return new Tier1Result(null, null, null); // nothing to compare against
 		}
 		try {
-			float[] recordVector = embedRecord(index, recordText, recordVectors);
+			float[] recordVector = embedRecord(index, recordText, recordVectors, embedder);
 
 			// Track whether ANY comparison happened separately from the best
 			// score: a negative cosine is the strongest "not grounded" signal,
@@ -206,7 +273,7 @@ public class CitationGroundingVerifier {
 				if (sentences.get(s).cites(index)) {
 					anyInlineCite = true;
 					compared = true;
-					double sim = similarity(recordVector, s, sentences, sentenceVectors);
+					double sim = similarity(recordVector, s, sentences, sentenceVectors, embedder);
 					if (sim > best) {
 						best = sim;
 						bestSentence = sentences.get(s).text;
@@ -220,7 +287,7 @@ public class CitationGroundingVerifier {
 			if (!anyInlineCite) {
 				for (int s = 0; s < sentences.size(); s++) {
 					compared = true;
-					double sim = similarity(recordVector, s, sentences, sentenceVectors);
+					double sim = similarity(recordVector, s, sentences, sentenceVectors, embedder);
 					if (sim > best) {
 						best = sim;
 						bestSentence = sentences.get(s).text;
@@ -234,8 +301,9 @@ public class CitationGroundingVerifier {
 			return new Tier1Result(Boolean.valueOf(best >= floor), bestSentence, recordText);
 		}
 		catch (RuntimeException e) {
-			// Never break the search path on a verification failure.
-			log.warn("Grounding check failed for citation [{}]; leaving unverified", index, e);
+			// Never break the search path on a verification failure; count it for the
+			// single summary log in verify() rather than spamming per citation.
+			stats.recordFailure(e);
 			return new Tier1Result(null, null, recordText);
 		}
 	}
@@ -278,19 +346,20 @@ public class CitationGroundingVerifier {
 	}
 
 	private double similarity(float[] recordVector, int sentenceIdx,
-			List<Sentence> sentences, Map<Integer, float[]> sentenceVectors) {
+			List<Sentence> sentences, Map<Integer, float[]> sentenceVectors, TextEmbedder embedder) {
 		float[] sentenceVector = sentenceVectors.get(sentenceIdx);
 		if (sentenceVector == null) {
-			sentenceVector = embeddingProvider.embed(sentences.get(sentenceIdx).text);
+			sentenceVector = embedder.embed(sentences.get(sentenceIdx).text);
 			sentenceVectors.put(sentenceIdx, sentenceVector);
 		}
 		return ChartSearchAiUtils.cosineSimilarity(recordVector, sentenceVector);
 	}
 
-	private float[] embedRecord(int index, String recordText, Map<Integer, float[]> recordVectors) {
+	private float[] embedRecord(int index, String recordText, Map<Integer, float[]> recordVectors,
+			TextEmbedder embedder) {
 		float[] vector = recordVectors.get(index);
 		if (vector == null) {
-			vector = embeddingProvider.embed(recordText);
+			vector = embedder.embed(recordText);
 			recordVectors.put(index, vector);
 		}
 		return vector;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
@@ -1,0 +1,337 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
+import org.openmrs.module.chartsearchai.embedding.EmbeddingProvider;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Checks that each cited record actually supports the answer sentence(s) that
+ * cite it, rather than trusting the LLM's citations blindly.
+ *
+ * <p>{@link LlmInferenceService} already validates that a {@code [N]} marker
+ * maps to a real retrieved record. That catches a model citing a record number
+ * that does not exist, but not the more dangerous case of a real record cited
+ * for a claim it does not support (e.g. "patient has diabetes [5]" where record
+ * 5 is a blood-pressure reading). This verifier closes that gap with a Tier-1
+ * semantic-overlap check: embed each cited record and the answer sentence(s)
+ * that reference it, and require their cosine similarity to clear a tunable
+ * floor ({@code chartsearchai.grounding.minCosine}). Below the floor, the
+ * citation is annotated {@code grounded=false} so the UI can flag it.
+ *
+ * <p><strong>Scope and limits.</strong> This is intentionally an annotate-only,
+ * non-destructive pass: it never rewrites the answer prose or drops citations,
+ * it only attaches a verdict. Cosine overlap reliably separates off-topic
+ * citations from on-topic ones, but it does <em>not</em> separate subtle
+ * subject/polarity flips ("patient has X" vs "mother had X", "denies X" vs
+ * "has X") — those embed nearly identically.
+ *
+ * <p><strong>Tier-2 (optional).</strong> When
+ * {@code chartsearchai.grounding.entailment.enabled} is set, each reference
+ * Tier-1 could evaluate is confirmed by a short yes/no LLM entailment call
+ * ({@link LlmProvider#entails}) whose verdict is authoritative. This is what
+ * catches the subject/polarity flips cosine cannot. It runs on Tier-1 passes
+ * <em>and</em> failures — the dangerous case (a high-overlap but unsupported
+ * citation) is a Tier-1 pass, so confirming only failures would miss it — and
+ * costs one LLM call per cited reference, capped at
+ * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} per answer.
+ *
+ * <p>The verifier never throws into the search path: any failure (embedding
+ * error, missing text) degrades to a {@code null} verdict — "could not verify"
+ * — which renders as unverified, exactly as if grounding were disabled.
+ */
+@Service("chartSearchAi.citationGroundingVerifier")
+public class CitationGroundingVerifier {
+
+	private static final Logger log = LoggerFactory.getLogger(CitationGroundingVerifier.class);
+
+	/**
+	 * Splits an answer into claim units, on terminal punctuation followed by
+	 * whitespace OR on line breaks. The line-break case matters: the system
+	 * prompt instructs the model to "use numbered lines or simple newlines to
+	 * structure lists", so a multi-item answer often has no sentence-ending
+	 * punctuation — without splitting on newlines every citation would be scored
+	 * against the whole answer instead of its own line.
+	 */
+	private static final Pattern SENTENCE_SPLIT = Pattern.compile("(?<=[.!?])\\s+|[\\r\\n]+");
+
+	@Autowired
+	private EmbeddingProvider embeddingProvider;
+
+	@Autowired
+	private LlmProvider llmProvider;
+
+	/** Test seam: production wires {@link EmbeddingProvider} via {@link Autowired}. */
+	void setEmbeddingProvider(EmbeddingProvider embeddingProvider) {
+		this.embeddingProvider = embeddingProvider;
+	}
+
+	/** Test seam: production wires {@link LlmProvider} via {@link Autowired}. */
+	void setLlmProvider(LlmProvider llmProvider) {
+		this.llmProvider = llmProvider;
+	}
+
+	/**
+	 * Returns a copy of {@code references} with each entry's grounding verdict
+	 * set. A reference is grounded when its record's text is at least
+	 * {@link ChartSearchAiUtils#getGroundingMinCosine()} cosine-similar to the
+	 * best-matching answer sentence that cites it (or, when no sentence cites it
+	 * inline — e.g. it appeared only in the structured citations array — to the
+	 * best-matching sentence anywhere in the answer). References whose record
+	 * carries no text, or that cannot be embedded, are returned with a
+	 * {@code null} verdict ("could not verify").
+	 *
+	 * @param answer the full answer prose, with inline {@code [N]} markers
+	 * @param references the index-validated references to annotate
+	 * @param mappings the record mappings carrying each index's source text
+	 * @return a new list, same order, with grounding verdicts attached
+	 */
+	public List<RecordReference> verify(String answer, List<RecordReference> references,
+			List<RecordMapping> mappings) {
+		return verify(answer, references, mappings, ChartSearchAiUtils.getGroundingMinCosine(),
+				ChartSearchAiUtils.isGroundingEntailmentEnabled());
+	}
+
+	/**
+	 * Flag-explicit overload — the seam the public {@link #verify} delegates to
+	 * after reading {@code chartsearchai.grounding.minCosine} and
+	 * {@code chartsearchai.grounding.entailment.enabled}. Package-private so unit
+	 * tests can exercise the grounding logic without an OpenMRS context.
+	 *
+	 * <p>When {@code entailmentEnabled}, every reference Tier-1 could evaluate is
+	 * confirmed by a Tier-2 LLM entailment call whose verdict is authoritative
+	 * (cosine errs in both directions, and the dangerous error — a high-overlap
+	 * but unsupported citation — is exactly the case Tier-1 cannot self-detect,
+	 * so the LLM must see Tier-1 passes too, not only failures). Tier-2 is
+	 * capped at {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS}
+	 * calls per answer; references beyond the cap keep their Tier-1 verdict.
+	 */
+	List<RecordReference> verify(String answer, List<RecordReference> references,
+			List<RecordMapping> mappings, double floor, boolean entailmentEnabled) {
+		if (references == null || references.isEmpty()) {
+			return references;
+		}
+
+		Map<Integer, String> textByIndex = new HashMap<Integer, String>();
+		if (mappings != null) {
+			for (RecordMapping mapping : mappings) {
+				textByIndex.put(mapping.getIndex(), mapping.getText());
+			}
+		}
+
+		List<Sentence> sentences = splitIntoCitedSentences(answer);
+
+		// Embedding caches: each record and each sentence is embedded at most
+		// once per call, even when an index is cited by several sentences.
+		Map<Integer, float[]> recordVectors = new HashMap<Integer, float[]>();
+		Map<Integer, float[]> sentenceVectors = new HashMap<Integer, float[]>();
+
+		int entailmentBudget = ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS;
+		int cappedCount = 0;
+
+		List<RecordReference> annotated = new ArrayList<RecordReference>(references.size());
+		for (RecordReference reference : references) {
+			Tier1Result tier1 = verdictTier1(reference.getIndex(), textByIndex, sentences,
+					floor, recordVectors, sentenceVectors);
+			Boolean verdict = tier1.verdict;
+
+			// Tier-2: only meaningful when Tier-1 reached a definite verdict and
+			// we have a concrete claim sentence to fact-check against the record.
+			if (entailmentEnabled && tier1.verdict != null && tier1.bestSentence != null
+					&& tier1.recordText != null) {
+				if (entailmentBudget > 0) {
+					entailmentBudget--;
+					Boolean llmVerdict = safeEntails(tier1.recordText, tier1.bestSentence,
+							reference.getIndex());
+					if (llmVerdict != null) {
+						verdict = llmVerdict; // authoritative; null -> keep Tier-1
+					}
+				} else {
+					cappedCount++;
+				}
+			}
+			annotated.add(reference.withGrounded(verdict));
+		}
+		if (cappedCount > 0) {
+			log.info("Tier-2 entailment cap ({}) reached; {} citation(s) kept their Tier-1 verdict only",
+					ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS, cappedCount);
+		}
+		return annotated;
+	}
+
+	/**
+	 * Computes the Tier-1 cosine verdict for one cited index and identifies the
+	 * single best-matching claim sentence (used as the Tier-2 entailment target).
+	 * Never throws: an embedding failure yields a {@code null} verdict.
+	 */
+	private Tier1Result verdictTier1(int index, Map<Integer, String> textByIndex,
+			List<Sentence> sentences, double floor,
+			Map<Integer, float[]> recordVectors, Map<Integer, float[]> sentenceVectors) {
+		String recordText = textByIndex.get(index);
+		if (recordText == null || recordText.trim().isEmpty()) {
+			return new Tier1Result(null, null, null); // nothing to compare against
+		}
+		try {
+			float[] recordVector = embedRecord(index, recordText, recordVectors);
+
+			// Track whether ANY comparison happened separately from the best
+			// score: a negative cosine is the strongest "not grounded" signal,
+			// so it must produce FALSE, not be mistaken for "nothing to compare".
+			double best = -Double.MAX_VALUE;
+			String bestSentence = null;
+			boolean compared = false;
+			boolean anyInlineCite = false;
+			for (int s = 0; s < sentences.size(); s++) {
+				if (sentences.get(s).cites(index)) {
+					anyInlineCite = true;
+					compared = true;
+					double sim = similarity(recordVector, s, sentences, sentenceVectors);
+					if (sim > best) {
+						best = sim;
+						bestSentence = sentences.get(s).text;
+					}
+				}
+			}
+			// No sentence cited this index inline (citations-array-only): fall
+			// back to the best match against any sentence, so a record wholly
+			// unrelated to the answer is still flagged without over-flagging a
+			// record the model legitimately listed but did not inline-cite.
+			if (!anyInlineCite) {
+				for (int s = 0; s < sentences.size(); s++) {
+					compared = true;
+					double sim = similarity(recordVector, s, sentences, sentenceVectors);
+					if (sim > best) {
+						best = sim;
+						bestSentence = sentences.get(s).text;
+					}
+				}
+			}
+
+			if (!compared) {
+				return new Tier1Result(null, null, recordText); // no sentences (empty answer)
+			}
+			return new Tier1Result(Boolean.valueOf(best >= floor), bestSentence, recordText);
+		}
+		catch (RuntimeException e) {
+			// Never break the search path on a verification failure.
+			log.warn("Grounding check failed for citation [{}]; leaving unverified", index, e);
+			return new Tier1Result(null, null, recordText);
+		}
+	}
+
+	/** Wraps the Tier-2 LLM call so a failure degrades to "could not verify" (null). */
+	private Boolean safeEntails(String recordText, String claim, int index) {
+		try {
+			return llmProvider.entails(recordText, stripCitationMarkers(claim));
+		}
+		catch (RuntimeException e) {
+			log.warn("Tier-2 entailment check failed for citation [{}]; keeping Tier-1 verdict", index, e);
+			return null;
+		}
+	}
+
+	/**
+	 * Removes inline {@code [N]} citation markers so the entailment STATEMENT is
+	 * the clinical claim alone — the markers are UI metadata, not part of what
+	 * the record must support, and leaving them in only adds noise the fact-check
+	 * LLM has to ignore.
+	 */
+	static String stripCitationMarkers(String text) {
+		return ChartSearchAiUtils.INLINE_CITATION.matcher(text).replaceAll("").trim();
+	}
+
+	/** Tier-1 outcome plus the claim sentence and record text Tier-2 needs. */
+	private static class Tier1Result {
+
+		final Boolean verdict;
+
+		final String bestSentence;
+
+		final String recordText;
+
+		Tier1Result(Boolean verdict, String bestSentence, String recordText) {
+			this.verdict = verdict;
+			this.bestSentence = bestSentence;
+			this.recordText = recordText;
+		}
+	}
+
+	private double similarity(float[] recordVector, int sentenceIdx,
+			List<Sentence> sentences, Map<Integer, float[]> sentenceVectors) {
+		float[] sentenceVector = sentenceVectors.get(sentenceIdx);
+		if (sentenceVector == null) {
+			sentenceVector = embeddingProvider.embed(sentences.get(sentenceIdx).text);
+			sentenceVectors.put(sentenceIdx, sentenceVector);
+		}
+		return ChartSearchAiUtils.cosineSimilarity(recordVector, sentenceVector);
+	}
+
+	private float[] embedRecord(int index, String recordText, Map<Integer, float[]> recordVectors) {
+		float[] vector = recordVectors.get(index);
+		if (vector == null) {
+			vector = embeddingProvider.embed(recordText);
+			recordVectors.put(index, vector);
+		}
+		return vector;
+	}
+
+	/**
+	 * Splits the answer into sentences, recording for each the set of {@code [N]}
+	 * indices it cites inline. Returns an empty list for null/blank answers.
+	 */
+	static List<Sentence> splitIntoCitedSentences(String answer) {
+		List<Sentence> sentences = new ArrayList<Sentence>();
+		if (answer == null || answer.trim().isEmpty()) {
+			return sentences;
+		}
+		for (String raw : SENTENCE_SPLIT.split(answer)) {
+			if (raw.trim().isEmpty()) {
+				continue;
+			}
+			Sentence sentence = new Sentence(raw);
+			Matcher marker = ChartSearchAiUtils.INLINE_CITATION.matcher(raw);
+			while (marker.find()) {
+				sentence.citedIndexes.add(Integer.valueOf(marker.group(1)));
+			}
+			sentences.add(sentence);
+		}
+		return sentences;
+	}
+
+	/** An answer sentence and the citation indices it references inline. */
+	static class Sentence {
+
+		final String text;
+
+		final java.util.Set<Integer> citedIndexes = new java.util.HashSet<Integer>();
+
+		Sentence(String text) {
+			this.text = text;
+		}
+
+		boolean cites(int index) {
+			return citedIndexes.contains(Integer.valueOf(index));
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.openmrs.Patient;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
@@ -60,6 +59,14 @@ public class LlmInferenceService implements ChartSearchService {
 
 	@Autowired
 	private ChartBuildingStrategy chartBuildingStrategy;
+
+	@Autowired
+	private CitationGroundingVerifier citationGroundingVerifier;
+
+	/** Test seam: production wires {@link CitationGroundingVerifier} via {@link Autowired}. */
+	void setCitationGroundingVerifier(CitationGroundingVerifier citationGroundingVerifier) {
+		this.citationGroundingVerifier = citationGroundingVerifier;
+	}
 
 	/** Test seam: production wires {@link LlmProvider} via {@link Autowired}.
 	 *  Package-private to allow {@code LlmInferenceServiceWarmupIntegrationTest} to
@@ -126,9 +133,11 @@ public class LlmInferenceService implements ChartSearchService {
 			inputTokens = response.getInputTokens();
 			cachedTokens = response.getCachedTokens();
 
-			ChartAnswer answer = new ChartAnswer(response.getAnswer(),
+			List<RecordReference> references = groundReferences(response.getAnswer(),
 					extractCitedReferences(response.getAnswer(), response.getCitations(),
 							chart.getMappings()),
+					chart.getMappings());
+			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens());
 			outcome = "ok";
@@ -238,9 +247,11 @@ public class LlmInferenceService implements ChartSearchService {
 			inputTokens = response.getInputTokens();
 			cachedTokens = response.getCachedTokens();
 
-			ChartAnswer answer = new ChartAnswer(response.getAnswer(),
+			List<RecordReference> references = groundReferences(response.getAnswer(),
 					extractCitedReferences(response.getAnswer(), response.getCitations(),
 							chart.getMappings()),
+					chart.getMappings());
+			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens());
 			outcome = "ok";
@@ -269,8 +280,20 @@ public class LlmInferenceService implements ChartSearchService {
 		return !"false".equalsIgnoreCase(value.trim());
 	}
 
-	/** Matches an inline {@code [N]} citation marker in the answer prose. */
-	private static final Pattern INLINE_CITATION = Pattern.compile("\\[(\\d{1,9})\\]");
+	/**
+	 * Annotates each index-validated citation with a grounding verdict when
+	 * {@code chartsearchai.grounding.enabled} is set, otherwise returns the
+	 * references unchanged. Annotate-only: it never drops or reorders
+	 * references, so disabling the flag (or a verifier failure, which degrades
+	 * to an unverified verdict) leaves today's behavior intact.
+	 */
+	private List<RecordReference> groundReferences(String answer, List<RecordReference> references,
+			List<RecordMapping> mappings) {
+		if (references == null || references.isEmpty() || !ChartSearchAiUtils.isGroundingEnabled()) {
+			return references;
+		}
+		return citationGroundingVerifier.verify(answer, references, mappings);
+	}
 
 	static List<RecordReference> extractCitedReferences(List<Integer> citations,
 			List<RecordMapping> mappings) {
@@ -302,7 +325,7 @@ public class LlmInferenceService implements ChartSearchService {
 			}
 		}
 		if (answer != null) {
-			Matcher marker = INLINE_CITATION.matcher(answer);
+			Matcher marker = ChartSearchAiUtils.INLINE_CITATION.matcher(answer);
 			while (marker.find()) {
 				seen.add(Integer.valueOf(marker.group(1)));
 			}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -335,6 +335,106 @@ public class LlmProvider {
 		}
 	}
 
+	static final String ENTAILMENT_SYSTEM_PROMPT = "You are a strict clinical fact-checker. "
+			+ "You are given a SOURCE record and a STATEMENT. The SOURCE supports the STATEMENT only "
+			+ "if it explicitly states it. It does NOT support the STATEMENT when the STATEMENT is "
+			+ "about a different person (e.g. a relative or family history), is negated or denied by "
+			+ "the SOURCE, or is simply not stated. Do not use any outside knowledge. "
+			// The shared response schema (ChartAnswerResponseFormat) makes the model emit
+			// {"reasoning": ..., "answer": ..., "citations": ...} — reasoning first. So tell it to
+			// reason briefly, then put the one-word verdict in the answer field; parseEntailmentVerdict
+			// reads YES/NO from that answer field, not from the reasoning. Citations stay empty.
+			+ "Briefly reason about whether the SOURCE supports the STATEMENT, then put your verdict "
+			+ "— the single word YES or NO — in the \"answer\" field, with an empty \"citations\" array.";
+
+	/**
+	 * Tier-2 grounding check: asks the active LLM whether {@code source} actually
+	 * supports {@code statement}. Used by {@code CitationGroundingVerifier} to
+	 * confirm a citation that cosine similarity alone cannot judge (high lexical
+	 * overlap but a subject/polarity flip, e.g. "patient has X" vs "mother had X").
+	 *
+	 * @param source the cited record's text
+	 * @param statement the answer sentence that cites it
+	 * @return {@code TRUE}/{@code FALSE} when the model answers YES/NO,
+	 *         {@code null} when the answer is empty or unparseable (caller should
+	 *         then fall back to the Tier-1 verdict rather than guess)
+	 */
+	public Boolean entails(String source, String statement) {
+		if (source == null || source.trim().isEmpty() || statement == null || statement.trim().isEmpty()) {
+			return null;
+		}
+		String userMessage = "SOURCE: " + source.trim() + "\nSTATEMENT: " + statement.trim()
+				+ "\nDoes the SOURCE support the STATEMENT? Answer YES or NO.";
+		LlmEngine.InferenceResult result = getActiveEngine().infer(
+				ENTAILMENT_SYSTEM_PROMPT, userMessage, getTimeoutSeconds());
+		return parseEntailmentVerdict(result == null ? null : result.getText());
+	}
+
+	/**
+	 * Reads the YES/NO entailment verdict out of the LLM's raw reply. The shared response schema
+	 * ({@link ChartAnswerResponseFormat}) emits a leading {@code "reasoning"} field before
+	 * {@code "answer"}, and a fact-checker's reasoning routinely contains words like "no" ("no
+	 * explicit mention…") — so scanning the RAW reply for the first YES/NO token (what
+	 * {@link #parseYesNo} does) would read the verdict out of the reasoning and flip it. Parse the
+	 * structured {@code answer} field first ({@link #extractResponse} ignores reasoning), then read
+	 * the verdict from that. Degrades safely: a bare, envelope-free reply ("YES") falls through
+	 * extractResponse unchanged, and a null/empty reply yields {@code null}.
+	 */
+	/** Matches a standalone YES or NO verdict token (word-boundary anchored). */
+	private static final java.util.regex.Pattern VERDICT_TOKEN =
+			java.util.regex.Pattern.compile("\\b(YES|NO)\\b");
+
+	static Boolean parseEntailmentVerdict(String rawLlmText) {
+		if (rawLlmText == null) {
+			return null;
+		}
+		String answer = extractResponse(rawLlmText).getAnswer();
+		// A compliant fact-check reply is the single word YES or NO in the answer
+		// field. If the model wrote a verbose answer containing BOTH verdict words
+		// (e.g. "Yes, but there is no explicit confirmation"), positional parsing
+		// could pick the wrong one and silently flip a citation's grounded verdict
+		// — so treat it as undecidable and let grounding fall back to its Tier-1
+		// verdict rather than guess.
+		if (answer != null && hasBothVerdicts(answer)) {
+			return null;
+		}
+		return parseYesNo(answer);
+	}
+
+	/** True when {@code text} contains both a standalone YES and a standalone NO token. */
+	private static boolean hasBothVerdicts(String text) {
+		boolean hasYes = false;
+		boolean hasNo = false;
+		java.util.regex.Matcher m = VERDICT_TOKEN.matcher(text.toUpperCase(java.util.Locale.ROOT));
+		while (m.find()) {
+			if ("YES".equals(m.group(1))) {
+				hasYes = true;
+			} else {
+				hasNo = true;
+			}
+		}
+		return hasYes && hasNo;
+	}
+
+	/**
+	 * Parses a YES/NO entailment reply. Tolerant of surrounding whitespace,
+	 * punctuation, casing, and a leading JSON-ish or markdown wrapper — looks
+	 * for the first standalone YES or NO token. Returns {@code null} when
+	 * neither is found. Callers that must not misread a verbose both-words reply
+	 * should screen with {@link #hasBothVerdicts} first (see
+	 * {@link #parseEntailmentVerdict}).
+	 */
+	static Boolean parseYesNo(String text) {
+		if (text == null) {
+			return null;
+		}
+		java.util.regex.Matcher m = VERDICT_TOKEN.matcher(text.toUpperCase(java.util.Locale.ROOT));
+		if (m.find()) {
+			return Boolean.valueOf("YES".equals(m.group(1)));
+		}
+		return null;
+	}
+
 	/**
 	 * Pre-warm the LLM's prompt cache by sending the same prefix a real query
 	 * would, with an empty trailing question. See {@link #buildUserMessage} for

--- a/api/src/main/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializer.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializer.java
@@ -87,14 +87,22 @@ public class PatientChartSerializer {
 		for (int i = 0; i < records.size(); i++) {
 			SerializedRecord record = records.get(i);
 			int index = i + 1;
-			mappings.add(new RecordMapping(index, record.getResourceType(), record.getResourceUuid(),
-					record.getDate(), record.getText()));
-
-			sb.append("[").append(index).append("] ");
+			// The exact per-record content the LLM sees in the chart line (everything after
+			// the "[N] " index): the date parenthetical plus the synonym-stripped body. The
+			// grounding verifier compares cited records against this same string, so its view
+			// matches the model's — otherwise a cited date (which the model reads from the
+			// prefix) would look unsupported because the bare record body omits it.
+			StringBuilder rendered = new StringBuilder();
 			if (record.getDate() != null) {
-				sb.append("(").append(DateFormatUtil.formatDate(record.getDate())).append(") ");
+				rendered.append("(").append(DateFormatUtil.formatDate(record.getDate())).append(") ");
 			}
-			sb.append(ConceptNameUtil.stripSynonyms(record.getText())).append("\n");
+			rendered.append(ConceptNameUtil.stripSynonyms(record.getText()));
+			String renderedText = rendered.toString();
+
+			mappings.add(new RecordMapping(index, record.getResourceType(), record.getResourceUuid(),
+					record.getDate(), renderedText));
+
+			sb.append("[").append(index).append("] ").append(renderedText).append("\n");
 
 			if (focusUuids != null && focusUuids.contains(record.getResourceUuid())) {
 				focusIndices.add(index);
@@ -212,10 +220,12 @@ public class PatientChartSerializer {
 		}
 
 		/**
-		 * The serialized record body the LLM saw for this index, used by the
-		 * citation grounding verifier to check that a cited record actually
-		 * supports the answer sentence(s) citing it. May be {@code null} when
-		 * the mapping was built without text.
+		 * The exact per-record content the LLM saw in the chart line for this
+		 * index — the date parenthetical (if any) plus the synonym-stripped body,
+		 * i.e. everything after the {@code "[N] "} prefix. The citation grounding
+		 * verifier compares cited records against this so its view matches the
+		 * model's (including the date the model may cite). May be {@code null}
+		 * when the mapping was built without text.
 		 */
 		public String getText() {
 			return text;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializer.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializer.java
@@ -87,7 +87,8 @@ public class PatientChartSerializer {
 		for (int i = 0; i < records.size(); i++) {
 			SerializedRecord record = records.get(i);
 			int index = i + 1;
-			mappings.add(new RecordMapping(index, record.getResourceType(), record.getResourceUuid(), record.getDate()));
+			mappings.add(new RecordMapping(index, record.getResourceType(), record.getResourceUuid(),
+					record.getDate(), record.getText()));
 
 			sb.append("[").append(index).append("] ");
 			if (record.getDate() != null) {
@@ -174,11 +175,24 @@ public class PatientChartSerializer {
 
 		private final Date date;
 
+		private final String text;
+
+		/**
+		 * Backward-compatible constructor that carries no source text. Mappings
+		 * built this way cannot be grounding-checked; the grounding verifier
+		 * treats a null/blank text as "cannot verify" and leaves the citation
+		 * unannotated.
+		 */
 		public RecordMapping(int index, String resourceType, String resourceUuid, Date date) {
+			this(index, resourceType, resourceUuid, date, null);
+		}
+
+		public RecordMapping(int index, String resourceType, String resourceUuid, Date date, String text) {
 			this.index = index;
 			this.resourceType = resourceType;
 			this.resourceUuid = resourceUuid;
 			this.date = date;
+			this.text = text;
 		}
 
 		public int getIndex() {
@@ -195,6 +209,16 @@ public class PatientChartSerializer {
 
 		public Date getDate() {
 			return date;
+		}
+
+		/**
+		 * The serialized record body the LLM saw for this index, used by the
+		 * citation grounding verifier to check that a cited record actually
+		 * supports the answer sentence(s) citing it. May be {@code null} when
+		 * the mapping was built without text.
+		 */
+		public String getText() {
+			return text;
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouterTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouterTest.java
@@ -1,0 +1,103 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+
+/**
+ * Unit tests for {@link ChartSearchServiceRouter#buildCacheKey}. The router caches the full
+ * {@code ChartAnswer} — including each citation's {@code grounded} verdict — under this key, so
+ * every global property that changes the answer (including the grounding GPs) MUST be folded into
+ * the key. Otherwise toggling a setting while caching is on serves an answer whose verdicts no
+ * longer match the live configuration. These tests pin that contract; the GP reads are supplied
+ * through the {@code gp()} seam so the key can be exercised without an OpenMRS context.
+ */
+public class ChartSearchServiceRouterTest {
+
+	/** Router whose global-property reads come from an in-memory map instead of {@code Context}. */
+	private static class StubRouter extends ChartSearchServiceRouter {
+
+		final Map<String, String> gps = new HashMap<String, String>();
+
+		@Override
+		protected String gp(String property, String defaultValue) {
+			return gps.containsKey(property) ? gps.get(property) : defaultValue;
+		}
+	}
+
+	private static Patient patient(String uuid) {
+		Patient p = new Patient();
+		p.setUuid(uuid);
+		return p;
+	}
+
+	@Test
+	public void buildCacheKey_isDeterministicForIdenticalConfig() {
+		StubRouter router = new StubRouter();
+		assertEquals(router.buildCacheKey(patient("p1"), "any kidney problems?"),
+				router.buildCacheKey(patient("p1"), "any kidney problems?"),
+				"same patient + question + config must produce the same cache key");
+	}
+
+	/**
+	 * Sanity check that the harness actually detects key changes — guards against a regression
+	 * where the key stops varying at all, which would make every grounding assertion below pass
+	 * vacuously.
+	 */
+	@Test
+	public void buildCacheKey_changesWhenANonGroundingGpChanges() {
+		StubRouter router = new StubRouter();
+		Patient p = patient("p1");
+		String before = router.buildCacheKey(p, "q");
+		router.gps.put(ChartSearchAiConstants.GP_EMBEDDING_TOP_K, "30");
+		assertNotEquals(before, router.buildCacheKey(p, "q"));
+	}
+
+	@Test
+	public void buildCacheKey_changesWhenGroundingEnabledToggles() {
+		StubRouter router = new StubRouter();
+		Patient p = patient("p1");
+		String groundingOff = router.buildCacheKey(p, "q");
+		router.gps.put(ChartSearchAiConstants.GP_GROUNDING_ENABLED, "true");
+		assertNotEquals(groundingOff, router.buildCacheKey(p, "q"),
+				"toggling grounding.enabled must change the key — else a cached answer's grounded "
+				+ "verdicts go stale when the flag flips");
+	}
+
+	@Test
+	public void buildCacheKey_changesWhenGroundingMinCosineChanges() {
+		StubRouter router = new StubRouter();
+		Patient p = patient("p1");
+		router.gps.put(ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE, "0.40");
+		String at040 = router.buildCacheKey(p, "q");
+		router.gps.put(ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE, "0.55");
+		assertNotEquals(at040, router.buildCacheKey(p, "q"),
+				"changing the grounding cosine floor changes which citations are grounded, so it "
+				+ "must change the key");
+	}
+
+	@Test
+	public void buildCacheKey_changesWhenGroundingEntailmentToggles() {
+		StubRouter router = new StubRouter();
+		Patient p = patient("p1");
+		String entailmentOff = router.buildCacheKey(p, "q");
+		router.gps.put(ChartSearchAiConstants.GP_GROUNDING_ENTAILMENT_ENABLED, "true");
+		assertNotEquals(entailmentOff, router.buildCacheKey(p, "q"),
+				"toggling the Tier-2 entailment flag changes verdicts, so it must change the key");
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
@@ -1,0 +1,379 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
+import org.openmrs.module.chartsearchai.embedding.EmbeddingProvider;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * Unit tests for {@link CitationGroundingVerifier}. Uses a deterministic stub
+ * {@link EmbeddingProvider} (each registered phrase maps to a fixed unit
+ * vector) and a stub {@link LlmProvider} (programmed yes/no verdicts) so both
+ * tiers of grounding are exercised without ONNX, an LLM, or an OpenMRS context.
+ */
+public class CitationGroundingVerifierTest {
+
+	private static final double FLOOR = 0.40;
+
+	private static final boolean TIER1_ONLY = false;
+
+	private static final boolean TIER2_ON = true;
+
+	/**
+	 * Maps exact strings to fixed vectors. Cosine between two registered strings
+	 * is just the dot product of their (unit) vectors. Unregistered text gets a
+	 * zero vector, which yields cosine 0 against everything — i.e. "no overlap".
+	 */
+	private static class StubEmbeddingProvider implements EmbeddingProvider {
+
+		private final Map<String, float[]> vectors = new HashMap<String, float[]>();
+
+		void register(String text, float[] vector) {
+			vectors.put(text, vector);
+		}
+
+		@Override
+		public float[] embed(String text) {
+			float[] v = vectors.get(text);
+			return v != null ? v : new float[] { 0f, 0f };
+		}
+
+		@Override
+		public int getDimensions() {
+			return 2;
+		}
+	}
+
+	/** A LlmProvider whose {@link #entails} returns a programmed verdict and counts calls. */
+	private static class StubLlmProvider extends LlmProvider {
+
+		Boolean verdict;
+
+		int calls;
+
+		StubLlmProvider(Boolean verdict) {
+			this.verdict = verdict;
+		}
+
+		@Override
+		public Boolean entails(String source, String statement) {
+			calls++;
+			return verdict;
+		}
+	}
+
+	private StubEmbeddingProvider embeddings;
+
+	private StubLlmProvider llm;
+
+	private CitationGroundingVerifier verifier;
+
+	private static final float[] AXIS_A = { 1f, 0f };
+
+	private static final float[] AXIS_B = { 0f, 1f };
+
+	@BeforeEach
+	public void setUp() {
+		embeddings = new StubEmbeddingProvider();
+		llm = new StubLlmProvider(null);
+		verifier = new CitationGroundingVerifier();
+		verifier.setEmbeddingProvider(embeddings);
+		verifier.setLlmProvider(llm);
+	}
+
+	private static RecordMapping mapping(int index, String text) {
+		return new RecordMapping(index, "obs", "uuid-" + index, new Date(), text);
+	}
+
+	private static RecordReference reference(int index) {
+		return new RecordReference(index, "obs", "uuid-" + index, new Date());
+	}
+
+	// ---- Tier-1 (cosine) ----
+
+	@Test
+	public void verify_marksOnTopicCitationGrounded() {
+		String sentence = "Patient has diabetes [1].";
+		String record = "Type 2 diabetes mellitus";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_A); // identical direction -> cosine 1.0
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, record)), FLOOR, TIER1_ONLY);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded());
+	}
+
+	@Test
+	public void verify_flagsOffTopicCitationUngrounded() {
+		String sentence = "Patient has diabetes [1].";
+		String record = "Blood pressure 120/80 mmHg";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_B); // orthogonal -> cosine 0.0
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, record)), FLOOR, TIER1_ONLY);
+
+		assertEquals(Boolean.FALSE, result.get(0).getGrounded());
+	}
+
+	@Test
+	public void verify_perSentenceCitationIsScoredAgainstItsOwnSentence() {
+		String s1 = "Patient has diabetes [1].";
+		String s2 = "Blood pressure is elevated [2].";
+		String answer = s1 + " " + s2;
+		embeddings.register(s1, AXIS_A);
+		embeddings.register(s2, AXIS_B);
+		embeddings.register("diabetes mellitus", AXIS_A);
+		embeddings.register("BP 150/95", AXIS_B);
+
+		List<RecordReference> result = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2))),
+				Arrays.asList(mapping(1, "diabetes mellitus"), mapping(2, "BP 150/95")),
+				FLOOR, TIER1_ONLY);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded());
+		assertEquals(Boolean.TRUE, result.get(1).getGrounded());
+	}
+
+	@Test
+	public void verify_negativeCosineIsUngroundedNotUnverified() {
+		// A record pointing the opposite way in embedding space (cosine -1) is the
+		// strongest "not grounded" signal — it must be FALSE, never null.
+		String sentence = "Patient has diabetes [1].";
+		String record = "completely unrelated";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, new float[] { -1f, 0f }); // cosine -1.0
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, record)), FLOOR, TIER1_ONLY);
+
+		assertEquals(Boolean.FALSE, result.get(0).getGrounded(),
+				"negative cosine -> ungrounded (FALSE), not unverified (null)");
+	}
+
+	@Test
+	public void verify_splitsClaimsOnNewlines() {
+		// Newline-structured answer with NO terminal punctuation. If the splitter
+		// did not break on newlines, the whole string (unregistered -> zero vector)
+		// would score 0 for both records and both would be FALSE. Splitting per
+		// line isolates each claim so each matches its own record.
+		String answer = "Diabetes [1]\nHypertension [2]";
+		embeddings.register("Diabetes [1]", AXIS_A);
+		embeddings.register("Hypertension [2]", AXIS_B);
+		embeddings.register("diabetes mellitus", AXIS_A);
+		embeddings.register("essential hypertension", AXIS_B);
+
+		List<RecordReference> result = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2))),
+				Arrays.asList(mapping(1, "diabetes mellitus"), mapping(2, "essential hypertension")),
+				FLOOR, TIER1_ONLY);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(), "claim on line 1 matched record 1");
+		assertEquals(Boolean.TRUE, result.get(1).getGrounded(), "claim on line 2 matched record 2");
+	}
+
+	@Test
+	public void verify_recordWithNoTextIsLeftUnverified() {
+		List<RecordReference> result = verifier.verify("Patient has diabetes [1].",
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, null)), FLOOR, TIER1_ONLY);
+
+		assertNull(result.get(0).getGrounded(), "no source text -> cannot verify -> null verdict");
+	}
+
+	@Test
+	public void verify_embeddingFailureDegradesToUnverified() {
+		EmbeddingProvider throwing = new EmbeddingProvider() {
+
+			@Override
+			public float[] embed(String text) {
+				throw new RuntimeException("ONNX session unavailable");
+			}
+
+			@Override
+			public int getDimensions() {
+				return 2;
+			}
+		};
+		verifier.setEmbeddingProvider(throwing);
+
+		List<RecordReference> result = verifier.verify("Patient has diabetes [1].",
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, "diabetes mellitus")), FLOOR, TIER1_ONLY);
+
+		assertNull(result.get(0).getGrounded(), "verifier must never break the search path");
+	}
+
+	@Test
+	public void verify_emptyReferencesReturnedUnchanged() {
+		List<RecordReference> empty = new ArrayList<RecordReference>();
+		assertTrue(verifier.verify("anything", empty,
+				new ArrayList<RecordMapping>(), FLOOR, TIER1_ONLY).isEmpty());
+	}
+
+	// ---- Tier-2 (LLM entailment) ----
+
+	@Test
+	public void tier2_overridesHighCosineFalsePositive() {
+		// The motivating danger case: "patient has cancer [5]" where record 5 is
+		// "grandmother had cancer". Cosine is high (same words) so Tier-1 passes,
+		// but the LLM entailment correctly says NO.
+		String sentence = "Patient has cancer [5].";
+		String record = "Patient reports grandmother had cancer";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_A); // high cosine -> Tier-1 would pass
+		llm.verdict = Boolean.FALSE;
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(5))),
+				Arrays.asList(mapping(5, record)), FLOOR, TIER2_ON);
+
+		assertEquals(Boolean.FALSE, result.get(0).getGrounded(), "entailment must override Tier-1 pass");
+		assertEquals(1, llm.calls);
+	}
+
+	@Test
+	public void tier2_rescuesLowCosineButSupportedClaim() {
+		// True claim phrased very differently from the record -> low cosine
+		// (Tier-1 would flag it), but the LLM confirms support.
+		String sentence = "Glucose control is poor [1].";
+		String record = "HbA1c 11.2 percent";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_B); // orthogonal -> Tier-1 would fail
+		llm.verdict = Boolean.TRUE;
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, record)), FLOOR, TIER2_ON);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(), "entailment must rescue Tier-1 fail");
+	}
+
+	@Test
+	public void tier2_keepsTier1WhenLlmCannotDecide() {
+		String sentence = "Patient has diabetes [1].";
+		String record = "Type 2 diabetes mellitus";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_A); // Tier-1 TRUE
+		llm.verdict = null; // LLM gave an unparseable answer
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, record)), FLOOR, TIER2_ON);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(), "null entailment -> fall back to Tier-1");
+	}
+
+	@Test
+	public void tier2_llmFailureDegradesToTier1() {
+		StubLlmProvider throwing = new StubLlmProvider(null) {
+
+			@Override
+			public Boolean entails(String source, String statement) {
+				throw new RuntimeException("llama-server timed out");
+			}
+		};
+		verifier.setLlmProvider(throwing);
+		String sentence = "Patient has diabetes [1].";
+		String record = "Type 2 diabetes mellitus";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_A); // Tier-1 TRUE
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, record)), FLOOR, TIER2_ON);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(), "entailment failure -> keep Tier-1");
+	}
+
+	@Test
+	public void tier2_disabledMakesNoLlmCalls() {
+		String sentence = "Patient has cancer [5].";
+		String record = "Patient reports grandmother had cancer";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_A);
+		llm.verdict = Boolean.FALSE;
+
+		verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(5))),
+				Arrays.asList(mapping(5, record)), FLOOR, TIER1_ONLY);
+
+		assertEquals(0, llm.calls, "Tier-2 must not call the LLM when disabled");
+	}
+
+	@Test
+	public void tier2_isCappedPerAnswer() {
+		// Build more cited references than the cap. With unregistered embeddings
+		// every Tier-1 verdict is FALSE (cosine 0); the stub entailment returns
+		// TRUE, so references that got a Tier-2 call flip to TRUE while those
+		// beyond the cap keep their Tier-1 FALSE.
+		int cap = ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS;
+		int total = cap + 2;
+		StringBuilder answer = new StringBuilder();
+		List<RecordReference> refs = new ArrayList<RecordReference>();
+		List<RecordMapping> maps = new ArrayList<RecordMapping>();
+		for (int i = 1; i <= total; i++) {
+			answer.append("claim ").append(i).append(" [").append(i).append("]. ");
+			refs.add(reference(i));
+			maps.add(mapping(i, "record " + i));
+		}
+		llm.verdict = Boolean.TRUE;
+
+		List<RecordReference> result = verifier.verify(answer.toString(), refs, maps, FLOOR, TIER2_ON);
+
+		assertEquals(cap, llm.calls, "Tier-2 calls must be capped");
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(), "within cap -> entailment applied");
+		assertEquals(Boolean.FALSE, result.get(total - 1).getGrounded(),
+				"beyond cap -> keeps Tier-1 verdict");
+	}
+
+	// ---- helpers ----
+
+	@Test
+	public void stripCitationMarkers_removesBracketsLeavingTheClaim() {
+		assertEquals("Patient has diabetes .",
+				CitationGroundingVerifier.stripCitationMarkers("Patient has diabetes [1]."));
+		assertEquals("BP is high",
+				CitationGroundingVerifier.stripCitationMarkers("BP is high [2][3]"));
+		assertEquals("no markers here",
+				CitationGroundingVerifier.stripCitationMarkers("no markers here"));
+	}
+
+	@Test
+	public void splitIntoCitedSentences_recordsInlineCitations() {
+		List<CitationGroundingVerifier.Sentence> sentences =
+				CitationGroundingVerifier.splitIntoCitedSentences(
+						"Patient has diabetes [1]. BP is high [2][3].");
+
+		assertEquals(2, sentences.size());
+		assertTrue(sentences.get(0).cites(1));
+		assertTrue(sentences.get(1).cites(2));
+		assertTrue(sentences.get(1).cites(3));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderEntailmentTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderEntailmentTest.java
@@ -1,0 +1,125 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the Tier-2 grounding entailment helpers on {@link LlmProvider}
+ * ({@link LlmProvider#parseYesNo} and the input guards of
+ * {@link LlmProvider#entails}). Kept in a dedicated class so this slice's
+ * coverage is independent of the main {@code LlmProviderTest}. The engine-backed
+ * path of {@code entails} is exercised via the stub provider in
+ * {@code CitationGroundingVerifierTest}; here we cover the no-engine guards and
+ * the response parser, which need no OpenMRS context.
+ */
+public class LlmProviderEntailmentTest {
+
+	@Test
+	public void parseYesNo_shouldParsePlainYesAndNo() {
+		assertEquals(Boolean.TRUE, LlmProvider.parseYesNo("YES"));
+		assertEquals(Boolean.FALSE, LlmProvider.parseYesNo("NO"));
+	}
+
+	@Test
+	public void parseYesNo_shouldBeCaseAndWhitespaceAndPunctuationTolerant() {
+		assertEquals(Boolean.TRUE, LlmProvider.parseYesNo("  yes.\n"));
+		assertEquals(Boolean.FALSE, LlmProvider.parseYesNo("No, the source does not support it."));
+	}
+
+	@Test
+	public void parseYesNo_shouldReturnNullWhenNeitherTokenPresent() {
+		assertNull(LlmProvider.parseYesNo("I am not sure"));
+		assertNull(LlmProvider.parseYesNo(""));
+		assertNull(LlmProvider.parseYesNo(null));
+	}
+
+	@Test
+	public void parseYesNo_shouldNotMatchTokenInsideALongerWord() {
+		// "NOTHING"/"YESTERDAY" begin with the tokens but are not standalone words;
+		// the word-boundary anchor must reject them.
+		assertNull(LlmProvider.parseYesNo("NOTHING is stated"));
+		assertNull(LlmProvider.parseYesNo("YESTERDAY's note"));
+	}
+
+	@Test
+	public void entailmentSystemPrompt_shouldDirectVerdictToTheAnswerField() {
+		// The shared response schema forces {reasoning, answer, citations}. The entailment prompt
+		// must put the YES/NO verdict in the "answer" field (where parseEntailmentVerdict reads it)
+		// and must NOT demand a bare one-word reply — that would contradict the enforced schema.
+		String p = LlmProvider.ENTAILMENT_SYSTEM_PROMPT;
+		assertTrue(p.contains("\"answer\""),
+				"entailment prompt must direct the verdict into the answer field, matching the schema");
+		assertTrue(p.contains("YES") && p.contains("NO"), "must still ask for a YES/NO verdict");
+		assertFalse(p.contains("exactly one word"),
+				"must not demand a bare one-word reply — the schema forces reasoning-first JSON");
+	}
+
+	@Test
+	public void parseEntailmentVerdict_shouldReadVerdictFromAnswerNotReasoning() {
+		// Regression for the reasoning-first response schema: "reasoning" is emitted before
+		// "answer" and a fact-checker's reasoning routinely contains "no" ("no explicit
+		// wording…"). Scanning the raw reply (what the old entails did via parseYesNo) grabs that
+		// leading "no" and flips the verdict. parseEntailmentVerdict must read the answer field.
+		String yesDespiteNoInReasoning = "{\"reasoning\": \"There is no explicit wording, but the "
+				+ "source does state the finding, so it supports the statement.\", "
+				+ "\"answer\": \"YES\", \"citations\": []}";
+		// Pre-fix behaviour (parseYesNo on the raw reply) would have returned FALSE here:
+		assertEquals(Boolean.FALSE, LlmProvider.parseYesNo(yesDespiteNoInReasoning),
+				"guards the regression: raw-text parsing reads the verdict out of the reasoning");
+		// The fix reads the structured answer field, recovering the true verdict:
+		assertEquals(Boolean.TRUE, LlmProvider.parseEntailmentVerdict(yesDespiteNoInReasoning));
+
+		String noDespiteYesInReasoning = "{\"reasoning\": \"At first glance one might say yes, but "
+				+ "the source is about a different body part.\", \"answer\": \"NO\", \"citations\": []}";
+		assertEquals(Boolean.FALSE, LlmProvider.parseEntailmentVerdict(noDespiteYesInReasoning));
+	}
+
+	@Test
+	public void parseEntailmentVerdict_shouldDegradeSafely() {
+		// A bare, envelope-free reply still parses (stubs / non-JSON paths), and null stays null.
+		assertEquals(Boolean.TRUE, LlmProvider.parseEntailmentVerdict("YES"));
+		assertEquals(Boolean.FALSE, LlmProvider.parseEntailmentVerdict("NO"));
+		assertNull(LlmProvider.parseEntailmentVerdict(null));
+	}
+
+	@Test
+	public void parseEntailmentVerdict_shouldReturnNullWhenAnswerHasBothVerdictWords() {
+		// A verbose, non-compliant answer field containing BOTH verdict words must
+		// not be parsed positionally (which would silently flip the verdict) — it is
+		// undecidable, so grounding falls back to its Tier-1 verdict.
+		String bothWords = "{\"reasoning\": \"weighing it up\", "
+				+ "\"answer\": \"Yes, but there is no explicit confirmation\", \"citations\": []}";
+		assertNull(LlmProvider.parseEntailmentVerdict(bothWords),
+				"both YES and NO present in answer -> undecidable -> null");
+
+		// A single verdict word with surrounding prose is still unambiguous.
+		String onlyYes = "{\"reasoning\": \"r\", \"answer\": \"Yes, the source supports it\", "
+				+ "\"citations\": []}";
+		assertEquals(Boolean.TRUE, LlmProvider.parseEntailmentVerdict(onlyYes));
+	}
+
+	@Test
+	public void entails_shouldReturnNullForBlankInputsWithoutCallingEngine() {
+		// These guards short-circuit before any engine call, so they are safe to
+		// exercise without an OpenMRS context. If they did not short-circuit, the
+		// missing engine/context would throw instead of returning null.
+		LlmProvider provider = new LlmProvider();
+		assertNull(provider.entails(null, "claim"));
+		assertNull(provider.entails("source", null));
+		assertNull(provider.entails("   ", "claim"));
+		assertNull(provider.entails("source", "   "));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializerTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializerTest.java
@@ -1,0 +1,49 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.serializer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+import org.openmrs.module.chartsearchai.serializer.PatientRecordLoader.SerializedRecord;
+
+/**
+ * Pure unit tests for {@link PatientChartSerializer}. Patient is passed as
+ * {@code null} (demographics are simply skipped) so the serializer runs without
+ * an OpenMRS context or a wired record loader.
+ */
+public class PatientChartSerializerTest {
+
+	@Test
+	public void serialize_shouldCarryEachRecordsTextIntoItsMapping() {
+		// Pins the prerequisite the citation grounding verifier depends on: the
+		// RecordMapping must carry the source text so the verifier can check that
+		// a cited record actually supports the answer. If a future edit drops the
+		// text argument, grounding silently degrades to "cannot verify" for every
+		// citation and no other test would catch it.
+		SerializedRecord r1 = new SerializedRecord("obs", "uuid-1", "Temperature: 36.7", new Date());
+		SerializedRecord r2 = new SerializedRecord("condition", "uuid-2", "Type 2 diabetes mellitus", new Date());
+
+		PatientChart chart = new PatientChartSerializer().serialize(null, Arrays.asList(r1, r2));
+
+		List<RecordMapping> mappings = chart.getMappings();
+		assertEquals(2, mappings.size());
+		assertEquals(1, mappings.get(0).getIndex());
+		assertEquals("Temperature: 36.7", mappings.get(0).getText());
+		assertEquals(2, mappings.get(1).getIndex());
+		assertEquals("Type 2 diabetes mellitus", mappings.get(1).getText());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializerTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/serializer/PatientChartSerializerTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.chartsearchai.serializer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
 import org.openmrs.module.chartsearchai.serializer.PatientRecordLoader.SerializedRecord;
+import org.openmrs.module.chartsearchai.util.DateFormatUtil;
 
 /**
  * Pure unit tests for {@link PatientChartSerializer}. Patient is passed as
@@ -28,22 +30,28 @@ import org.openmrs.module.chartsearchai.serializer.PatientRecordLoader.Serialize
 public class PatientChartSerializerTest {
 
 	@Test
-	public void serialize_shouldCarryEachRecordsTextIntoItsMapping() {
-		// Pins the prerequisite the citation grounding verifier depends on: the
-		// RecordMapping must carry the source text so the verifier can check that
-		// a cited record actually supports the answer. If a future edit drops the
-		// text argument, grounding silently degrades to "cannot verify" for every
-		// citation and no other test would catch it.
-		SerializedRecord r1 = new SerializedRecord("obs", "uuid-1", "Temperature: 36.7", new Date());
-		SerializedRecord r2 = new SerializedRecord("condition", "uuid-2", "Type 2 diabetes mellitus", new Date());
+	public void serialize_mappingTextMatchesWhatTheLlmSaw() {
+		// Pins the contract the citation grounding verifier depends on: the RecordMapping
+		// must carry the SAME per-record content the LLM saw in the chart line (date
+		// parenthetical + body), not the bare record body. Otherwise Tier-2 entailment
+		// flags an otherwise-valid citation as unsupported when the model cites the date
+		// (the date lives in the prefix, not in record.getText()). If a future edit drops
+		// the rendered text, grounding silently degrades and no other test would catch it.
+		Date d = new Date(1700000000000L); // fixed instant for determinism
+		String datePrefix = "(" + DateFormatUtil.formatDate(d) + ") ";
+		SerializedRecord dated = new SerializedRecord("obs", "uuid-1", "Temperature: 36.7", d);
+		SerializedRecord undated = new SerializedRecord("condition", "uuid-2", "Type 2 diabetes mellitus", null);
 
-		PatientChart chart = new PatientChartSerializer().serialize(null, Arrays.asList(r1, r2));
-
+		PatientChart chart = new PatientChartSerializer().serialize(null, Arrays.asList(dated, undated));
 		List<RecordMapping> mappings = chart.getMappings();
+
 		assertEquals(2, mappings.size());
-		assertEquals(1, mappings.get(0).getIndex());
-		assertEquals("Temperature: 36.7", mappings.get(0).getText());
-		assertEquals(2, mappings.get(1).getIndex());
+		// Dated record: mapping text includes the date prefix the model can cite.
+		assertEquals(datePrefix + "Temperature: 36.7", mappings.get(0).getText());
+		// Undated record: just the body, no parenthetical.
 		assertEquals("Type 2 diabetes mellitus", mappings.get(1).getText());
+		// And the mapping text is exactly the chart line content after the "[N] " prefix.
+		assertTrue(chart.getText().contains("[1] " + datePrefix + "Temperature: 36.7"),
+				"chart line should equal '[N] ' + the mapping text; chart was:\n" + chart.getText());
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -220,6 +220,9 @@ public class ChartSearchAiRestController {
 			refMap.put("resourceType", ref.getResourceType());
 			refMap.put("resourceUuid", ref.getResourceUuid());
 			refMap.put("date", formatDate(ref.getDate()));
+			// null when grounding is disabled or could not run — clients must
+			// render null as "unverified", never as "verified".
+			refMap.put("grounded", ref.getGrounded());
 			refs.add(refMap);
 		}
 		response.put("references", refs);
@@ -402,6 +405,9 @@ public class ChartSearchAiRestController {
 				refMap.put("resourceType", ref.getResourceType());
 				refMap.put("resourceUuid", ref.getResourceUuid());
 				refMap.put("date", formatDate(ref.getDate()));
+				// null when grounding is disabled or could not run — clients must
+				// render null as "unverified", never as "verified".
+				refMap.put("grounded", ref.getGrounded());
 				refs.add(refMap);
 			}
 			doneData.put("references", refs);


### PR DESCRIPTION
## What

Adds **citation grounding verification**: after the LLM answers a chart-search query and cites records, this checks that each cited record actually *supports* the answer sentence citing it — rather than trusting the LLM's citations blindly. Today the system only validates that a `[N]` marker maps to a real retrieved record; it cannot catch a real record cited for a claim it does not support (e.g. "patient has cancer [5]" where record 5 says a *relative* had cancer).

Both layers are **opt-in and default-off**, so behavior is unchanged unless an admin enables them.

## How

Two tiers, gated by global properties:

- **Tier-1 — semantic overlap** (`chartsearchai.grounding.enabled`): embeds each cited record and the answer sentence(s) that cite it and requires cosine similarity to clear a tunable floor (`chartsearchai.grounding.minCosine`, default `0.40`). Reuses the existing `EmbeddingProvider` + `cosineSimilarity` — no new model, no network.
- **Tier-2 — entailment** (`chartsearchai.grounding.entailment.enabled`): a short yes/no LLM fact-check whose verdict is authoritative, catching subject/polarity flips ("patient has X" vs "mother had X") that cosine cannot. Capped at 16 calls per answer.

The verdict is **annotate-only** (never rewrites prose or drops citations): each `RecordReference` carries a `grounded` value (`true`/`false`/`null`=unverified), surfaced on the REST response and SSE `done` event. `null` must render as "unverified", never "verified".

Reconciled with the reasoning-first response schema: the entailment verdict is read from the structured `answer` field (not the raw reply, whose reasoning routinely contains "no"), and a verbose answer containing **both** YES and NO is treated as undecidable so grounding falls back to Tier-1 rather than guessing.

## Safety / degradation

- Disabled, or any verifier failure (missing text, embedding/LLM error), degrades to a `null` verdict — today's exact behavior. The verifier never throws into the search path.
- GP readers fail safe to defaults when no admin service is available.
- Router cache key now includes the grounding GPs, so toggling grounding busts the cache instead of serving stale verdicts.

## Tests

`CitationGroundingVerifierTest` (Tier-1 on/off-topic, per-sentence, negative-cosine, newline split, Tier-2 override/rescue/cap/degrade), `LlmProviderEntailmentTest` (verdict parsing incl. both-words guard), `PatientChartSerializerTest` (record text reaches the mapping), and `ChartSearchServiceRouterTest` (cache-key segments). All green; `api` and `omod` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)