### PR TITLE
Register the grounding global properties in config.xml

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -215,6 +215,24 @@
 		<description>Relative path, including the filename, within the OpenMRS application data directory to the WordPiece vocabulary file (vocab.txt) for the ONNX embedding model. Required when embedding pre-filtering is enabled (chartsearchai.embedding.preFilter is true (non-default)). Example: chartsearchai/vocab.txt (resolves to &lt;application-data-directory&gt;/chartsearchai/vocab.txt). Download vocab.txt from the same model repository as the ONNX model (e.g. https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2). Path traversal (e.g. "..") is not allowed.</description>
 	</globalProperty>
 
+	<globalProperty>
+		<property>chartsearchai.grounding.enabled</property>
+		<defaultValue>false</defaultValue>
+		<description>When true, every cited record is checked for grounding after the LLM answers: the record's text must be semantically close enough to the answer sentence(s) that cite it, otherwise the citation is flagged as unverified. Index validation alone (does [N] map to a real retrieved record?) cannot catch the dangerous case of a real record cited for a claim it does not actually support. Default: false (opt-in).</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.grounding.minCosine</property>
+		<defaultValue>0.40</defaultValue>
+		<description>Minimum cosine similarity between a cited record's text and the answer sentence that cites it for the citation to count as grounded. This Tier-1 check catches grossly off-topic citations (a blood-pressure record cited for a diabetes claim), not subtle subject/negation flips ("patient has X" vs "mother had X") — those need the Tier-2 entailment pass. The right floor depends on the embedding model: 0.40 suits a wide-spread model like all-MiniLM-L6-v2, but is far too low for e5 (the model querystore uses, which the verifier reuses when chartsearchai.querystore.enabled=true) — set it to ~0.82 on an e5/querystore deployment. Must be between 0 and 1. Default: 0.40.</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.grounding.entailment.enabled</property>
+		<defaultValue>false</defaultValue>
+		<description>When true (and chartsearchai.grounding.enabled is also on), the Tier-1 cosine verdict is confirmed by a Tier-2 entailment check: a short yes/no LLM call asking whether the cited record actually supports the answer sentence. This catches high-overlap-but-false citations ("patient has X [5]" where record 5 says a relative had X, or the record negates X) that cosine similarity cannot separate. Costs one extra LLM call per cited reference (capped per answer), so it is a separate opt-in from the cheap Tier-1 pass. Default: false.</description>
+	</globalProperty>
+
 	<!-- AOP -->
 	<advice>
 		<point>org.openmrs.api.EncounterService</point>

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/ConfigXmlGroundingPropertiesTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/ConfigXmlGroundingPropertiesTest.java
@@ -1,0 +1,107 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Pins the contract that the grounding feature's three global properties are
+ * registered in the module's {@code config.xml} AND that their declared
+ * {@code defaultValue}s stay in sync with the code-side defaults in
+ * {@link ChartSearchAiConstants}.
+ *
+ * <p>This matters because a registered global property's stored row wins over
+ * the code default at runtime: once OpenMRS seeds the row from config.xml, the
+ * production readers in {@code ChartSearchAiUtils} return that row's value, not
+ * the constant. The {@code minCosine} Javadoc states the floor must be retuned
+ * per embedding model, so the constant is a likely future edit — if it changes
+ * without config.xml following, every installed deployment silently keeps the
+ * old floor (no exception, just wrong grounding), which this test prevents.
+ */
+public class ConfigXmlGroundingPropertiesTest {
+
+	private static Map<String, String> defaultsByProperty;
+
+	@BeforeAll
+	public static void parseConfigXml() throws Exception {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		// config.xml carries no DOCTYPE; harden against any external entity fetch.
+		factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		DocumentBuilder builder = factory.newDocumentBuilder();
+
+		defaultsByProperty = new HashMap<>();
+		try (InputStream in = ConfigXmlGroundingPropertiesTest.class.getResourceAsStream("/config.xml")) {
+			assertNotNull(in, "config.xml must be on the classpath (built into the module)");
+			NodeList gps = builder.parse(in).getElementsByTagName("globalProperty");
+			for (int i = 0; i < gps.getLength(); i++) {
+				Element gp = (Element) gps.item(i);
+				String property = textOfChild(gp, "property");
+				String defaultValue = textOfChild(gp, "defaultValue");
+				if (property != null) {
+					defaultsByProperty.put(property, defaultValue);
+				}
+			}
+		}
+	}
+
+	private static String textOfChild(Element parent, String tag) {
+		NodeList children = parent.getElementsByTagName(tag);
+		if (children.getLength() == 0) {
+			return null;
+		}
+		Node node = children.item(0);
+		String text = node.getTextContent();
+		return text == null ? "" : text.trim();
+	}
+
+	@Test
+	public void configXml_registersGroundingEnabledWithMatchingDefault() {
+		assertTrue(defaultsByProperty.containsKey(ChartSearchAiConstants.GP_GROUNDING_ENABLED),
+				ChartSearchAiConstants.GP_GROUNDING_ENABLED + " must be registered in config.xml");
+		assertEquals(String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_ENABLED),
+				defaultsByProperty.get(ChartSearchAiConstants.GP_GROUNDING_ENABLED),
+				"config.xml defaultValue must match DEFAULT_GROUNDING_ENABLED");
+	}
+
+	@Test
+	public void configXml_registersGroundingEntailmentEnabledWithMatchingDefault() {
+		assertTrue(defaultsByProperty.containsKey(ChartSearchAiConstants.GP_GROUNDING_ENTAILMENT_ENABLED),
+				ChartSearchAiConstants.GP_GROUNDING_ENTAILMENT_ENABLED + " must be registered in config.xml");
+		assertEquals(String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_ENTAILMENT_ENABLED),
+				defaultsByProperty.get(ChartSearchAiConstants.GP_GROUNDING_ENTAILMENT_ENABLED),
+				"config.xml defaultValue must match DEFAULT_GROUNDING_ENTAILMENT_ENABLED");
+	}
+
+	@Test
+	public void configXml_registersGroundingMinCosineWithMatchingDefault() {
+		assertTrue(defaultsByProperty.containsKey(ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE),
+				ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE + " must be registered in config.xml");
+		String declared = defaultsByProperty.get(ChartSearchAiConstants.GP_GROUNDING_MIN_COSINE);
+		assertNotNull(declared, "minCosine defaultValue must be present");
+		// Parse exactly as production does (ChartSearchAiUtils.getGroundingMinCosine).
+		assertEquals(ChartSearchAiConstants.DEFAULT_GROUNDING_MIN_COSINE, Double.parseDouble(declared), 1e-9,
+				"config.xml defaultValue must match DEFAULT_GROUNDING_MIN_COSINE");
+	}
+}


### PR DESCRIPTION
The citation-grounding feature (#34) reads three global properties — chartsearchai.grounding.enabled, .minCosine, and .entailment.enabled — but they were never declared in the module's config.xml, so they did not appear in Admin > Settings and were never seeded into global_property.

Register all three with defaultValues that mirror the ChartSearchAiConstants defaults (false / 0.40 / false), and pin that mirror with a unit test that parses the packaged config.xml and asserts each declared defaultValue equals its code constant (minCosine via the same Double.parseDouble production uses). This guards the silent-drift case the minCosine Javadoc invites: retuning the constant per embedding model without updating config.xml would otherwise leave every installed deployment on the stale, registered floor.