### PR TITLE
Batch citation-grounding into one LLM call; stream citations before grounding

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -338,10 +338,11 @@ public class ChartSearchAiConstants {
 	public static final boolean DEFAULT_GROUNDING_ENTAILMENT_ENABLED = false;
 
 	/**
-	 * Upper bound on Tier-2 entailment LLM calls per answer, so a heavily-cited
-	 * answer cannot trigger an unbounded number of round-trips. References
-	 * beyond this many keep their Tier-1 verdict; the verifier logs once when
-	 * the cap is hit (no silent truncation).
+	 * Upper bound on the number of citations Tier-2 entailment verifies per answer (i.e. the batch
+	 * size), so a heavily-cited answer cannot make the single batched entailment prompt grow without
+	 * bound. References beyond this many keep their Tier-1 verdict; the verifier logs once when the
+	 * cap is hit (no silent truncation). Tier-2 issues one batched LLM call per answer regardless of
+	 * how many citations it carries.
 	 */
 	public static final int GROUNDING_ENTAILMENT_MAX_CHECKS = 16;
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -62,6 +62,24 @@ public interface ChartSearchService {
 	}
 
 	/**
+	 * Streaming variant that additionally forwards the answer's citations to {@code citationsConsumer}
+	 * the moment the answer is generated — <em>before</em> the citation-grounding pass — so a caller
+	 * can render the answer and its clickable citations immediately and let grounding verdicts arrive
+	 * afterwards. Grounding (Tier-2 entailment) can add a tail of LLM work; this keeps it off the
+	 * path to a readable, cited answer. The returned {@link ChartAnswer} still carries the fully
+	 * grounded references. The default ignores {@code citationsConsumer} and delegates to the four-arg
+	 * variant, so existing implementations and callers are unaffected.
+	 *
+	 * @param citationsConsumer called once with the answer's references <em>before</em> grounding
+	 *        (verdicts not yet attached); the returned answer carries the grounded references
+	 * @return the complete answer with grounded source references
+	 */
+	default ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer,
+			Consumer<String> reasoningConsumer, Consumer<List<RecordReference>> citationsConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer);
+	}
+
+	/**
 	 * Pre-warm any patient-specific caches (serialized chart, LLM prompt cache) so the
 	 * first real query on this patient does not pay cold-start cost. Implementations
 	 * that don't support warmup may return immediately. Callers should treat this as

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
@@ -11,6 +11,7 @@ package org.openmrs.module.chartsearchai.api.impl;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -81,6 +82,13 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 	@Override
 	public ChartAnswer searchStreaming(Patient patient, String question,
 			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, refs -> { });
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+			Consumer<List<RecordReference>> citationsConsumer) {
 		int ttlMinutes = getCacheTtlMinutes();
 
 		if (ttlMinutes > 0) {
@@ -89,18 +97,22 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 			if (cached != null) {
 				log.debug("Cache hit for patient [id={}] (streaming)", patient.getPatientId());
 				// Cache hit: the answer is returned instantly with no LLM call, so there is no
-				// live reasoning to stream — only replay the cached answer.
+				// live reasoning to stream — only replay the cached answer. Its references are
+				// already grounded, so also surface them on the citations channel for protocol
+				// parity with the live path.
 				tokenConsumer.accept(cached.getAnswer());
+				citationsConsumer.accept(cached.getReferences());
 				return cached;
 			}
 
 			ChartAnswer answer = llmService.searchStreaming(patient, question, tokenConsumer,
-					reasoningConsumer);
+					reasoningConsumer, citationsConsumer);
 			putCache(cacheKey, answer);
 			return answer;
 		}
 
-		return llmService.searchStreaming(patient, question, tokenConsumer, reasoningConsumer);
+		return llmService.searchStreaming(patient, question, tokenConsumer, reasoningConsumer,
+				citationsConsumer);
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
@@ -48,14 +48,14 @@ import org.springframework.stereotype.Service;
  * "has X") — those embed nearly identically.
  *
  * <p><strong>Tier-2 (optional).</strong> When
- * {@code chartsearchai.grounding.entailment.enabled} is set, each reference
- * Tier-1 could evaluate is confirmed by a short yes/no LLM entailment call
- * ({@link LlmProvider#entails}) whose verdict is authoritative. This is what
+ * {@code chartsearchai.grounding.entailment.enabled} is set, the cited references are
+ * confirmed by a yes/no LLM entailment verdict that is authoritative. This is what
  * catches the subject/polarity flips cosine cannot. It runs on Tier-1 passes
  * <em>and</em> failures — the dangerous case (a high-overlap but unsupported
- * citation) is a Tier-1 pass, so confirming only failures would miss it — and
- * costs one LLM call per cited reference, capped at
- * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} per answer.
+ * citation) is a Tier-1 pass, so confirming only failures would miss it. All of an answer's
+ * cited references are verified in a SINGLE batched call ({@link LlmProvider#entailsBatch}),
+ * capped at {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer;
+ * references beyond the cap keep their Tier-1 verdict.
  *
  * <p>The verifier never throws into the search path: any failure (embedding
  * error, missing text) degrades to a {@code null} verdict — "could not verify"
@@ -174,12 +174,13 @@ public class CitationGroundingVerifier {
 	 * tests can exercise the grounding logic without an OpenMRS context.
 	 *
 	 * <p>When {@code entailmentEnabled}, every reference Tier-1 could evaluate is
-	 * confirmed by a Tier-2 LLM entailment call whose verdict is authoritative
+	 * confirmed by a Tier-2 LLM entailment verdict that is authoritative
 	 * (cosine errs in both directions, and the dangerous error — a high-overlap
 	 * but unsupported citation — is exactly the case Tier-1 cannot self-detect,
-	 * so the LLM must see Tier-1 passes too, not only failures). Tier-2 is
-	 * capped at {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS}
-	 * calls per answer; references beyond the cap keep their Tier-1 verdict.
+	 * so the LLM must see Tier-1 passes too, not only failures). All of them are checked in
+	 * ONE batched call ({@link LlmProvider#entailsBatch}), capped at
+	 * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer;
+	 * references beyond the cap keep their Tier-1 verdict.
 	 */
 	List<RecordReference> verify(String answer, List<RecordReference> references,
 			List<RecordMapping> mappings, double floor, boolean entailmentEnabled) {
@@ -203,31 +204,61 @@ public class CitationGroundingVerifier {
 		Map<Integer, float[]> sentenceVectors = new HashMap<Integer, float[]>();
 		GroundingStats stats = new GroundingStats();
 
+		// Pass 1: Tier-1 (cosine) for every reference, collecting the claim/record pairs Tier-2
+		// should confirm — up to the per-answer cap. Tier-2 runs on Tier-1 passes AND failures:
+		// the dangerous case (high cosine but unsupported, e.g. a family-history flip) is a Tier-1
+		// pass, so confirming only failures would miss it.
 		int entailmentBudget = ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS;
 		int cappedCount = 0;
-
-		List<RecordReference> annotated = new ArrayList<RecordReference>(references.size());
-		for (RecordReference reference : references) {
+		Tier1Result[] tier1Results = new Tier1Result[references.size()];
+		List<Integer> tier2Positions = new ArrayList<Integer>();
+		List<String> batchSources = new ArrayList<String>();
+		List<String> batchStatements = new ArrayList<String>();
+		for (int i = 0; i < references.size(); i++) {
+			RecordReference reference = references.get(i);
 			Tier1Result tier1 = verdictTier1(reference.getIndex(), textByIndex, sentences,
 					floor, recordVectors, sentenceVectors, embedder, stats);
-			Boolean verdict = tier1.verdict;
-
-			// Tier-2: only meaningful when Tier-1 reached a definite verdict and
-			// we have a concrete claim sentence to fact-check against the record.
+			tier1Results[i] = tier1;
+			// Tier-2 candidate: only meaningful when Tier-1 reached a definite verdict and we have
+			// a concrete claim sentence to fact-check against the record.
 			if (entailmentEnabled && tier1.verdict != null && tier1.bestSentence != null
 					&& tier1.recordText != null) {
 				if (entailmentBudget > 0) {
 					entailmentBudget--;
-					Boolean llmVerdict = safeEntails(tier1.recordText, tier1.bestSentence,
-							reference.getIndex());
-					if (llmVerdict != null) {
-						verdict = llmVerdict; // authoritative; null -> keep Tier-1
-					}
+					tier2Positions.add(i);
+					batchSources.add(tier1.recordText);
+					batchStatements.add(stripCitationMarkers(tier1.bestSentence));
 				} else {
 					cappedCount++;
 				}
 			}
-			annotated.add(reference.withGrounded(verdict));
+		}
+
+		// One batched entailment call confirms every collected citation at once — replacing one
+		// serial LLM call per citation (the single-slot engine ran them strictly in sequence, the
+		// dominant grounding latency). A null result (whole-batch failure) or a short result leaves
+		// the affected verdicts null, i.e. the Tier-1 verdict stands.
+		List<Boolean> batchVerdicts = batchSources.isEmpty()
+				? java.util.Collections.<Boolean> emptyList()
+				: safeEntailsBatch(batchSources, batchStatements);
+		// Tier-2 verdict per reference position (parallel to tier1Results). A null entry means
+		// either "not a Tier-2 candidate" or "Tier-2 could not verify" — Pass 2 treats both the
+		// same (keep the Tier-1 verdict), so they collapse to one null with no information lost.
+		Boolean[] tier2Verdict = new Boolean[references.size()];
+		for (int k = 0; k < tier2Positions.size(); k++) {
+			tier2Verdict[tier2Positions.get(k)] = (batchVerdicts != null && k < batchVerdicts.size())
+					? batchVerdicts.get(k) : null;
+		}
+
+		// Pass 2: assemble — Tier-2 is authoritative when it reached a verdict, else keep Tier-1.
+		List<RecordReference> annotated = new ArrayList<RecordReference>(references.size());
+		for (int i = 0; i < references.size(); i++) {
+			Boolean verdict = tier1Results[i].verdict;
+			Boolean llmVerdict = tier2Verdict[i];
+			if (llmVerdict != null) {
+				verdict = llmVerdict; // authoritative; null (no Tier-2 or unverifiable) -> keep Tier-1
+			}
+			annotated.add(references.get(i).withGrounded(verdict));
 		}
 		if (cappedCount > 0) {
 			log.info("Tier-2 entailment cap ({}) reached; {} citation(s) kept their Tier-1 verdict only",
@@ -308,13 +339,19 @@ public class CitationGroundingVerifier {
 		}
 	}
 
-	/** Wraps the Tier-2 LLM call so a failure degrades to "could not verify" (null). */
-	private Boolean safeEntails(String recordText, String claim, int index) {
+	/**
+	 * Wraps the batched Tier-2 call so a failure degrades to all-"could not verify" ({@code null}),
+	 * leaving every affected citation on its Tier-1 verdict — the verifier never breaks the search
+	 * path. Returns {@code null} (not an empty list) on failure so the caller can tell "batch failed"
+	 * from "batch ran and returned verdicts".
+	 */
+	private List<Boolean> safeEntailsBatch(List<String> sources, List<String> statements) {
 		try {
-			return llmProvider.entails(recordText, stripCitationMarkers(claim));
+			return llmProvider.entailsBatch(sources, statements);
 		}
 		catch (RuntimeException e) {
-			log.warn("Tier-2 entailment check failed for citation [{}]; keeping Tier-1 verdict", index, e);
+			log.warn("Tier-2 batch entailment failed for {} citation(s); keeping Tier-1 verdicts",
+					sources.size(), e);
 			return null;
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/EntailmentBatchResponseFormat.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/EntailmentBatchResponseFormat.java
@@ -1,0 +1,77 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Strict verdict-only response schema for <em>batch</em> citation grounding: a single
+ * {@code "verdicts"} array of exactly {@code count} {@code enum("YES","NO")} items — one per
+ * (record, claim) pair, in order.
+ *
+ * <p>Unlike {@link ChartAnswerResponseFormat}, this schema deliberately has <strong>no</strong>
+ * leading {@code reasoning} field. The chart-answer schema forces the model to emit reasoning
+ * before any value; for a one-word entailment verdict that reasoning <em>is</em> the entire cost.
+ * Direct measurement against the local llama-server (Gemma E2B): a single per-call verdict took
+ * ~1.7&nbsp;s (decode-bound on ~60–95 reasoning tokens), so verifying an answer's citations one at
+ * a time cost up to ~34&nbsp;s. Verifying all of them in ONE verdict-only call cost ~1.7–3.3&nbsp;s
+ * (≈10× faster) with no loss of accuracy — verdict agreement with the per-call path was 19/20, and
+ * the single disagreement was the batch being correct where the reasoning-laden single call had
+ * reasoned itself into the wrong answer. The {@code enum} plus {@code minItems == maxItems ==
+ * count} constraints guarantee a parseable, correctly-sized array so verdicts align to pairs by
+ * position.
+ */
+final class EntailmentBatchResponseFormat {
+
+	private EntailmentBatchResponseFormat() {
+	}
+
+	static ObjectNode build(ObjectMapper mapper, int count) {
+		ArrayNode enumValues = mapper.createArrayNode();
+		enumValues.add("YES");
+		enumValues.add("NO");
+
+		ObjectNode verdictItem = mapper.createObjectNode();
+		verdictItem.put("type", "string");
+		verdictItem.set("enum", enumValues);
+
+		ObjectNode verdictsProp = mapper.createObjectNode();
+		verdictsProp.put("type", "array");
+		verdictsProp.set("items", verdictItem);
+		// Exactly one verdict per pair: the grammar emits a fixed-length array, so verdicts
+		// align to the numbered pairs by position and a short/over-long reply is impossible.
+		verdictsProp.put("minItems", count);
+		verdictsProp.put("maxItems", count);
+
+		ObjectNode properties = mapper.createObjectNode();
+		properties.set("verdicts", verdictsProp);
+
+		ArrayNode required = mapper.createArrayNode();
+		required.add("verdicts");
+
+		ObjectNode schema = mapper.createObjectNode();
+		schema.put("type", "object");
+		schema.set("properties", properties);
+		schema.set("required", required);
+		schema.put("additionalProperties", false);
+
+		ObjectNode jsonSchema = mapper.createObjectNode();
+		jsonSchema.put("name", "entailment_verdicts");
+		jsonSchema.put("strict", true);
+		jsonSchema.set("schema", schema);
+
+		ObjectNode responseFormat = mapper.createObjectNode();
+		responseFormat.put("type", "json_schema");
+		responseFormat.set("json_schema", jsonSchema);
+		return responseFormat;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmEngine.java
@@ -11,6 +11,8 @@ package org.openmrs.module.chartsearchai.api.impl;
 
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 /**
  * Abstraction for LLM inference engines. Implementations handle the actual
  * model invocation (local or remote) while prompt construction and response
@@ -27,6 +29,24 @@ public interface LlmEngine {
 	 * @return the inference result containing generated text and input/output token counts
 	 */
 	InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds);
+
+	/**
+	 * Run inference constraining the output to a caller-supplied JSON-schema {@code response_format}
+	 * instead of the default chart-answer schema. Used by batch citation grounding to apply a
+	 * verdict-only schema (see {@link EntailmentBatchResponseFormat}) that omits the per-call
+	 * reasoning the chart-answer schema would force.
+	 *
+	 * <p>The default ignores {@code responseFormat} and falls back to {@link #infer(String, String,
+	 * int)}: an engine that has not opted in simply uses its normal schema, and grounding then reads
+	 * a different envelope and degrades each verdict to "could not verify" (Tier-1 fallback) — never
+	 * a crash. {@link LocalLlmEngine} and {@link RemoteLlmEngine} override it.
+	 *
+	 * @param responseFormat an OpenAI-style {@code response_format} node, or {@code null} for the default
+	 */
+	default InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds,
+			ObjectNode responseFormat) {
+		return infer(systemPrompt, userMessage, timeoutSeconds);
+	}
 
 	/**
 	 * Run inference with streaming, calling the consumer for each token fragment.

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -232,13 +232,21 @@ public class LlmInferenceService implements ChartSearchService {
 	@Override
 	public ChartAnswer searchStreaming(Patient patient, String question,
 			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, refs -> { });
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+			Consumer<List<RecordReference>> citationsConsumer) {
 		// LOG FORMAT — stable contract: same field set as search() with op=searchStreaming
-		// in the log tag. Streaming is the path the frontend actually uses by default, so
-		// this is what demo operators see in their logs. try/finally so exceptions still
-		// emit a timing line — see search() for the exception-safety rationale.
+		// in the log tag, plus groundMs (Tier-2 grounding is now timed separately so the tail is
+		// visible). Streaming is the path the frontend actually uses by default, so this is what
+		// demo operators see in their logs. try/finally so exceptions still emit a timing line.
 		long buildStart = System.currentTimeMillis();
 		long buildMs = 0;
 		long llmMs = 0;
+		long groundMs = 0;
 		long inputTokens = 0;
 		long cachedTokens = 0;
 		String outcome = "error";
@@ -254,10 +262,19 @@ public class LlmInferenceService implements ChartSearchService {
 			inputTokens = response.getInputTokens();
 			cachedTokens = response.getCachedTokens();
 
-			List<RecordReference> references = groundReferences(response.getAnswer(),
-					extractCitedReferences(response.getAnswer(), response.getCitations(),
-							chart.getMappings()),
+			// Citations are known as soon as the answer is generated. Hand them to the caller
+			// BEFORE the grounding pass (which can add a tail of Tier-2 entailment calls) so the UI
+			// can render the answer and its clickable citations immediately; the returned answer
+			// carries the grounded references once verification completes.
+			List<RecordReference> cited = extractCitedReferences(response.getAnswer(),
+					response.getCitations(), chart.getMappings());
+			citationsConsumer.accept(cited);
+
+			long groundStart = System.currentTimeMillis();
+			List<RecordReference> references = groundReferences(response.getAnswer(), cited,
 					chart.getMappings());
+			groundMs = System.currentTimeMillis() - groundStart;
+
 			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens());
@@ -265,9 +282,9 @@ public class LlmInferenceService implements ChartSearchService {
 			return answer;
 		}
 		finally {
-			log.info("[timing] searchStreaming patient={} chartBuildMs={} llmMs={} totalMs={} inputTokens={} cachedTokens={} outcome={}",
+			log.info("[timing] searchStreaming patient={} chartBuildMs={} llmMs={} groundMs={} totalMs={} inputTokens={} cachedTokens={} outcome={}",
 					patient == null ? null : patient.getPatientId(),
-					buildMs, llmMs, buildMs + llmMs,
+					buildMs, llmMs, groundMs, buildMs + llmMs + groundMs,
 					inputTokens, cachedTokens, outcome);
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -15,6 +15,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
 import org.slf4j.Logger;
@@ -32,6 +37,9 @@ import org.springframework.stereotype.Component;
 public class LlmProvider {
 
 	private static final Logger log = LoggerFactory.getLogger(LlmProvider.class);
+
+	/** Builds the batch-grounding response_format and parses the verdict array it returns. */
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 
 	/** Label that prefixes the focus-hint line in the user message. Shared with the
 	 *  DEFAULT_SYSTEM_PROMPT few-shot so the demonstration always mirrors the real prompt
@@ -376,10 +384,12 @@ public class LlmProvider {
 			+ "— the single word YES or NO — in the \"answer\" field, with an empty \"citations\" array.";
 
 	/**
-	 * Tier-2 grounding check: asks the active LLM whether {@code source} actually
-	 * supports {@code statement}. Used by {@code CitationGroundingVerifier} to
-	 * confirm a citation that cosine similarity alone cannot judge (high lexical
-	 * overlap but a subject/polarity flip, e.g. "patient has X" vs "mother had X").
+	 * Tier-2 grounding check for a SINGLE {@code (source, statement)} pair: asks the active LLM
+	 * whether {@code source} actually supports {@code statement}. It catches the subject/polarity
+	 * flips cosine alone cannot judge (high lexical overlap but e.g. "patient has X" vs "mother had
+	 * X"). The chart-grounding path now verifies all of an answer's citations in one round-trip via
+	 * {@link #entailsBatch}; this single-pair form is retained as the primitive and for one-off
+	 * checks.
 	 *
 	 * @param source the cited record's text
 	 * @param statement the answer sentence that cites it
@@ -396,6 +406,71 @@ public class LlmProvider {
 		LlmEngine.InferenceResult result = getActiveEngine().infer(
 				ENTAILMENT_SYSTEM_PROMPT, userMessage, getTimeoutSeconds());
 		return parseEntailmentVerdict(result == null ? null : result.getText());
+	}
+
+	static final String ENTAILMENT_BATCH_SYSTEM_PROMPT = "You are a strict clinical fact-checker. "
+			+ "For EACH numbered pair you are given a SOURCE record and a STATEMENT. A SOURCE "
+			+ "supports its STATEMENT only if it explicitly states it. It does NOT support the "
+			+ "STATEMENT when the STATEMENT is about a different person (e.g. a relative or family "
+			+ "history), is negated or denied by the SOURCE, is unconfirmed or merely suspected, or "
+			+ "is simply not stated. Do not use any outside knowledge. Return a \"verdicts\" array "
+			+ "with exactly one entry per numbered pair, IN ORDER — each the single word YES or NO.";
+
+	/**
+	 * Batch Tier-2 grounding: verifies many {@code (source, statement)} pairs in ONE LLM call,
+	 * returning a verdict per pair aligned to the inputs by index. Replaces N sequential
+	 * {@link #entails} calls. Measured against the local llama-server (Gemma E2B) it is ~10x faster:
+	 * the verdict-only {@link EntailmentBatchResponseFormat} drops the per-call reasoning the
+	 * chart-answer schema forces — the dominant, decode-bound cost of a one-word verdict — and pays
+	 * one prefill and one round-trip instead of N (the engine is single-slot, so the N calls were
+	 * strictly serial). Verdict accuracy matched the per-call path on a 20-pair stress set (19/20
+	 * agreement; the lone difference was the batch being correct where the reasoning-laden single
+	 * call had reasoned itself wrong).
+	 *
+	 * @param sources the cited records' texts
+	 * @param statements the answer sentences citing them; must be the same length as {@code sources}
+	 * @return a list the same size as the inputs: {@code TRUE}/{@code FALSE} per pair, or
+	 *         {@code null} where the pair was blank or the model's verdict was missing/unparseable —
+	 *         callers fall back to the Tier-1 verdict for those, exactly as for {@link #entails}
+	 */
+	public List<Boolean> entailsBatch(List<String> sources, List<String> statements) {
+		if (sources == null || statements == null || sources.size() != statements.size()) {
+			throw new IllegalArgumentException(
+					"sources and statements must be non-null and the same length");
+		}
+		int n = sources.size();
+		List<Boolean> result = new ArrayList<>(Collections.<Boolean> nCopies(n, null));
+
+		// A blank source or statement can't be checked — leave it null (mirrors entails()). Number
+		// only the checkable pairs so the model sees a clean 1..k list; map its k verdicts back to
+		// the original positions afterwards.
+		List<Integer> positions = new ArrayList<>();
+		StringBuilder user = new StringBuilder();
+		for (int i = 0; i < n; i++) {
+			String source = sources.get(i);
+			String statement = statements.get(i);
+			if (source == null || source.trim().isEmpty()
+					|| statement == null || statement.trim().isEmpty()) {
+				continue;
+			}
+			positions.add(i);
+			user.append("PAIR ").append(positions.size()).append(":\n SOURCE: ")
+					.append(source.trim()).append("\n STATEMENT: ").append(statement.trim())
+					.append('\n');
+		}
+		if (positions.isEmpty()) {
+			return result;
+		}
+
+		ObjectNode responseFormat = EntailmentBatchResponseFormat.build(MAPPER, positions.size());
+		LlmEngine.InferenceResult inference = getActiveEngine().infer(
+				ENTAILMENT_BATCH_SYSTEM_PROMPT, user.toString(), getTimeoutSeconds(), responseFormat);
+		List<Boolean> verdicts = parseBatchVerdicts(
+				inference == null ? null : inference.getText(), positions.size());
+		for (int k = 0; k < positions.size(); k++) {
+			result.set(positions.get(k), k < verdicts.size() ? verdicts.get(k) : null);
+		}
+		return result;
 	}
 
 	/**
@@ -461,6 +536,42 @@ public class LlmProvider {
 			return Boolean.valueOf("YES".equals(m.group(1)));
 		}
 		return null;
+	}
+
+	/**
+	 * Reads the {@code "verdicts"} array out of a batch entailment reply
+	 * ({@link EntailmentBatchResponseFormat} emits {@code {"verdicts": ["YES","NO",...]}}) into a
+	 * list of {@code TRUE}/{@code FALSE}, reusing the tolerant {@link #parseYesNo} token reader.
+	 * Defensive so a misbehaving model never breaks grounding: a null/blank reply, a malformed or
+	 * envelope-free reply, or a missing array yields an empty list (the caller then falls back to
+	 * Tier-1 for the unfilled positions); an element that is neither YES nor NO becomes {@code null}.
+	 * The strict json_schema makes the well-formed {@code {"verdicts":[...]}} envelope the norm.
+	 *
+	 * @param expectedCount the number of pairs sent; used only to log a (schema-should-prevent) size
+	 *        mismatch — the array is returned as parsed, and the caller aligns by position
+	 */
+	static List<Boolean> parseBatchVerdicts(String rawLlmText, int expectedCount) {
+		List<Boolean> verdicts = new ArrayList<>();
+		if (rawLlmText == null || rawLlmText.trim().isEmpty()) {
+			return verdicts;
+		}
+		try {
+			JsonNode array = MAPPER.readTree(rawLlmText).get("verdicts");
+			if (array != null && array.isArray()) {
+				for (JsonNode element : array) {
+					verdicts.add(parseYesNo(element.asText()));
+				}
+			}
+		}
+		catch (JsonProcessingException e) {
+			log.warn("Could not parse batch entailment verdicts; falling back to Tier-1 ({})",
+					e.getMessage());
+		}
+		if (!verdicts.isEmpty() && verdicts.size() != expectedCount) {
+			log.debug("Batch entailment returned {} verdict(s) for {} pair(s)", verdicts.size(),
+					expectedCount);
+		}
+		return verdicts;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -109,9 +109,26 @@ public class LocalLlmEngine implements LlmEngine {
 	public synchronized InferenceResult infer(String systemPrompt, String userMessage,
 			int timeoutSeconds) {
 		ensureServerRunning();
+		return postForResult(buildRequestBody(systemPrompt, userMessage, false), timeoutSeconds);
+	}
 
-		String requestBody = buildRequestBody(systemPrompt, userMessage, false);
+	@Override
+	public synchronized InferenceResult infer(String systemPrompt, String userMessage,
+			int timeoutSeconds, ObjectNode responseFormat) {
+		ensureServerRunning();
+		String requestBody = responseFormat == null
+				? buildRequestBody(systemPrompt, userMessage, false)
+				: buildRequestBody(systemPrompt, userMessage, false,
+						ChartSearchAiConstants.DEFAULT_LLM_MAX_OUTPUT_TOKENS, responseFormat);
+		return postForResult(requestBody, timeoutSeconds);
+	}
 
+	/**
+	 * Sends a pre-built request body to the local llama-server and parses the (non-streaming)
+	 * result. Shared by the default-schema and custom-{@code response_format} {@link #infer}
+	 * overloads. Called only from {@code synchronized} methods, so it runs under the engine lock.
+	 */
+	private InferenceResult postForResult(String requestBody, int timeoutSeconds) {
 		HttpRequest request = HttpRequest.newBuilder()
 				.uri(URI.create(getCompletionsUrl()))
 				.timeout(Duration.ofSeconds(timeoutSeconds))
@@ -474,6 +491,19 @@ public class LocalLlmEngine implements LlmEngine {
 
 	String buildRequestBody(String systemPrompt, String userMessage, boolean stream,
 			int maxTokens) {
+		return buildRequestBody(systemPrompt, userMessage, stream, maxTokens,
+				ChartAnswerResponseFormat.build(MAPPER));
+	}
+
+	/**
+	 * As {@link #buildRequestBody(String, String, boolean, int)} but with a caller-supplied
+	 * {@code response_format} (e.g. the verdict-only {@link EntailmentBatchResponseFormat}) in
+	 * place of the default chart-answer schema. Every other field — temperature, the pinned
+	 * sampler chain, DRY penalties, {@code cache_prompt} — is identical, so KV-cache reuse and
+	 * decoding behaviour are unchanged.
+	 */
+	String buildRequestBody(String systemPrompt, String userMessage, boolean stream,
+			int maxTokens, ObjectNode responseFormat) {
 		ObjectNode root = MAPPER.createObjectNode();
 		root.put("temperature", 0.0);
 		root.put("max_tokens", maxTokens);
@@ -520,7 +550,7 @@ public class LocalLlmEngine implements LlmEngine {
 			root.set("stream_options", streamOptions);
 		}
 
-		root.set("response_format", ChartAnswerResponseFormat.build(MAPPER));
+		root.set("response_format", responseFormat);
 		root.set("messages", ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage));
 
 		try {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
@@ -47,11 +47,17 @@ public class RemoteLlmEngine implements LlmEngine {
 
 	@Override
 	public InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds) {
+		return infer(systemPrompt, userMessage, timeoutSeconds, null);
+	}
+
+	@Override
+	public InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds,
+			ObjectNode responseFormat) {
 		String endpointUrl = getRequiredGlobalProperty(ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL);
 		String apiKey = getOptionalRuntimeProperty(ChartSearchAiConstants.RP_LLM_REMOTE_API_KEY);
 		String modelName = getRequiredGlobalProperty(ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME);
 
-		String requestBody = buildRequestBody(systemPrompt, userMessage, modelName, false);
+		String requestBody = buildRequestBody(systemPrompt, userMessage, modelName, false, responseFormat);
 
 		HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
 				.uri(URI.create(endpointUrl))
@@ -152,6 +158,16 @@ public class RemoteLlmEngine implements LlmEngine {
 
 	String buildRequestBody(String systemPrompt, String userMessage, String modelName,
 			boolean stream) {
+		return buildRequestBody(systemPrompt, userMessage, modelName, stream, null);
+	}
+
+	/**
+	 * As {@link #buildRequestBody(String, String, String, boolean)} but with a caller-supplied
+	 * {@code response_format} (e.g. the verdict-only batch-grounding schema). A {@code null}
+	 * {@code responseFormat} falls back to the default chart-answer schema.
+	 */
+	String buildRequestBody(String systemPrompt, String userMessage, String modelName,
+			boolean stream, ObjectNode responseFormat) {
 		ObjectNode root = MAPPER.createObjectNode();
 		root.put("model", modelName);
 		// Anthropic's compat endpoint rejects temperature/top_p on Opus 4.7; top_k=1 is the only greedy-decoding lever it still accepts.
@@ -168,7 +184,8 @@ public class RemoteLlmEngine implements LlmEngine {
 			root.set("stream_options", streamOptions);
 		}
 
-		root.set("response_format", ChartAnswerResponseFormat.build(MAPPER));
+		root.set("response_format",
+				responseFormat != null ? responseFormat : ChartAnswerResponseFormat.build(MAPPER));
 		root.set("messages", ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage));
 
 		try {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
@@ -66,21 +66,33 @@ public class CitationGroundingVerifierTest {
 		}
 	}
 
-	/** A LlmProvider whose {@link #entails} returns a programmed verdict and counts calls. */
+	/**
+	 * A LlmProvider whose batch entailment returns the programmed verdict for every pair.
+	 * {@code calls} counts pairs verified (so the per-citation expectations still read naturally
+	 * under batching — N citations verified == {@code calls == N}); {@code batches} counts
+	 * {@code entailsBatch} invocations, which must be one per answer.
+	 */
 	private static class StubLlmProvider extends LlmProvider {
 
 		Boolean verdict;
 
 		int calls;
 
+		int batches;
+
 		StubLlmProvider(Boolean verdict) {
 			this.verdict = verdict;
 		}
 
 		@Override
-		public Boolean entails(String source, String statement) {
-			calls++;
-			return verdict;
+		public List<Boolean> entailsBatch(List<String> sources, List<String> statements) {
+			batches++;
+			calls += sources.size();
+			List<Boolean> out = new ArrayList<Boolean>();
+			for (int i = 0; i < sources.size(); i++) {
+				out.add(verdict);
+			}
+			return out;
 		}
 	}
 
@@ -295,7 +307,7 @@ public class CitationGroundingVerifierTest {
 		StubLlmProvider throwing = new StubLlmProvider(null) {
 
 			@Override
-			public Boolean entails(String source, String statement) {
+			public List<Boolean> entailsBatch(List<String> sources, List<String> statements) {
 				throw new RuntimeException("llama-server timed out");
 			}
 		};
@@ -351,6 +363,33 @@ public class CitationGroundingVerifierTest {
 		assertEquals(Boolean.TRUE, result.get(0).getGrounded(), "within cap -> entailment applied");
 		assertEquals(Boolean.FALSE, result.get(total - 1).getGrounded(),
 				"beyond cap -> keeps Tier-1 verdict");
+	}
+
+	@Test
+	public void tier2_verifiesAllCitationsInOneBatchCall() {
+		// The latency fix: every cited reference Tier-2 confirms is checked in ONE entailsBatch
+		// call, not one serial LLM call per citation. Three on-topic citations -> a single batch
+		// of three pairs, and each reference still gets the batch's verdict.
+		String answer = "Diabetes [1]. Hypertension [2]. Asthma [3].";
+		embeddings.register("Diabetes [1].", AXIS_A);
+		embeddings.register("Hypertension [2].", AXIS_A);
+		embeddings.register("Asthma [3].", AXIS_A);
+		embeddings.register("type 2 diabetes", AXIS_A);
+		embeddings.register("essential hypertension", AXIS_A);
+		embeddings.register("mild asthma", AXIS_A);
+		llm.verdict = Boolean.TRUE;
+
+		List<RecordReference> result = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2), reference(3))),
+				Arrays.asList(mapping(1, "type 2 diabetes"), mapping(2, "essential hypertension"),
+						mapping(3, "mild asthma")),
+				FLOOR, TIER2_ON);
+
+		assertEquals(1, llm.batches, "all citations must be verified in a single batch call");
+		assertEquals(3, llm.calls, "the one batch must carry all three (record, claim) pairs");
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded());
+		assertEquals(Boolean.TRUE, result.get(1).getGrounded());
+		assertEquals(Boolean.TRUE, result.get(2).getGrounded());
 	}
 
 	// ---- helpers ----

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/EntailmentBatchResponseFormatTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/EntailmentBatchResponseFormatTest.java
@@ -1,0 +1,68 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link EntailmentBatchResponseFormat} — the verdict-only batch-grounding schema.
+ */
+public class EntailmentBatchResponseFormatTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@Test
+	public void build_producesStrictFixedLengthYesNoArray() {
+		ObjectNode rf = EntailmentBatchResponseFormat.build(MAPPER, 5);
+		assertEquals("json_schema", rf.get("type").asText());
+		JsonNode jsonSchema = rf.get("json_schema");
+		assertTrue(jsonSchema.get("strict").asBoolean(),
+				"must be strict so the model cannot return the wrong number of verdicts");
+		JsonNode schema = jsonSchema.get("schema");
+		assertFalse(schema.get("additionalProperties").asBoolean());
+		JsonNode verdicts = schema.get("properties").get("verdicts");
+		assertEquals("array", verdicts.get("type").asText());
+		// Exactly one verdict per pair: so verdicts align to the numbered pairs by position.
+		assertEquals(5, verdicts.get("minItems").asInt());
+		assertEquals(5, verdicts.get("maxItems").asInt());
+		JsonNode enumValues = verdicts.get("items").get("enum");
+		assertEquals(2, enumValues.size());
+		assertEquals("YES", enumValues.get(0).asText());
+		assertEquals("NO", enumValues.get(1).asText());
+	}
+
+	@Test
+	public void build_hasNoReasoningField() {
+		// The whole point vs ChartAnswerResponseFormat: NO leading reasoning field. The per-verdict
+		// reasoning the chart-answer schema forces is the decode-bound latency a one-word verdict
+		// does not need (measured ~10x slower). Only the verdicts array may be present.
+		JsonNode properties = EntailmentBatchResponseFormat.build(MAPPER, 3)
+				.get("json_schema").get("schema").get("properties");
+		assertFalse(properties.has("reasoning"),
+				"batch verdict schema must not force per-call reasoning");
+		assertEquals(1, properties.size(), "only the verdicts array");
+	}
+
+	@Test
+	public void build_arrayLengthTracksPairCount() {
+		JsonNode verdicts = EntailmentBatchResponseFormat.build(MAPPER, 1)
+				.get("json_schema").get("schema").get("properties").get("verdicts");
+		assertEquals(1, verdicts.get("minItems").asInt());
+		assertEquals(1, verdicts.get("maxItems").asInt());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceTest.java
@@ -21,12 +21,16 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
 import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
 import org.openmrs.module.chartsearchai.model.ChartEmbedding;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
 import org.openmrs.module.chartsearchai.api.impl.PipelineConfig;
 import org.openmrs.module.chartsearchai.api.impl.ScoredEmbedding;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
@@ -265,6 +269,52 @@ public class LlmInferenceServiceTest {
 				"Demographics-only chart has non-empty text");
 		assertTrue(chart.getMappings().isEmpty(),
 				"Demographics-only chart should have no record mappings");
+	}
+
+	@Test
+	public void searchStreaming_emitsCitationsOnTheCitationsChannelDuringTheCall() {
+		// The async-grounding contract: the answer's citations are pushed to the citations channel
+		// DURING the call (so the UI can render clickable citations immediately) — not only via the
+		// returned answer — and they carry no grounding verdict yet (grounded == null). Exercises the
+		// real production orchestration (buildChart -> generate -> extract citations -> ground) with
+		// the chart/LLM collaborators stubbed; grounding is off (no context) so it is a clean no-op.
+		List<RecordMapping> mappings = Arrays.asList(
+				new RecordMapping(1, "obs", uuid(11), null),
+				new RecordMapping(2, "order", uuid(22), null));
+		PatientChart chart = new PatientChart("records", mappings);
+
+		LlmInferenceService service = new LlmInferenceService();
+		service.setChartBuildingStrategy(new ChartBuildingStrategy() {
+
+			@Override
+			PatientChart buildChart(Patient patient, String question) {
+				return chart;
+			}
+		});
+		service.setLlmProvider(new LlmProvider() {
+
+			@Override
+			public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices,
+					String question, Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
+				tokenConsumer.accept("Finding A [1] and finding B [2].");
+				return new LlmResponse("Finding A [1] and finding B [2].", Arrays.asList(1, 2));
+			}
+		});
+
+		List<List<RecordReference>> captured = new ArrayList<List<RecordReference>>();
+		ChartAnswer answer = service.searchStreaming(null, "any findings?",
+				token -> { }, reasoning -> { }, captured::add);
+
+		assertEquals(1, captured.size(), "citations channel must fire exactly once per answer");
+		List<RecordReference> early = captured.get(0);
+		assertEquals(2, early.size(), "both cited records must reach the citations channel");
+		assertEquals(uuid(11), early.get(0).getResourceUuid());
+		assertEquals(uuid(22), early.get(1).getResourceUuid());
+		// Emitted before grounding -> no verdict yet; clients must render these as unverified.
+		assertNull(early.get(0).getGrounded());
+		assertNull(early.get(1).getGrounded());
+		// The same citations come back on the returned answer.
+		assertEquals(2, answer.getReferences().size());
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmProviderTest.java
@@ -11,11 +11,16 @@ package org.openmrs.module.chartsearchai.api.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.junit.jupiter.api.Test;
 
@@ -407,6 +412,132 @@ public class LlmProviderTest {
 		assertTrue(result.getAnswer().startsWith("On 2026-01-1 the patient had encounter [0]"),
 				"should recover the answer prefix from a truncated JSON, got: "
 						+ result.getAnswer().substring(0, Math.min(80, result.getAnswer().length())));
+	}
+
+	// ---- batch entailment verdict parsing (Tier-2 grounding, one call for many citations) ----
+
+	@Test
+	public void parseBatchVerdicts_readsYesNoArrayInOrder() {
+		assertEquals(Arrays.asList(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE),
+				LlmProvider.parseBatchVerdicts("{\"verdicts\": [\"YES\", \"NO\", \"YES\"]}", 3));
+	}
+
+	@Test
+	public void parseBatchVerdicts_nullOrBlankYieldsEmptyList() {
+		assertTrue(LlmProvider.parseBatchVerdicts(null, 3).isEmpty());
+		assertTrue(LlmProvider.parseBatchVerdicts("   ", 3).isEmpty());
+	}
+
+	@Test
+	public void parseBatchVerdicts_envelopeFreeReplyDegradesToEmpty() {
+		// A reply that is not the {"verdicts":[...]} envelope (e.g. an engine that ignored the
+		// custom schema and used chart_answer) must yield an empty list so the caller falls back to
+		// the Tier-1 verdict instead of misreading a verdict from the wrong field.
+		assertTrue(LlmProvider.parseBatchVerdicts(
+				"{\"reasoning\": \"x\", \"answer\": \"YES\", \"citations\": []}", 1).isEmpty());
+		assertTrue(LlmProvider.parseBatchVerdicts("not json at all", 1).isEmpty());
+	}
+
+	@Test
+	public void parseBatchVerdicts_unrecognisedElementBecomesNull() {
+		// Defensive: an element that is neither YES nor NO is undecidable (null), not a guess —
+		// grounding then keeps the Tier-1 verdict for that citation.
+		java.util.List<Boolean> v = LlmProvider.parseBatchVerdicts("{\"verdicts\": [\"YES\", \"MAYBE\"]}", 2);
+		assertEquals(2, v.size());
+		assertEquals(Boolean.TRUE, v.get(0));
+		assertNull(v.get(1));
+	}
+
+	/** Minimal {@link LlmEngine} that echoes a canned response body, so {@code entailsBatch}'s
+	 *  numbering / blank-skip / position-mapping / parse wiring can be exercised without a real
+	 *  model or an OpenMRS context. */
+	private static class StubEngine implements LlmEngine {
+
+		private final String content;
+
+		StubEngine(String content) {
+			this.content = content;
+		}
+
+		@Override
+		public InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds) {
+			return new InferenceResult(content, 0, 0);
+		}
+
+		@Override
+		public InferenceResult infer(String systemPrompt, String userMessage, int timeoutSeconds,
+				ObjectNode responseFormat) {
+			return new InferenceResult(content, 0, 0);
+		}
+
+		@Override
+		public InferenceResult inferStreaming(String systemPrompt, String userMessage, int timeoutSeconds,
+				Consumer<String> tokenConsumer) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void warmup(String systemPrompt, String userMessage, int timeoutSeconds) {
+		}
+
+		@Override
+		public void close() {
+		}
+
+		@Override
+		public void shutdown() {
+		}
+	}
+
+	@Test
+	public void entailsBatch_mapsVerdictsToInputPositionsAndSkipsBlankPairs() {
+		// entailsBatch numbers ONLY the checkable pairs (1..k) in the prompt, then maps the model's
+		// k verdicts back to the ORIGINAL input positions. A blank pair stays null and must not
+		// shift the others — an off-by-one here would assign one citation's verdict to another (a
+		// silent grounding error). Stub the engine to echo a fixed verdicts array.
+		LlmProvider provider = new LlmProvider() {
+
+			@Override
+			LlmEngine getActiveEngine() {
+				return new StubEngine("{\"verdicts\": [\"NO\", \"YES\"]}");
+			}
+
+			@Override
+			protected int getTimeoutSeconds() {
+				return 30;
+			}
+		};
+		// Middle pair has a blank source -> only positions 0 and 2 are checked -> verdicts [NO, YES].
+		List<Boolean> out = provider.entailsBatch(
+				Arrays.asList("record A", "   ", "record C"),
+				Arrays.asList("claim A", "claim B", "claim C"));
+		assertEquals(3, out.size());
+		assertEquals(Boolean.FALSE, out.get(0), "first checkable pair -> NO");
+		assertNull(out.get(1), "blank pair -> not checked -> null verdict");
+		assertEquals(Boolean.TRUE, out.get(2), "second checkable pair -> YES (not shifted by the blank)");
+	}
+
+	@Test
+	public void entailsBatch_rejectsMismatchedInputLengths() {
+		assertThrows(IllegalArgumentException.class,
+				() -> new LlmProvider().entailsBatch(Arrays.asList("a"), Arrays.asList("x", "y")));
+	}
+
+	@Test
+	public void entailsBatch_makesNoEngineCallWhenNoPairIsCheckable() {
+		// Every pair blank -> returns all-null WITHOUT touching the engine (getActiveEngine throws
+		// if called), so a degenerate answer never issues a wasted LLM round-trip.
+		LlmProvider provider = new LlmProvider() {
+
+			@Override
+			LlmEngine getActiveEngine() {
+				throw new AssertionError("entailsBatch must not call the engine when nothing is checkable");
+			}
+		};
+		List<Boolean> out = provider.entailsBatch(Arrays.asList("", "  "), Arrays.asList("", "x"));
+		assertEquals(2, out.size());
+		assertNull(out.get(0));
+		assertNull(out.get(1));
 	}
 
 }

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -362,15 +362,20 @@ public class ChartSearchAiRestController {
 		try {
 			long startTime = System.currentTimeMillis();
 
-			// Two channels: "token" carries the answer; "thinking" carries the model's reasoning
-			// (chain-of-thought), which is emitted first so the UI can show live progress and the
-			// rationale instead of a dead spinner. The frontend must render "thinking" distinctly
-			// (e.g. a collapsible panel), never as the answer. Both unwind on client disconnect via
-			// writeSseEventOrThrow.
+			// Three channels: "token" carries the answer; "thinking" carries the model's reasoning
+			// (chain-of-thought), emitted first so the UI can show live progress and the rationale
+			// instead of a dead spinner; "references" carries the answer's citations the moment the
+			// answer is done — BEFORE the grounding pass — so the UI can render clickable citations
+			// immediately and not wait on Tier-2 verification. The final "done" event re-sends the
+			// same references with their grounding verdicts attached. The frontend must render
+			// "thinking" distinctly (e.g. a collapsible panel), never as the answer; until "done"
+			// arrives it must show "references" citations as unverified. All unwind on client
+			// disconnect via writeSseEventOrThrow.
 			ChartAnswer chartAnswer = chartSearchService.searchStreaming(
 					patient, sanitizedQuestion,
 					token -> writeSseEventOrThrow(out, "token", token),
-					reasoning -> writeSseEventOrThrow(out, "thinking", reasoning));
+					reasoning -> writeSseEventOrThrow(out, "thinking", reasoning),
+					citations -> sendReferencesEvent(out, citations));
 
 			long responseTimeMs = System.currentTimeMillis() - startTime;
 
@@ -396,19 +401,7 @@ public class ChartSearchAiRestController {
 			doneData.put("answer", chartAnswer.getAnswer());
 			doneData.put("disclaimer", DISCLAIMER);
 
-			List<Map<String, Object>> refs = new ArrayList<Map<String, Object>>();
-			for (RecordReference ref : chartAnswer.getReferences()) {
-				Map<String, Object> refMap = new LinkedHashMap<String, Object>();
-				refMap.put("index", ref.getIndex());
-				refMap.put("resourceType", ref.getResourceType());
-				refMap.put("resourceUuid", ref.getResourceUuid());
-				refMap.put("date", formatDate(ref.getDate()));
-				// null when grounding is disabled or could not run — clients must
-				// render null as "unverified", never as "verified".
-				refMap.put("grounded", ref.getGrounded());
-				refs.add(refMap);
-			}
-			doneData.put("references", refs);
+			doneData.put("references", serializeReferences(chartAnswer.getReferences()));
 			if (auditLog.getAuditLogId() != null) {
 				doneData.put("questionId", String.valueOf(auditLog.getAuditLogId()));
 			}
@@ -728,6 +721,47 @@ public class ChartSearchAiRestController {
 			return "Question contains disallowed content";
 		}
 		return null;
+	}
+
+	/**
+	 * Serializes references to the SSE wire shape shared by the early {@code references} event
+	 * (grounding verdicts not yet attached) and the final {@code done} event (grounded).
+	 * {@code grounded} is null when grounding is disabled or could not run — clients must render
+	 * null as "unverified", never as "verified".
+	 */
+	private List<Map<String, Object>> serializeReferences(List<RecordReference> references) {
+		List<Map<String, Object>> refs = new ArrayList<Map<String, Object>>();
+		for (RecordReference ref : references) {
+			Map<String, Object> refMap = new LinkedHashMap<String, Object>();
+			refMap.put("index", ref.getIndex());
+			refMap.put("resourceType", ref.getResourceType());
+			refMap.put("resourceUuid", ref.getResourceUuid());
+			refMap.put("date", formatDate(ref.getDate()));
+			refMap.put("grounded", ref.getGrounded());
+			refs.add(refMap);
+		}
+		return refs;
+	}
+
+	/**
+	 * Emits the {@code references} SSE event carrying the answer's citations before the grounding
+	 * pass completes, so the UI can render clickable citations without waiting on Tier-2
+	 * verification. A serialization failure is non-fatal — the final {@code done} event re-sends the
+	 * references with verdicts — but a client disconnect during the write unwinds the stream like the
+	 * other channels (via {@link #writeSseEventOrThrow}).
+	 */
+	private void sendReferencesEvent(OutputStream out, List<RecordReference> references) {
+		String json;
+		try {
+			Map<String, Object> data = new HashMap<String, Object>();
+			data.put("references", serializeReferences(references));
+			json = new ObjectMapper().writeValueAsString(data);
+		}
+		catch (IOException e) {
+			log.warn("Could not serialize early references event; the final done event still carries them", e);
+			return;
+		}
+		writeSseEventOrThrow(out, "references", json);
 	}
 
 	private void writeSseEvent(OutputStream out, String event, String data) throws IOException {


### PR DESCRIPTION
## What & why

Citation grounding (Tier-2 entailment) made one blocking, non-streaming LLM call **per cited record** — up to 16 serial calls on the single-slot local engine, the dominant grounding latency (a 16-citation answer spent ~27–32 s on grounding alone, driving the p99/max latency tails).

This PR makes grounding issue **one batched call** and streams citations to the UI **before** grounding runs.

## Changes

- **Batch entailment** — `LlmProvider.entailsBatch` verifies all of an answer's citations in a single call using a new verdict-only schema (`EntailmentBatchResponseFormat`: strict `{"verdicts":["YES"|"NO", …]}`, no per-call reasoning). `CitationGroundingVerifier.verify` now does a Tier-1 pass that collects candidates (capped at `GROUNDING_ENTAILMENT_MAX_CHECKS`), one `entailsBatch` call, then assembles the verdicts.
- **Async citations** — `searchStreaming` forwards the answer's references on a new `references` SSE event the moment the answer is generated, *before* grounding, so the UI can render clickable citations without waiting on Tier-2. The final `done` event still re-sends the references with their grounding verdicts.
- **Shared infra** — `LlmEngine.infer(…, ObjectNode responseFormat)` overload (the default degrades to the chart-answer schema → Tier-1 fallback), overridden by the local and remote engines.
- The streaming timing log now breaks out `groundMs`.

## Measured impact (local llama-server, Gemma E2B)

- Grounding step ~**10× faster**: a 16–19-citation answer's grounding dropped from ~27–32 s to ~6 s; a 2-citation answer's tail from ~4.4 s to ~1.9 s.
- Verdict accuracy preserved — 19/20 agreement with the per-call path on a stress set, and the single difference was the **batch being correct** where the reasoning-laden single call had reasoned itself wrong.

## Unchanged / compatibility

- Grounding remains **annotate-only**: the answer text, which records are cited, and abstention behaviour are all unchanged — only the per-citation `grounded` flag and the SSE event timing differ.
- Backward-compatible: clients that only read the `done` event are unaffected (the new `references` event is additive; an unknown SSE event type is ignored).

## Testing

- Unit tests green (verifier; provider incl. `entailsBatch` position-mapping + `parseBatchVerdicts`; engines; schema; router; inference incl. the async citations-during-call ordering).
- Retrieval eval harnesses run on L6-v2: the failures observed (EnrichedRetrievalEvalTest 2/497, LlmInferenceServiceEvalTest 18 recall, RetrievalQualityEvalTest `<200ms` latency) reproduce **identically on the base branch without this change** — i.e. pre-existing and/or environmental, not introduced here. This PR does not touch the retrieval pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
