### PR TITLE
Clause-scoped citation grounding + per-compound-sentence Tier-2 unbatching (re-land of #38)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -338,6 +338,17 @@ public class ChartSearchAiConstants {
 	public static final boolean DEFAULT_GROUNDING_ENTAILMENT_ENABLED = false;
 
 	/**
+	 * When set, citation grounding is clause-scoped: a sentence citing multiple records checks each
+	 * citation against the answer text up to and including its own {@code [N]} marker, not the whole
+	 * compound sentence. This grounds a citation that supports its own clause but not a later clause
+	 * cited by a different record (e.g. an active condition cited alongside a provisional diagnosis in
+	 * one sentence). Default {@code false} (sentence-scoped, the original behaviour).
+	 */
+	public static final String GP_GROUNDING_CLAUSE_SCOPED = "chartsearchai.grounding.clauseScoped";
+
+	public static final boolean DEFAULT_GROUNDING_CLAUSE_SCOPED = false;
+
+	/**
 	 * Upper bound on the number of citations Tier-2 entailment verifies per answer (i.e. the batch
 	 * size), so a heavily-cited answer cannot make the single batched entailment prompt grow without
 	 * bound. References beyond this many keep their Tier-1 verdict; the verifier logs once when the

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
@@ -525,6 +525,25 @@ public class ChartSearchAiUtils {
 	}
 
 	/**
+	 * @return true when grounding is clause-scoped via
+	 *         {@link ChartSearchAiConstants#GP_GROUNDING_CLAUSE_SCOPED} — each citation in a
+	 *         multi-citation sentence is checked against its own clause rather than the whole
+	 *         sentence. Fails safe to {@code false} (sentence-scoped) when no admin service is
+	 *         available.
+	 */
+	public static boolean isGroundingClauseScoped() {
+		try {
+			String value = org.openmrs.api.context.Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_GROUNDING_CLAUSE_SCOPED,
+							String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_CLAUSE_SCOPED));
+			return "true".equalsIgnoreCase(value.trim());
+		}
+		catch (RuntimeException e) {
+			return ChartSearchAiConstants.DEFAULT_GROUNDING_CLAUSE_SCOPED;
+		}
+	}
+
+	/**
 	 * @return the cosine floor below which a citation is treated as ungrounded,
 	 *         read from {@link ChartSearchAiConstants#GP_GROUNDING_MIN_COSINE},
 	 *         falling back to {@link ChartSearchAiConstants#DEFAULT_GROUNDING_MIN_COSINE}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.chartsearchai.api.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,9 +53,13 @@ import org.springframework.stereotype.Service;
  * confirmed by a yes/no LLM entailment verdict that is authoritative. This is what
  * catches the subject/polarity flips cosine cannot. It runs on Tier-1 passes
  * <em>and</em> failures — the dangerous case (a high-overlap but unsupported
- * citation) is a Tier-1 pass, so confirming only failures would miss it. All of an answer's
- * cited references are verified in a SINGLE batched call ({@link LlmProvider#entailsBatch}),
- * capped at {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer;
+ * citation) is a Tier-1 pass, so confirming only failures would miss it. References are verified
+ * in a SINGLE batched call ({@link LlmProvider#entailsBatch}) — except that, under clause-scoped
+ * grounding, the citations of one compound sentence are each verified in their OWN call: batched
+ * entailment is NOT per-pair independent, so co-batching a compound sentence's citations (whose
+ * overlapping clause statements differ only by length) lets the LLM couple their verdicts and
+ * silently flip a correct citation to not-grounded. The total is capped at
+ * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer;
  * references beyond the cap keep their Tier-1 verdict.
  *
  * <p>The verifier never throws into the search path: any failure (embedding
@@ -164,7 +169,17 @@ public class CitationGroundingVerifier {
 	public List<RecordReference> verify(String answer, List<RecordReference> references,
 			List<RecordMapping> mappings) {
 		return verify(answer, references, mappings, ChartSearchAiUtils.getGroundingMinCosine(),
-				ChartSearchAiUtils.isGroundingEntailmentEnabled());
+				ChartSearchAiUtils.isGroundingEntailmentEnabled(),
+				ChartSearchAiUtils.isGroundingClauseScoped());
+	}
+
+	/**
+	 * Backward-compatible 5-arg overload — sentence-scoped grounding (the original behaviour).
+	 * Existing tests pin this; the public {@link #verify} now delegates to the 6-arg form.
+	 */
+	List<RecordReference> verify(String answer, List<RecordReference> references,
+			List<RecordMapping> mappings, double floor, boolean entailmentEnabled) {
+		return verify(answer, references, mappings, floor, entailmentEnabled, false);
 	}
 
 	/**
@@ -177,13 +192,21 @@ public class CitationGroundingVerifier {
 	 * confirmed by a Tier-2 LLM entailment verdict that is authoritative
 	 * (cosine errs in both directions, and the dangerous error — a high-overlap
 	 * but unsupported citation — is exactly the case Tier-1 cannot self-detect,
-	 * so the LLM must see Tier-1 passes too, not only failures). All of them are checked in
-	 * ONE batched call ({@link LlmProvider#entailsBatch}), capped at
-	 * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer;
-	 * references beyond the cap keep their Tier-1 verdict.
+	 * so the LLM must see Tier-1 passes too, not only failures). They are confirmed in a batched
+	 * call ({@link LlmProvider#entailsBatch}), capped at
+	 * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer; references
+	 * beyond the cap keep their Tier-1 verdict (but see the clause-scoped exception below).
+	 *
+	 * <p>When {@code clauseScoped}, a sentence citing multiple records is split so each citation is
+	 * checked against the answer text up to and including its own {@code [N]} marker, not the whole
+	 * compound sentence (see {@link #splitIntoClauseScopedSentences}). Those split citations are each
+	 * Tier-2 verified in their OWN entailment call rather than co-batched: batched entailment is not
+	 * per-pair independent, so co-batching a compound sentence's citations (whose clause statements
+	 * overlap) lets the LLM couple their verdicts. Every other citation is still confirmed in the one
+	 * shared batched call.
 	 */
 	List<RecordReference> verify(String answer, List<RecordReference> references,
-			List<RecordMapping> mappings, double floor, boolean entailmentEnabled) {
+			List<RecordMapping> mappings, double floor, boolean entailmentEnabled, boolean clauseScoped) {
 		if (references == null || references.isEmpty()) {
 			return references;
 		}
@@ -195,7 +218,9 @@ public class CitationGroundingVerifier {
 			}
 		}
 
-		List<Sentence> sentences = splitIntoCitedSentences(answer);
+		List<Sentence> sentences = clauseScoped
+				? splitIntoClauseScopedSentences(answer)
+				: splitIntoCitedSentences(answer);
 		TextEmbedder embedder = resolveEmbedder();
 
 		// Embedding caches: each record and each sentence is embedded at most
@@ -211,9 +236,17 @@ public class CitationGroundingVerifier {
 		int entailmentBudget = ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS;
 		int cappedCount = 0;
 		Tier1Result[] tier1Results = new Tier1Result[references.size()];
-		List<Integer> tier2Positions = new ArrayList<Integer>();
+		// Non-isolate candidates share ONE batch — their statements don't overlap, so the batched
+		// (not per-pair-independent) LLM cannot couple them.
+		List<Integer> batchPositions = new ArrayList<Integer>();
 		List<String> batchSources = new ArrayList<String>();
 		List<String> batchStatements = new ArrayList<String>();
+		// Isolate candidates — the citations of one compound sentence under clause-scope, whose clause
+		// statements overlap — are each verified in their OWN single-pair call so the LLM cannot couple
+		// their verdicts (see this class's Tier-2 javadoc).
+		List<Integer> isolatePositions = new ArrayList<Integer>();
+		List<String> isolateSources = new ArrayList<String>();
+		List<String> isolateStatements = new ArrayList<String>();
 		for (int i = 0; i < references.size(); i++) {
 			RecordReference reference = references.get(i);
 			Tier1Result tier1 = verdictTier1(reference.getIndex(), textByIndex, sentences,
@@ -225,29 +258,42 @@ public class CitationGroundingVerifier {
 					&& tier1.recordText != null) {
 				if (entailmentBudget > 0) {
 					entailmentBudget--;
-					tier2Positions.add(i);
-					batchSources.add(tier1.recordText);
-					batchStatements.add(stripCitationMarkers(tier1.bestSentence));
+					String statement = stripCitationMarkers(tier1.bestSentence);
+					if (tier1.isolate) {
+						isolatePositions.add(i);
+						isolateSources.add(tier1.recordText);
+						isolateStatements.add(statement);
+					} else {
+						batchPositions.add(i);
+						batchSources.add(tier1.recordText);
+						batchStatements.add(statement);
+					}
 				} else {
 					cappedCount++;
 				}
 			}
 		}
 
-		// One batched entailment call confirms every collected citation at once — replacing one
-		// serial LLM call per citation (the single-slot engine ran them strictly in sequence, the
-		// dominant grounding latency). A null result (whole-batch failure) or a short result leaves
-		// the affected verdicts null, i.e. the Tier-1 verdict stands.
-		List<Boolean> batchVerdicts = batchSources.isEmpty()
-				? java.util.Collections.<Boolean> emptyList()
-				: safeEntailsBatch(batchSources, batchStatements);
-		// Tier-2 verdict per reference position (parallel to tier1Results). A null entry means
-		// either "not a Tier-2 candidate" or "Tier-2 could not verify" — Pass 2 treats both the
-		// same (keep the Tier-1 verdict), so they collapse to one null with no information lost.
 		Boolean[] tier2Verdict = new Boolean[references.size()];
-		for (int k = 0; k < tier2Positions.size(); k++) {
-			tier2Verdict[tier2Positions.get(k)] = (batchVerdicts != null && k < batchVerdicts.size())
-					? batchVerdicts.get(k) : null;
+		// One batched call confirms all NON-isolate citations at once (the latency win); a null/short
+		// result leaves those verdicts null, i.e. the Tier-1 verdict stands. A null entry in
+		// tier2Verdict means "not a Tier-2 candidate" OR "Tier-2 could not verify" — Pass 2 keeps the
+		// Tier-1 verdict for both, so they collapse to one null with no information lost.
+		if (!batchSources.isEmpty()) {
+			List<Boolean> batchVerdicts = safeEntailsBatch(batchSources, batchStatements);
+			for (int k = 0; k < batchPositions.size(); k++) {
+				tier2Verdict[batchPositions.get(k)] = (batchVerdicts != null && k < batchVerdicts.size())
+						? batchVerdicts.get(k) : null;
+			}
+		}
+		// Isolate citations (one compound sentence's, under clause-scope) get a single-pair call each,
+		// so the batched LLM cannot couple their overlapping clause statements into each other's
+		// verdicts. Same null-degrades-to-Tier-1 contract as the batch.
+		for (int k = 0; k < isolatePositions.size(); k++) {
+			List<Boolean> verdict = safeEntailsBatch(Collections.singletonList(isolateSources.get(k)),
+					Collections.singletonList(isolateStatements.get(k)));
+			tier2Verdict[isolatePositions.get(k)] = (verdict != null && !verdict.isEmpty())
+					? verdict.get(0) : null;
 		}
 
 		// Pass 2: assemble — Tier-2 is authoritative when it reached a verdict, else keep Tier-1.
@@ -278,9 +324,9 @@ public class CitationGroundingVerifier {
 	}
 
 	/**
-	 * Computes the Tier-1 cosine verdict for one cited index and identifies the
-	 * single best-matching claim sentence (used as the Tier-2 entailment target).
-	 * Never throws: an embedding failure yields a {@code null} verdict.
+	 * Computes the Tier-1 cosine verdict for one cited index and identifies the single best-matching
+	 * claim sentence — a clause when grounding is clause-scoped — used as the Tier-2 entailment
+	 * target. Never throws: an embedding failure yields a {@code null} verdict.
 	 */
 	private Tier1Result verdictTier1(int index, Map<Integer, String> textByIndex,
 			List<Sentence> sentences, double floor,
@@ -288,7 +334,7 @@ public class CitationGroundingVerifier {
 			TextEmbedder embedder, GroundingStats stats) {
 		String recordText = textByIndex.get(index);
 		if (recordText == null || recordText.trim().isEmpty()) {
-			return new Tier1Result(null, null, null); // nothing to compare against
+			return new Tier1Result(null, null, null, false); // nothing to compare against
 		}
 		try {
 			float[] recordVector = embedRecord(index, recordText, recordVectors, embedder);
@@ -298,6 +344,7 @@ public class CitationGroundingVerifier {
 			// so it must produce FALSE, not be mistaken for "nothing to compare".
 			double best = -Double.MAX_VALUE;
 			String bestSentence = null;
+			boolean bestIsolate = false;
 			boolean compared = false;
 			boolean anyInlineCite = false;
 			for (int s = 0; s < sentences.size(); s++) {
@@ -308,6 +355,7 @@ public class CitationGroundingVerifier {
 					if (sim > best) {
 						best = sim;
 						bestSentence = sentences.get(s).text;
+						bestIsolate = sentences.get(s).isolate;
 					}
 				}
 			}
@@ -322,20 +370,21 @@ public class CitationGroundingVerifier {
 					if (sim > best) {
 						best = sim;
 						bestSentence = sentences.get(s).text;
+						bestIsolate = sentences.get(s).isolate;
 					}
 				}
 			}
 
 			if (!compared) {
-				return new Tier1Result(null, null, recordText); // no sentences (empty answer)
+				return new Tier1Result(null, null, recordText, false); // no sentences (empty answer)
 			}
-			return new Tier1Result(Boolean.valueOf(best >= floor), bestSentence, recordText);
+			return new Tier1Result(Boolean.valueOf(best >= floor), bestSentence, recordText, bestIsolate);
 		}
 		catch (RuntimeException e) {
 			// Never break the search path on a verification failure; count it for the
 			// single summary log in verify() rather than spamming per citation.
 			stats.recordFailure(e);
-			return new Tier1Result(null, null, recordText);
+			return new Tier1Result(null, null, recordText, false);
 		}
 	}
 
@@ -366,7 +415,8 @@ public class CitationGroundingVerifier {
 		return ChartSearchAiUtils.INLINE_CITATION.matcher(text).replaceAll("").trim();
 	}
 
-	/** Tier-1 outcome plus the claim sentence and record text Tier-2 needs. */
+	/** Tier-1 outcome plus the claim sentence/clause, record text, and whether that clause must be
+	 *  Tier-2 verified in isolation — everything Tier-2 needs. */
 	private static class Tier1Result {
 
 		final Boolean verdict;
@@ -375,10 +425,15 @@ public class CitationGroundingVerifier {
 
 		final String recordText;
 
-		Tier1Result(Boolean verdict, String bestSentence, String recordText) {
+		/** True when {@link #bestSentence} is a clause from a multi-citation sentence under
+		 *  clause-scope, so it must be Tier-2 verified in its own call rather than co-batched. */
+		final boolean isolate;
+
+		Tier1Result(Boolean verdict, String bestSentence, String recordText, boolean isolate) {
 			this.verdict = verdict;
 			this.bestSentence = bestSentence;
 			this.recordText = recordText;
+			this.isolate = isolate;
 		}
 	}
 
@@ -425,15 +480,73 @@ public class CitationGroundingVerifier {
 		return sentences;
 	}
 
-	/** An answer sentence and the citation indices it references inline. */
+	/**
+	 * Clause-scoped variant of {@link #splitIntoCitedSentences}: a sentence citing MORE than one
+	 * record is split so each citation is checked against the answer text up to and including its
+	 * own {@code [N]} marker, not the whole compound sentence. This grounds a citation that supports
+	 * its own clause but not a later clause cited by a different record — e.g. "Hearing Loss was
+	 * noted as a condition [89] and diagnosed as a provisional condition [91]", where [89] (an
+	 * active condition) does not support the "provisional diagnosis" clause that [91] backs. The
+	 * clause is the cumulative prefix through the marker, so it retains the sentence subject whenever
+	 * the subject precedes the first marker (the normal case — answers state the finding before its
+	 * citation): a family-history / negation flip in a later clause is then still judged against the
+	 * full preceding claim, not a subject-stripped fragment. A leading {@code [N]} with no text
+	 * before it yields an empty clause, which grounds conservatively (not-grounded) rather than
+	 * spuriously. Single-citation sentences are returned unchanged. Each split clause is flagged for
+	 * isolation ({@link Sentence#isolate}) so Tier-2 verifies it in its OWN call rather than
+	 * co-batching the sentence's citations, whose overlapping clause statements would otherwise couple
+	 * the (not per-pair-independent) batched LLM verdict.
+	 */
+	static List<Sentence> splitIntoClauseScopedSentences(String answer) {
+		List<Sentence> clauses = new ArrayList<Sentence>();
+		for (Sentence sentence : splitIntoCitedSentences(answer)) {
+			if (sentence.citedIndexes.size() <= 1) {
+				clauses.add(sentence);
+				continue;
+			}
+			Matcher marker = ChartSearchAiUtils.INLINE_CITATION.matcher(sentence.text);
+			while (marker.find()) {
+				Integer idx = Integer.valueOf(marker.group(1));
+				clauses.add(new Sentence(sentence.text.substring(0, marker.end()),
+						Collections.singleton(idx), true));
+			}
+		}
+		return clauses;
+	}
+
+	/**
+	 * An answer sentence (or, under clause-scoped grounding, a clause) and the citation indices it is
+	 * scored against. For a whole sentence (the default path) {@link #citedIndexes} is exactly the
+	 * {@code [N]} markers in {@link #text}; for a clause-scoped fragment the text may contain earlier
+	 * markers while {@code citedIndexes} holds only the one citation the clause is attributed to — so
+	 * do NOT re-derive citedIndexes by re-parsing the text.
+	 */
 	static class Sentence {
 
 		final String text;
 
 		final java.util.Set<Integer> citedIndexes = new java.util.HashSet<Integer>();
 
+		/**
+		 * True when this is a clause split from a MULTI-citation sentence, so its citation must be
+		 * Tier-2 verified ALONE — not co-batched with the sentence's other citations, whose
+		 * overlapping clause-scoped statements would otherwise couple the (not per-pair-independent)
+		 * batched LLM verdict. False for a whole sentence: sentence-scope, or a single-citation
+		 * sentence under clause-scope.
+		 */
+		final boolean isolate;
+
 		Sentence(String text) {
+			this(text, java.util.Collections.<Integer> emptySet(), false);
+		}
+
+		/** Clause constructor: text, an explicit cited-index set, and whether the clause must be
+		 *  Tier-2 verified in isolation (used by clause-scoped splitting, where a clause's text may
+		 *  contain earlier markers but is attributed to one citation only). */
+		Sentence(String text, java.util.Set<Integer> citedIndexes, boolean isolate) {
 			this.text = text;
+			this.citedIndexes.addAll(citedIndexes);
+			this.isolate = isolate;
 		}
 
 		boolean cites(int index) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.chartsearchai.api.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -80,6 +81,11 @@ public class CitationGroundingVerifierTest {
 
 		int batches;
 
+		/** The statements passed to each {@code entailsBatch} invocation, in call order. Lets a test
+		 *  assert how citations are GROUPED into calls (e.g. that two citations of one compound
+		 *  sentence are not co-batched, which would let the LLM couple their verdicts). */
+		final List<List<String>> statementsPerCall = new ArrayList<List<String>>();
+
 		StubLlmProvider(Boolean verdict) {
 			this.verdict = verdict;
 		}
@@ -88,6 +94,7 @@ public class CitationGroundingVerifierTest {
 		public List<Boolean> entailsBatch(List<String> sources, List<String> statements) {
 			batches++;
 			calls += sources.size();
+			statementsPerCall.add(new ArrayList<String>(statements));
 			List<Boolean> out = new ArrayList<Boolean>();
 			for (int i = 0; i < sources.size(); i++) {
 				out.add(verdict);
@@ -414,5 +421,152 @@ public class CitationGroundingVerifierTest {
 		assertTrue(sentences.get(0).cites(1));
 		assertTrue(sentences.get(1).cites(2));
 		assertTrue(sentences.get(1).cites(3));
+	}
+
+	// ---- clause-scoped grounding ----
+
+	@Test
+	public void splitIntoClauseScopedSentences_cumulativePrefixAttributedToOneCitation() {
+		List<CitationGroundingVerifier.Sentence> clauses =
+				CitationGroundingVerifier.splitIntoClauseScopedSentences("A condition [1] and a diagnosis [2].");
+		assertEquals(2, clauses.size());
+		assertEquals("A condition [1]", clauses.get(0).text);
+		assertTrue(clauses.get(0).cites(1));
+		assertFalse(clauses.get(0).cites(2), "[1]'s clause must not be attributed to [2]");
+		// [2]'s clause is the cumulative prefix (keeps the subject) but is attributed to [2] only.
+		assertEquals("A condition [1] and a diagnosis [2]", clauses.get(1).text);
+		assertTrue(clauses.get(1).cites(2));
+		assertFalse(clauses.get(1).cites(1), "[2]'s clause cites only [2] though its text contains [1]");
+	}
+
+	@Test
+	public void splitIntoClauseScopedSentences_middleMarkerClauseStopsAtItsOwnMarker() {
+		// 3+ citations: the MIDDLE marker's clause is the cumulative prefix through ITS OWN marker —
+		// it keeps the earlier marker's text (so the subject/first claim is retained for entailment)
+		// but must STOP before the later marker, and be attributed to the middle index alone. The
+		// 2-citation case cannot catch a "clause runs past its own marker into the next clause" bug
+		// because its last marker has no following text to wrongly absorb.
+		List<CitationGroundingVerifier.Sentence> clauses =
+				CitationGroundingVerifier.splitIntoClauseScopedSentences(
+						"Has diabetes [1] and hypertension [2] and cancer [3].");
+		assertEquals(3, clauses.size());
+		assertEquals("Has diabetes [1]", clauses.get(0).text);
+		assertEquals("Has diabetes [1] and hypertension [2]", clauses.get(1).text);
+		assertEquals("Has diabetes [1] and hypertension [2] and cancer [3]", clauses.get(2).text);
+		// middle clause: cumulative prefix keeps [1]'s text, stops before the later [3], cites only [2].
+		assertTrue(clauses.get(1).cites(2));
+		assertFalse(clauses.get(1).cites(1), "middle clause keeps [1]'s text but is not attributed to [1]");
+		assertFalse(clauses.get(1).cites(3), "middle clause must stop before the later [3]");
+	}
+
+	@Test
+	public void splitIntoClauseScopedSentences_leavesSingleCitationSentencesUnchanged() {
+		List<CitationGroundingVerifier.Sentence> clauses =
+				CitationGroundingVerifier.splitIntoClauseScopedSentences("Patient has diabetes [1].");
+		assertEquals(1, clauses.size());
+		assertTrue(clauses.get(0).cites(1));
+	}
+
+	@Test
+	public void clauseScoped_groundsFirstCitationAgainstItsClauseNotTheCompoundSentence() {
+		// Compound sentence: [1]'s own clause matches its record, but the WHOLE sentence (which also
+		// makes a second, different claim cited by [2]) does not — the [89]/[91] scenario. Sentence-
+		// scope flags [1] not-grounded; clause-scope grounds it against its clause.
+		String answer = "Hearing loss is a condition [1] and a provisional diagnosis [2].";
+		embeddings.register(answer, AXIS_B);                       // whole sentence: orthogonal to record 1
+		embeddings.register("Hearing loss is a condition [1]", AXIS_A);  // [1]'s clause: aligned to record 1
+		embeddings.register("active condition hearing loss", AXIS_A);    // record 1
+		embeddings.register("provisional diagnosis hearing loss", AXIS_B);
+
+		List<RecordReference> refs = Arrays.asList(reference(1), reference(2));
+		List<RecordMapping> maps = Arrays.asList(
+				mapping(1, "active condition hearing loss"), mapping(2, "provisional diagnosis hearing loss"));
+
+		List<RecordReference> sentenceScoped = verifier.verify(answer,
+				new ArrayList<RecordReference>(refs), maps, FLOOR, TIER1_ONLY, false);
+		assertEquals(Boolean.FALSE, sentenceScoped.get(0).getGrounded(),
+				"sentence-scope: [1] vs the whole compound sentence -> not grounded");
+
+		List<RecordReference> clauseScoped = verifier.verify(answer,
+				new ArrayList<RecordReference>(refs), maps, FLOOR, TIER1_ONLY, true);
+		assertEquals(Boolean.TRUE, clauseScoped.get(0).getGrounded(),
+				"clause-scope: [1] vs its own clause -> grounded");
+	}
+
+	@Test
+	public void clauseScoped_singleCitationSentenceVerdictIsUnchanged() {
+		String answer = "Patient has diabetes [1].";
+		embeddings.register(answer, AXIS_A);
+		embeddings.register("type 2 diabetes mellitus", AXIS_A);
+		List<RecordReference> refs = Arrays.asList(reference(1));
+		List<RecordMapping> maps = Arrays.asList(mapping(1, "type 2 diabetes mellitus"));
+
+		Boolean sentence = verifier.verify(answer, new ArrayList<RecordReference>(refs), maps,
+				FLOOR, TIER1_ONLY, false).get(0).getGrounded();
+		Boolean clause = verifier.verify(answer, new ArrayList<RecordReference>(refs), maps,
+				FLOOR, TIER1_ONLY, true).get(0).getGrounded();
+		assertEquals(Boolean.TRUE, sentence);
+		assertEquals(sentence, clause, "single-citation sentence: clause-scope must not change the verdict");
+	}
+
+	@Test
+	public void clauseScoped_emptyLeadingClauseIsUngroundedNotCrash() {
+		// A compound sentence whose FIRST citation has no descriptive text before its marker yields an
+		// empty / marker-only clause "[1]". Clause-scope must handle it safely: [1]'s clause embeds to
+		// a zero vector -> cosine 0 (< floor) -> NOT grounded, never a NaN/crash and never spurious.
+		// (Tier-2's blank-statement skip is pinned separately in LlmProviderTest.entailsBatch_*.)
+		String answer = "[1] and hearing loss [2].";
+		embeddings.register("active condition", AXIS_A);       // record 1; its clause "[1]" is unregistered -> zero vector
+		embeddings.register("provisional diagnosis", AXIS_A);  // record 2
+		List<RecordReference> result = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2))),
+				Arrays.asList(mapping(1, "active condition"), mapping(2, "provisional diagnosis")),
+				FLOOR, TIER1_ONLY, true);
+		assertEquals(Boolean.FALSE, result.get(0).getGrounded(),
+				"empty leading clause -> cosine 0 -> safe under-ground, not a crash or spurious verdict");
+	}
+
+	@Test
+	public void clauseScoped_doesNotCoBatchTwoCitationsOfTheSameCompoundSentence() {
+		// The Tier-2 regression is a batch-COUPLING effect: when [1] and [2] of ONE compound sentence
+		// share an entailsBatch call, the LLM's verdict for one bleeds into the other (on the live
+		// model, shortening [1]'s clause flipped [2]'s verdict, 3/3). The fix judges each
+		// compound-sentence citation in its OWN entailment call, so [1] and [2] must NOT land in the
+		// same call; [3], the sole citation of a separate sentence, is unaffected and may stay batched.
+		// The real grounding effect needs the live LLM (verified by eval/grounding-scope/); a stub
+		// returns a fixed verdict regardless of co-batching, so here we pin the structural contract the
+		// stub CAN observe — the call grouping that the coupling depends on.
+		String answer = "A condition [1] and a diagnosis [2]. A separate finding [3].";
+		embeddings.register("A condition [1]", AXIS_A);
+		embeddings.register("A condition [1] and a diagnosis [2]", AXIS_A);
+		embeddings.register("A separate finding [3].", AXIS_A);
+		embeddings.register("rec1", AXIS_A);
+		embeddings.register("rec2", AXIS_A);
+		embeddings.register("rec3", AXIS_A);
+		llm.verdict = Boolean.TRUE;
+		List<RecordReference> refs = Arrays.asList(reference(1), reference(2), reference(3));
+		List<RecordMapping> maps = Arrays.asList(mapping(1, "rec1"), mapping(2, "rec2"), mapping(3, "rec3"));
+
+		verifier.verify(answer, new ArrayList<RecordReference>(refs), maps, FLOOR, TIER2_ON, true);
+
+		// Use the production marker-stripper to derive the exact statements the verifier emits.
+		String stmt1 = CitationGroundingVerifier.stripCitationMarkers("A condition [1]");
+		String stmt2 = CitationGroundingVerifier.stripCitationMarkers("A condition [1] and a diagnosis [2]");
+		int call1 = callIndexContaining(stmt1);
+		int call2 = callIndexContaining(stmt2);
+		assertTrue(call1 >= 0 && call2 >= 0, "both compound-sentence citations must be verified by Tier-2");
+		assertFalse(call1 == call2,
+				"[1] and [2] from the same compound sentence must be judged in separate entailment calls");
+	}
+
+	/** Index of the first {@code entailsBatch} call whose statement list contains {@code statement}
+	 *  exactly, or -1 — lets a test assert how citations were grouped into calls. */
+	private int callIndexContaining(String statement) {
+		for (int i = 0; i < llm.statementsPerCall.size(); i++) {
+			if (llm.statementsPerCall.get(i).contains(statement)) {
+				return i;
+			}
+		}
+		return -1;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
@@ -559,6 +559,48 @@ public class CitationGroundingVerifierTest {
 				"[1] and [2] from the same compound sentence must be judged in separate entailment calls");
 	}
 
+	@Test
+	public void clauseScoped_singleCitationSentencesStayInOneBatch() {
+		// The other half of the isolate/batch split: sentences that each cite ONE record are left
+		// unsplit (isolate=false), so under clause-scope they must all share the SINGLE batched Tier-2
+		// call — not fan out into one call apiece. This is the latency win (list-style answers pay no
+		// extra calls). A regression that isolated every citation would still ground them correctly but
+		// silently do N serial calls; only a call-count assertion catches that.
+		String answer = "Has diabetes [1]. Has hypertension [2]. Has asthma [3].";
+		embeddings.register("Has diabetes [1].", AXIS_A);
+		embeddings.register("Has hypertension [2].", AXIS_A);
+		embeddings.register("Has asthma [3].", AXIS_A);
+		embeddings.register("rec1", AXIS_A);
+		embeddings.register("rec2", AXIS_A);
+		embeddings.register("rec3", AXIS_A);
+		llm.verdict = Boolean.TRUE;
+		verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2), reference(3))),
+				Arrays.asList(mapping(1, "rec1"), mapping(2, "rec2"), mapping(3, "rec3")), FLOOR, TIER2_ON, true);
+		assertEquals(1, llm.batches, "single-citation sentences must share ONE batched call, not one per citation");
+		assertEquals(3, llm.calls, "all three single-citation pairs belong to that one batch");
+	}
+
+	@Test
+	public void clauseScoped_isolateCitationAppliesItsSinglePairTier2Verdict() {
+		// A compound sentence's citations are Tier-2'd in their own single-pair calls; prove that
+		// verdict is actually APPLIED and authoritative. Tier-1 passes (record aligned to its clause),
+		// but the single-pair entailment returns NO -> both must come back grounded=false. If the
+		// isolate verdict-assembly loop failed to assign, the verdict would wrongly stay Tier-1 (true).
+		String answer = "Has diabetes [1] and hypertension [2].";
+		embeddings.register("Has diabetes [1]", AXIS_A);                       // [1]'s clause
+		embeddings.register("Has diabetes [1] and hypertension [2]", AXIS_A);  // [2]'s clause (cumulative prefix)
+		embeddings.register("rec1", AXIS_A);
+		embeddings.register("rec2", AXIS_A);
+		llm.verdict = Boolean.FALSE; // Tier-2 says NO on each isolate single-pair call
+		List<RecordReference> out = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2))),
+				Arrays.asList(mapping(1, "rec1"), mapping(2, "rec2")), FLOOR, TIER2_ON, true);
+		assertEquals(Boolean.FALSE, out.get(0).getGrounded(), "[1]: isolate Tier-2 NO overrides the Tier-1 pass");
+		assertEquals(Boolean.FALSE, out.get(1).getGrounded(), "[2]: isolate Tier-2 NO overrides the Tier-1 pass");
+		assertEquals(2, llm.batches, "each compound-sentence citation is verified in its own single-pair call");
+	}
+
 	/** Index of the first {@code entailsBatch} call whose statement list contains {@code statement}
 	 *  exactly, or -1 — lets a test assert how citations were grouped into calls. */
 	private int callIndexContaining(String statement) {

--- a/eval/grounding-scope/grounding_scope_ab.py
+++ b/eval/grounding-scope/grounding_scope_ab.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Live grounding-scope A/B harness for chartsearchai (measure-first gate).
+
+Measures how citation grounding verdicts change between scoping modes on the
+RUNNING standalone, for a fixed (patient, query) set. This is the measurement
+gate for any change to CitationGroundingVerifier's sentence/clause scoping —
+it exercises the FULL production grounding path (real querystore retrieval, the
+real LLM answer, and the real batched Tier-2 entailment), which is essential
+because the clause-scoping regression is an emergent BATCH-COUPLING effect that
+no stubbed unit test can reproduce.
+
+For each (patient, query) case it runs POST /chartsearchai/search under each
+value of the `chartsearchai.grounding.clauseScoped` GP and records, per cited
+index, the grounded verdict. Sentence-scope (clauseScoped=false) is the SAFE
+baseline. Versus it:
+  * a True->False flip is a REGRESSION candidate (e.g. patient 165497e8
+    "any feeding problems?" cite [5], a provisional-diagnosis false negative);
+  * a False->True flip is a WIN candidate (e.g. "any ear problems?" cite [89]).
+
+The GP is saved before and restored after. Answers are grounding-independent,
+so a differing answer between modes signals LLM nondeterminism (reported).
+
+Usage:  python3 eval/grounding-scope/grounding_scope_ab.py
+Env:    BASE (default http://localhost:8081/openmrs/ws/rest/v1), OMRS_USER, OMRS_PASS.
+"""
+import base64
+import json
+import os
+import urllib.request
+
+BASE = os.environ.get("BASE", "http://localhost:8081/openmrs/ws/rest/v1")
+AUTH = base64.b64encode(
+    ("%s:%s" % (os.environ.get("OMRS_USER", "admin"),
+               os.environ.get("OMRS_PASS", "Admin123"))).encode()).decode()
+GP = "chartsearchai.grounding.clauseScoped"
+
+# (patient, question). 165497e8 = Sarah Taylor: malnutrition recorded as BOTH an
+# active condition AND a provisional primary diagnosis (the compound-sentence
+# shape clause-scoping targets), microstomia, etc.
+CASES = [
+    ("165497e8-13e0-4fa4-8190-8e6fa067c4b7", "any ear problems?"),
+    ("165497e8-13e0-4fa4-8190-8e6fa067c4b7", "any feeding problems?"),
+    ("165497e8-13e0-4fa4-8190-8e6fa067c4b7", "any nutritional problems?"),
+    ("165497e8-13e0-4fa4-8190-8e6fa067c4b7", "what are the patient's diagnoses?"),
+    ("165497e8-13e0-4fa4-8190-8e6fa067c4b7", "any mouth or swallowing problems?"),
+    ("165497e8-13e0-4fa4-8190-8e6fa067c4b7", "what active conditions does the patient have?"),
+]
+
+
+def req(path, data=None, method="GET"):
+    r = urllib.request.Request(
+        BASE + path,
+        data=(json.dumps(data).encode() if data is not None else None),
+        method=method)
+    r.add_header("Authorization", "Basic " + AUTH)
+    if data is not None:
+        r.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(r, timeout=300) as resp:
+        b = resp.read()
+        return json.loads(b) if b else {}
+
+
+def get_gp(name):
+    rows = req("/systemsetting?q=%s&v=full" % name).get("results", [])
+    return (rows[0]["uuid"], rows[0].get("value")) if rows else (None, None)
+
+
+def set_gp(name, value):
+    uuid, _ = get_gp(name)
+    if uuid:
+        req("/systemsetting/" + uuid, {"value": str(value)}, "POST")
+
+
+def search(patient, question):
+    d = req("/chartsearchai/search", {"patient": patient, "question": question}, "POST")
+    verdicts = {r.get("index"): r.get("grounded") for r in (d.get("references") or [])}
+    return (d.get("answer", "") or "").strip(), verdicts
+
+
+def run():
+    orig_uuid, orig = get_gp(GP)
+    print("harness BASE=%s  %s baseline value=%r\n" % (BASE, GP, orig))
+    regressions, wins = 0, 0
+    try:
+        for patient, q in CASES:
+            set_gp(GP, "false")
+            s_ans, s = search(patient, q)
+            set_gp(GP, "true")
+            c_ans, c = search(patient, q)
+            print("Q: %s" % q)
+            if s_ans != c_ans:
+                print("  !! answer differs between modes (LLM nondeterminism) — verdict A/B is confounded")
+            idxs = sorted(set(s) | set(c))
+            cells = []
+            for i in idxs:
+                tag = ""
+                if s.get(i) is True and c.get(i) is False:
+                    tag = "<REGRESSION"
+                    regressions += 1
+                elif s.get(i) is False and c.get(i) is True:
+                    tag = "<win"
+                    wins += 1
+                cells.append("[%s] sent=%s clause=%s %s" % (i, s.get(i), c.get(i), tag))
+            print("  " + ("\n  ".join(cells) if cells else "(no citations)"))
+            print("  answer: %s\n" % (c_ans[:160] + ("…" if len(c_ans) > 160 else "")))
+    finally:
+        if orig_uuid:
+            set_gp(GP, orig)
+            print("restored %s -> %r" % (GP, get_gp(GP)[1]))
+    print("\nTALLY across %d queries: clause-scope WINS=%d  REGRESSIONS=%d (vs sentence-scope safe baseline)"
+          % (len(CASES), wins, regressions))
+    print("GATE for a candidate scoping: must ground [89] on 'any ear problems?' AND produce ZERO")
+    print("True->False regressions across all cases (i.e. wins>=1 on the ear case, regressions==0).")
+
+
+if __name__ == "__main__":
+    run()

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -230,7 +230,13 @@
 	<globalProperty>
 		<property>chartsearchai.grounding.entailment.enabled</property>
 		<defaultValue>false</defaultValue>
-		<description>When true (and chartsearchai.grounding.enabled is also on), the Tier-1 cosine verdict is confirmed by a Tier-2 entailment check: a short yes/no LLM call asking whether the cited record actually supports the answer sentence. This catches high-overlap-but-false citations ("patient has X [5]" where record 5 says a relative had X, or the record negates X) that cosine similarity cannot separate. Costs one extra LLM call per cited reference (capped per answer), so it is a separate opt-in from the cheap Tier-1 pass. Default: false.</description>
+		<description>When true (and chartsearchai.grounding.enabled is also on), the Tier-1 cosine verdict is confirmed by a Tier-2 entailment check: a yes/no LLM judgement of whether the cited record actually supports the answer sentence. This catches high-overlap-but-false citations ("patient has X [5]" where record 5 says a relative had X, or the record negates X) that cosine similarity cannot separate. An answer's citations are verified in a batched LLM call (capped per answer; see chartsearchai.grounding.clauseScoped for when a compound sentence's citations are instead verified individually), so it is a separate opt-in from the cheap Tier-1 pass. Default: false.</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.grounding.clauseScoped</property>
+		<defaultValue>false</defaultValue>
+		<description>When true, citation grounding is clause-scoped: in a sentence that cites multiple records, each citation is checked against the answer text up to and including its own [N] marker, rather than the whole compound sentence. This grounds a citation that supports its own clause but not a later clause cited by a different record — e.g. "Hearing Loss was noted as a condition [89] and diagnosed as a provisional condition [91]", where [89] (an active condition) does not support the "provisional diagnosis" clause that [91] backs. The clause is the cumulative prefix through the marker, so it keeps the sentence subject when the subject precedes the first marker (the normal case) and still flags family-history/negation flips in later clauses. Default: false (sentence-scoped). Only affects which text a citation is verified against; never changes the answer or which records are cited.</description>
 	</globalProperty>
 
 	<!-- AOP -->


### PR DESCRIPTION
Re-lands the clause-scoping work approved as #38 but never reached `main`: #38 merged into the `batch-entailment-async-citations` branch, and #37's squash-merge to `main` (`f371619`) didn't carry #38's commits — so the feature was orphaned (GitHub shows #38 "merged," but `main` has none of it). Same content (`a53159e` + `9eec4f7`), rebased cleanly onto current `main`; the batch/async base is already here via #37.

## What
Opt-in clause-scoped citation grounding (`chartsearchai.grounding.clauseScoped`, default **false**). In a sentence citing multiple records, each citation is verified against the answer text up to and including its own `[N]` marker instead of the whole compound sentence — so a citation that backs its own clause but not a sibling clause still grounds (e.g. `[89]` in *"Hearing Loss was noted as a condition [89] and diagnosed as a provisional condition [91]"*).

## The batch-coupling fix (the important part)
Tier-2 entailment batches all citations into one LLM call, and that call is **not** per-pair independent — shortening one citation's clause statement flips a batch-mate's verdict even when the mate's own (source, statement) pair is byte-identical. Naively clause-scoping a compound sentence's citations therefore regressed a *correct* citation to not-grounded (reproduced deterministically on patient `165497e8` "any feeding problems?"). Fix: each compound-sentence citation is Tier-2 verified in its **own** single-pair call; everything else stays in the one shared batch, so list answers pay no latency cost.

## Evidence + tests
`eval/grounding-scope/grounding_scope_ab.py` (live A/B harness): clause-scope nets **+1 grounding win, 0 regressions**. `CitationGroundingVerifierTest` pins the split (first/middle/last-marker cumulative prefix, empty leading clause), the "compound-sentence citations are never co-batched" contract, single-cite-stays-batched, and isolate-verdict-applied. Suite green (CitationGroundingVerifier **26**, LlmProvider 43, LlmInferenceService 84). Default stays sentence-scoped.

Supersedes #38 (orphaned by the stacked-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
