### PR TITLE
Add a latency benchmark + SSE decomposition harness (eval/latency)

### DIFF
--- a/eval/latency/decompose.py
+++ b/eval/latency/decompose.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Latency decomposition for chartsearchai chart-search, via SSE event timing.
+
+Streams POST /chartsearchai/search/stream and timestamps each event to split total
+latency into phases:
+  - prefill   : t0 -> first output  (retrieval + chart serialize + prompt prefill + TTFT)
+  - reasoning : first 'thinking' -> last 'thinking'   (chain-of-thought generation)
+  - answer    : first 'token' -> last 'token'         (answer generation)
+  - grounding : 'references' event -> 'done' event    (Tier-2 batched entailment)
+Run across a citation-count range so grounding's scaling (vs the pre-#37 34s-at-16-cites
+pathology) is visible. Patient 165497e8 (large chart) is the worst case.
+
+Usage: python3 eval/latency/decompose.py
+"""
+import base64
+import json
+import time
+import urllib.request
+
+BASE = "http://localhost:8081/openmrs/ws/rest/v1"
+AUTH = base64.b64encode(b"admin:Admin123").decode()
+P = "165497e8-13e0-4fa4-8190-8e6fa067c4b7"
+QUERIES = [
+    "Is she pregnant?",
+    "any feeding problems?",
+    "what active conditions does the patient have?",
+    "what are the patient's diagnoses?",
+]
+
+
+def warmup():
+    try:
+        r = urllib.request.Request(BASE + "/chartsearchai/warmup",
+                                   data=json.dumps({"patient": P}).encode(), method="POST")
+        r.add_header("Authorization", "Basic " + AUTH); r.add_header("Content-Type", "application/json")
+        urllib.request.urlopen(r, timeout=180).read()
+    except Exception:
+        pass
+
+
+def decompose(q):
+    r = urllib.request.Request(BASE + "/chartsearchai/search/stream",
+                               data=json.dumps({"patient": P, "question": q}).encode(), method="POST")
+    r.add_header("Authorization", "Basic " + AUTH)
+    r.add_header("Content-Type", "application/json")
+    r.add_header("Accept", "text/event-stream")
+    t0 = time.time()
+    mark = {}  # event-type -> (first_t, last_t)
+    cur = None
+    refs = 0
+    with urllib.request.urlopen(r, timeout=300) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "replace").rstrip("\n")
+            if line.startswith("event:"):
+                cur = line[6:].strip()
+            elif line.startswith("data:"):
+                now = time.time() - t0
+                f, _ = mark.get(cur, (now, now))
+                mark[cur] = (f, now)
+                if cur == "done":
+                    try:
+                        refs = len(json.loads(line[5:].strip()).get("references") or [])
+                    except Exception:
+                        pass
+    return t0, mark, refs, time.time() - t0
+
+
+def span(mark, ev):
+    return mark.get(ev, (0, 0))
+
+
+warmup()
+time.sleep(2)
+print("patient 165497e8 | clauseScoped=false, grounding entailment on, preFilter off\n")
+print("%-46s %6s %8s %8s %8s %8s %6s" % ("query", "total", "prefill", "reason", "answer", "ground", "cites"))
+for q in QUERIES:
+    t0, mark, refs, total = decompose(q)
+    first_out = min((v[0] for v in mark.values()), default=0.0)
+    th0, th1 = span(mark, "thinking")
+    tk0, tk1 = span(mark, "token")
+    rf0, rf1 = span(mark, "references")
+    dn0, dn1 = span(mark, "done")
+    prefill = first_out
+    reasoning = (th1 - th0) if "thinking" in mark else 0.0
+    answer = (tk1 - tk0) if "token" in mark else 0.0
+    grounding = (dn1 - rf0) if ("references" in mark and "done" in mark) else 0.0
+    print("%-46s %5.1fs %7.1fs %7.1fs %7.1fs %7.1fs %6d"
+          % (q[:46], total, prefill, reasoning, answer, grounding, refs))
+    time.sleep(2.5)

--- a/eval/latency/latency_bench.py
+++ b/eval/latency/latency_bench.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""End-to-end latency benchmark for chartsearchai chart-search.
+
+Times the locked rubric — 4 OpenMRS reference-demo patients x 8 scope queries = 32 cells —
+against the live standalone's blocking POST /chartsearchai/search, and reports median / p95 /
+max with counts vs the ship bar (median <=3s, p99 <=5s).
+
+Production config assumed: querystore on, preFilter off (full-chart), grounding entailment on,
+clauseScoped off (the shipped default — set here, also undoing config drift). Each patient is
+warmed once (POST /warmup, as the UI does on chart open) so timings reflect the warm
+prompt-cache steady state. Requests are spaced to stay under the search endpoint's rate limit.
+
+Usage: python3 eval/latency/latency_bench.py
+"""
+import base64
+import json
+import statistics
+import time
+import urllib.request
+
+BASE = "http://localhost:8081/openmrs/ws/rest/v1"
+AUTH = base64.b64encode(b"admin:Admin123").decode()
+SPACING_S = 2.5
+BAR_MEDIAN_S = 3.0
+BAR_P99_S = 5.0
+
+PATIENTS = {
+    # Stock RefApp demo patients present on this standalone. (The drift-metric eval
+    # patients betty/richard/karen/mark live only in the preserve backup, not the
+    # stock demo DB, so they 404 here — use patients that actually exist.)
+    "susan-hall": "6fc3ccf9-54f5-45a1-bec3-6213b4968973",
+    "donna-roberts": "884a5281-c3d4-47d7-b451-65e54158f772",
+    "agnes-adams": "5a440752-e11d-4b2d-a9a5-c53ee0cab928",
+    "michelle-lewis": "e98b9e19-e5e9-4262-9a74-7c8bdbee6198",
+}
+QUERIES = [
+    "Is the patient enrolled in any programs?",
+    "Does the patient have any allergies?",
+    "What medications is the patient taking?",
+    "Does the patient have any eye problems?",
+    "Does the patient have any heart or cardiac problems?",
+    "Has the patient had any fractures or broken bones?",
+    "Does the patient have any kidney problems?",
+    "Does the patient have any mental health or psychiatric conditions?",
+]
+
+
+def req(path, data=None, method="GET"):
+    r = urllib.request.Request(BASE + path,
+                               data=(json.dumps(data).encode() if data is not None else None), method=method)
+    r.add_header("Authorization", "Basic " + AUTH)
+    if data is not None:
+        r.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(r, timeout=180) as resp:
+        b = resp.read()
+        return json.loads(b) if b else {}
+
+
+def set_gp(name, value):
+    rows = req("/systemsetting?q=%s&v=full" % name).get("results", [])
+    if rows:
+        req("/systemsetting/" + rows[0]["uuid"], {"value": str(value)}, "POST")
+
+
+def timed_search(uuid, q):
+    t = time.time()
+    d = req("/chartsearchai/search", {"patient": uuid, "question": q}, "POST")
+    return time.time() - t, len(d.get("references") or [])
+
+
+def pct(sorted_vals, p):
+    if not sorted_vals:
+        return 0.0
+    k = max(0, min(len(sorted_vals) - 1, int(round((p / 100.0) * len(sorted_vals) + 0.5)) - 1))
+    return sorted_vals[k]
+
+
+set_gp("chartsearchai.grounding.clauseScoped", "false")
+# Disable the per-user rate limit (chartsearchai.rateLimitPerMinute, default 10/min) for the run:
+# firing the whole rubric as a single user trips it (HTTP 429) and drops cells. Restored in the
+# finally below, so the standalone keeps its configured limit afterward.
+rl_rows = req("/systemsetting?q=chartsearchai.rateLimitPerMinute&v=full").get("results", [])
+orig_rl = rl_rows[0].get("value") if rl_rows else None
+set_gp("chartsearchai.rateLimitPerMinute", "0")
+print("config: clauseScoped=false, grounding entailment on, preFilter off, querystore on, "
+      "rate-limit disabled for run\n")
+
+results = []
+try:
+    for name, uuid in PATIENTS.items():
+        try:
+            req("/chartsearchai/warmup", {"patient": uuid}, "POST")
+        except Exception:
+            pass
+        time.sleep(SPACING_S)
+        for q in QUERIES:
+            try:
+                dt, nrefs = timed_search(uuid, q)
+                results.append(dt)
+                print("  %-8s %-52s %5.2fs  (%d cites)" % (name, q[:50], dt, nrefs))
+            except Exception as e:
+                print("  %-8s %-52s ERROR %s" % (name, q[:50], e))
+            time.sleep(SPACING_S)
+finally:
+    set_gp("chartsearchai.rateLimitPerMinute", orig_rl if orig_rl else "10")
+    print("\n(restored chartsearchai.rateLimitPerMinute=%s)" % (orig_rl if orig_rl else "10"))
+
+if not results:
+    raise SystemExit("no successful cells — check the standalone and patient UUIDs")
+lat = sorted(results)
+n = len(lat)
+median = statistics.median(lat)
+p95 = pct(lat, 95)
+worst = lat[-1]
+over3 = sum(1 for x in lat if x > BAR_MEDIAN_S)
+over5 = sum(1 for x in lat if x > BAR_P99_S)
+print("\n===== LATENCY (%d cells) =====" % n)
+print("  median=%.2fs  p95=%.2fs  max=%.2fs  min=%.2fs  mean=%.2fs" % (median, p95, worst, lat[0], statistics.mean(lat)))
+print("  cells > 3s: %d/%d   cells > 5s: %d/%d" % (over3, n, over5, n))
+print("  BAR: median<=%.0fs -> %s | p99(~max for n=%d)<=%.0fs -> %s"
+      % (BAR_MEDIAN_S, "PASS" if median <= BAR_MEDIAN_S else "FAIL", n, BAR_P99_S, "PASS" if worst <= BAR_P99_S else "FAIL"))


### PR DESCRIPTION
Adds a reusable latency harness under `eval/latency/`, used to verify the chart-search latency goal after the batch-grounding work (#37):

- **`latency_bench.py`** — times the rubric (demo patients × 8 scope queries) against blocking `/chartsearchai/search`; reports median / p95 / max vs the ship bar (median ≤3s, p99 ≤5s). Disables the per-user rate limit (`chartsearchai.rateLimitPerMinute`) for the run and restores it.
- **`decompose.py`** — splits one query into prefill / reasoning / answer / grounding via SSE event timing.

**Measured (post-#37, clauseScoped off):** median **2.95s PASS**; p99 **FAIL** (tail 8–13s on data-rich high-citation queries). Decomposition: prefill ~0.8s (flat), reasoning ~1–2s; answer-decode and grounding dominate the tail — grounding is batched by #37, so the old 34s-at-16-cites pathology is gone (that's what got the median under the bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
