### PR TITLE
Lazy Tier-1 grounding: skip cosine embeds where Tier-2 is authoritative

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -325,13 +325,16 @@ public class ChartSearchAiConstants {
 
 	/**
 	 * When {@code true} (and {@link #GP_GROUNDING_ENABLED} is also on), the
-	 * Tier-1 cosine verdict is confirmed by a Tier-2 entailment check: a short
-	 * yes/no LLM call asking whether the cited record actually supports the
-	 * answer sentence. This is what catches high-overlap-but-false citations
+	 * cited references are confirmed by a Tier-2 entailment check: a yes/no LLM
+	 * judgement of whether each cited record actually supports the answer
+	 * sentence citing it. This is what catches high-overlap-but-false citations
 	 * ("patient has X [5]" where record 5 says a relative had X, or the record
-	 * negates X) that cosine similarity cannot separate. Costs one extra LLM
-	 * call per cited reference, so it is a separate opt-in from the cheap
-	 * Tier-1 pass. Default {@code false}. See {@code CitationGroundingVerifier}.
+	 * negates X) that cosine similarity cannot separate. An answer's citations
+	 * are verified in one batched LLM call (capped per answer; clause-scoped
+	 * compound-sentence citations get single-pair calls), and the Tier-1 cosine
+	 * verdict is computed lazily only where Tier-2 yields none, so the marginal
+	 * cost is one LLM round-trip per answer. Still a separate opt-in from the
+	 * cheap Tier-1 pass. Default {@code false}. See {@code CitationGroundingVerifier}.
 	 */
 	public static final String GP_GROUNDING_ENTAILMENT_ENABLED = "chartsearchai.grounding.entailment.enabled";
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
@@ -39,7 +39,9 @@ import org.springframework.stereotype.Service;
  * semantic-overlap check: embed each cited record and the answer sentence(s)
  * that reference it, and require their cosine similarity to clear a tunable
  * floor ({@code chartsearchai.grounding.minCosine}). Below the floor, the
- * citation is annotated {@code grounded=false} so the UI can flag it.
+ * citation is annotated {@code grounded=false} so the UI can flag it. (When
+ * Tier-2 entailment is enabled, this cosine pass runs lazily — see "Lazy
+ * Tier-1 under entailment" below.)
  *
  * <p><strong>Scope and limits.</strong> This is intentionally an annotate-only,
  * non-destructive pass: it never rewrites the answer prose or drops citations,
@@ -249,7 +251,8 @@ public class CitationGroundingVerifier {
 		// unsupported, e.g. a family-history flip) is a Tier-1 pass, so confirming only failures
 		// would miss it.
 		//
-		// When entailment is enabled, Tier-1's cosine verdict is computed LAZILY (Pass 3): the
+		// When entailment is enabled, Tier-1's cosine verdict is computed LAZILY (the "Lazy
+		// Tier-1" block below, after the Tier-2 calls and before Pass 2): the
 		// authoritative Tier-2 verdict overrides it wherever Tier-2 reaches one, so the eager
 		// cosine work — a full embedding-model forward pass per record and per sentence, the
 		// dominant grounding cost on CPU-only servers — would be discarded for exactly the

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
@@ -62,6 +62,18 @@ import org.springframework.stereotype.Service;
  * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer;
  * references beyond the cap keep their Tier-1 verdict.
  *
+ * <p><strong>Lazy Tier-1 under entailment.</strong> Because the Tier-2 verdict overrides Tier-1
+ * wherever it lands, running the cosine pass eagerly for every reference would spend a full
+ * embedding-model forward pass per record and per sentence — the dominant grounding cost on
+ * CPU-only servers — on verdicts that are then discarded. So when entailment is enabled, Tier-1
+ * embeds run only where they still decide something: choosing the claim sentence when more than
+ * one candidate cites the record (the statement must be the cosine-best match, identical to the
+ * eager path), and supplying the fallback verdict for references whose Tier-2 check produced none
+ * (cap overflow, engine failure) — computed lazily, after Tier-2. A list-style answer where each
+ * line cites its own record runs no Tier-1 embeds at all. A consequence pinned in tests: a
+ * broken or absent Tier-1 embedding model no longer blocks Tier-2 verdicts for unambiguous
+ * claim sentences — previously it silently downgraded every citation to "unverified".
+ *
  * <p>The verifier never throws into the search path: any failure (embedding
  * error, missing text) degrades to a {@code null} verdict — "could not verify"
  * — which renders as unverified, exactly as if grounding were disabled.
@@ -188,14 +200,16 @@ public class CitationGroundingVerifier {
 	 * {@code chartsearchai.grounding.entailment.enabled}. Package-private so unit
 	 * tests can exercise the grounding logic without an OpenMRS context.
 	 *
-	 * <p>When {@code entailmentEnabled}, every reference Tier-1 could evaluate is
-	 * confirmed by a Tier-2 LLM entailment verdict that is authoritative
+	 * <p>When {@code entailmentEnabled}, every reference with a resolvable claim sentence and
+	 * record text is confirmed by a Tier-2 LLM entailment verdict that is authoritative
 	 * (cosine errs in both directions, and the dangerous error — a high-overlap
 	 * but unsupported citation — is exactly the case Tier-1 cannot self-detect,
 	 * so the LLM must see Tier-1 passes too, not only failures). They are confirmed in a batched
 	 * call ({@link LlmProvider#entailsBatch}), capped at
 	 * {@link ChartSearchAiConstants#GROUNDING_ENTAILMENT_MAX_CHECKS} pairs per answer; references
 	 * beyond the cap keep their Tier-1 verdict (but see the clause-scoped exception below).
+	 * Tier-1's own cosine verdict is computed lazily in this mode — see the class javadoc's
+	 * "Lazy Tier-1 under entailment" section.
 	 *
 	 * <p>When {@code clauseScoped}, a sentence citing multiple records is split so each citation is
 	 * checked against the answer text up to and including its own {@code [N]} marker, not the whole
@@ -229,10 +243,20 @@ public class CitationGroundingVerifier {
 		Map<Integer, float[]> sentenceVectors = new HashMap<Integer, float[]>();
 		GroundingStats stats = new GroundingStats();
 
-		// Pass 1: Tier-1 (cosine) for every reference, collecting the claim/record pairs Tier-2
-		// should confirm — up to the per-answer cap. Tier-2 runs on Tier-1 passes AND failures:
-		// the dangerous case (high cosine but unsupported, e.g. a family-history flip) is a Tier-1
-		// pass, so confirming only failures would miss it.
+		// Pass 1: claim selection (and, where still needed, Tier-1 cosine) for every reference,
+		// collecting the claim/record pairs Tier-2 should confirm — up to the per-answer cap.
+		// Tier-2 runs on Tier-1 passes AND failures: the dangerous case (high cosine but
+		// unsupported, e.g. a family-history flip) is a Tier-1 pass, so confirming only failures
+		// would miss it.
+		//
+		// When entailment is enabled, Tier-1's cosine verdict is computed LAZILY (Pass 3): the
+		// authoritative Tier-2 verdict overrides it wherever Tier-2 reaches one, so the eager
+		// cosine work — a full embedding-model forward pass per record and per sentence, the
+		// dominant grounding cost on CPU-only servers — would be discarded for exactly the
+		// references it ran for. Eager Tier-1 here is needed only to CHOOSE the claim sentence
+		// when the choice is ambiguous (more than one candidate); the common list-answer case
+		// (every citation has exactly one citing sentence) selects deterministically and runs
+		// no embeds at all.
 		int entailmentBudget = ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS;
 		int cappedCount = 0;
 		Tier1Result[] tier1Results = new Tier1Result[references.size()];
@@ -249,12 +273,17 @@ public class CitationGroundingVerifier {
 		List<String> isolateStatements = new ArrayList<String>();
 		for (int i = 0; i < references.size(); i++) {
 			RecordReference reference = references.get(i);
-			Tier1Result tier1 = verdictTier1(reference.getIndex(), textByIndex, sentences,
-					floor, recordVectors, sentenceVectors, embedder, stats);
+			Tier1Result tier1 = entailmentEnabled
+					? selectClaim(reference.getIndex(), textByIndex, sentences,
+							floor, recordVectors, sentenceVectors, embedder, stats)
+					: verdictTier1(reference.getIndex(), textByIndex, sentences,
+							floor, recordVectors, sentenceVectors, embedder, stats);
 			tier1Results[i] = tier1;
-			// Tier-2 candidate: only meaningful when Tier-1 reached a definite verdict and we have
-			// a concrete claim sentence to fact-check against the record.
-			if (entailmentEnabled && tier1.verdict != null && tier1.bestSentence != null
+			// Tier-2 candidate: needs a concrete claim sentence to fact-check against the record.
+			// Candidacy deliberately does NOT require a Tier-1 verdict: for an unambiguous claim
+			// sentence the verdict is deferred (and may never be needed), and a broken Tier-1
+			// embedder must not block the authoritative Tier-2 check it has no part in.
+			if (entailmentEnabled && tier1.bestSentence != null
 					&& tier1.recordText != null) {
 				if (entailmentBudget > 0) {
 					entailmentBudget--;
@@ -296,6 +325,17 @@ public class CitationGroundingVerifier {
 					? verdict.get(0) : null;
 		}
 
+		// Lazy Tier-1: references whose cosine verdict was deferred at claim-selection time get it
+		// computed now, but ONLY where Tier-2 did not reach a verdict (cap overflow, engine failure,
+		// unparseable reply) — everywhere else the eager cosine would have been overridden and its
+		// embedding cost (the dominant grounding cost on CPU) wasted.
+		for (int i = 0; i < references.size(); i++) {
+			if (tier2Verdict[i] == null && tier1Results[i].deferred) {
+				tier1Results[i] = cosineVerdict(tier1Results[i], floor, references.get(i).getIndex(),
+						sentences, recordVectors, sentenceVectors, embedder, stats);
+			}
+		}
+
 		// Pass 2: assemble — Tier-2 is authoritative when it reached a verdict, else keep Tier-1.
 		List<RecordReference> annotated = new ArrayList<RecordReference>(references.size());
 		for (int i = 0; i < references.size(); i++) {
@@ -321,6 +361,94 @@ public class CitationGroundingVerifier {
 					stats.embedFailures, references.size(), stats.firstError);
 		}
 		return annotated;
+	}
+
+	/**
+	 * Claim selection for entailment-enabled grounding: identifies the claim sentence Tier-2 will
+	 * fact-check for one cited index, running Tier-1 embeds ONLY when the choice is ambiguous.
+	 * The common case — exactly one candidate sentence (a list-style answer where each line cites
+	 * its own record, or a clause under clause-scope) — selects deterministically with no
+	 * embedding work, and the cosine verdict is DEFERRED ({@link Tier1Result#deferred}): it is
+	 * computed lazily by {@link #cosineVerdict} only if Tier-2 fails to produce a verdict.
+	 * With several candidates the eager cosine argmax runs exactly as {@link #verdictTier1}
+	 * would, so the chosen statement is byte-identical to the eager path's; the verdict then
+	 * comes for free and is not deferred. Never throws: a selection-embedding failure yields a
+	 * {@code null}-verdict, no-claim result (no Tier-2 candidate), mirroring the eager path.
+	 */
+	private Tier1Result selectClaim(int index, Map<Integer, String> textByIndex,
+			List<Sentence> sentences, double floor,
+			Map<Integer, float[]> recordVectors, Map<Integer, float[]> sentenceVectors,
+			TextEmbedder embedder, GroundingStats stats) {
+		String recordText = textByIndex.get(index);
+		if (recordText == null || recordText.trim().isEmpty()) {
+			return new Tier1Result(null, null, null, false); // nothing to compare against
+		}
+		// Candidate claim sentences: the ones citing this index inline; when none does
+		// (citations-array-only), every sentence is a candidate — same fallback as the
+		// eager path, so the selected statement cannot differ from it.
+		List<Integer> candidates = new ArrayList<Integer>();
+		for (int s = 0; s < sentences.size(); s++) {
+			if (sentences.get(s).cites(index)) {
+				candidates.add(Integer.valueOf(s));
+			}
+		}
+		if (candidates.isEmpty()) {
+			for (int s = 0; s < sentences.size(); s++) {
+				candidates.add(Integer.valueOf(s));
+			}
+		}
+		if (candidates.isEmpty()) {
+			return new Tier1Result(null, null, recordText, false); // no sentences (empty answer)
+		}
+		if (candidates.size() == 1) {
+			int only = candidates.get(0).intValue();
+			Sentence claim = sentences.get(only);
+			return new Tier1Result(null, claim.text, recordText, claim.isolate, only, true);
+		}
+		try {
+			float[] recordVector = embedRecord(index, recordText, recordVectors, embedder);
+			double best = -Double.MAX_VALUE;
+			int bestIdx = -1;
+			for (Integer candidate : candidates) {
+				int s = candidate.intValue();
+				double sim = similarity(recordVector, s, sentences, sentenceVectors, embedder);
+				if (sim > best) {
+					best = sim;
+					bestIdx = s;
+				}
+			}
+			Sentence claim = sentences.get(bestIdx);
+			return new Tier1Result(Boolean.valueOf(best >= floor), claim.text, recordText,
+					claim.isolate, bestIdx, false);
+		}
+		catch (RuntimeException e) {
+			stats.recordFailure(e);
+			return new Tier1Result(null, null, recordText, false);
+		}
+	}
+
+	/**
+	 * Lazily computes the deferred Tier-1 cosine verdict for a reference whose Tier-2 check
+	 * produced no verdict (cap overflow, engine failure, unparseable reply). Reuses the per-call
+	 * record/sentence vector caches, so the work and the result are exactly what the eager path
+	 * would have produced for the same (record, claim sentence) pair. Never throws: an embedding
+	 * failure degrades to a {@code null} ("could not verify") verdict.
+	 */
+	private Tier1Result cosineVerdict(Tier1Result selected, double floor, int index,
+			List<Sentence> sentences, Map<Integer, float[]> recordVectors,
+			Map<Integer, float[]> sentenceVectors, TextEmbedder embedder, GroundingStats stats) {
+		try {
+			float[] recordVector = embedRecord(index, selected.recordText, recordVectors, embedder);
+			double sim = similarity(recordVector, selected.bestSentenceIdx, sentences,
+					sentenceVectors, embedder);
+			return new Tier1Result(Boolean.valueOf(sim >= floor), selected.bestSentence,
+					selected.recordText, selected.isolate, selected.bestSentenceIdx, false);
+		}
+		catch (RuntimeException e) {
+			stats.recordFailure(e);
+			return new Tier1Result(null, selected.bestSentence, selected.recordText,
+					selected.isolate, selected.bestSentenceIdx, false);
+		}
 	}
 
 	/**
@@ -429,11 +557,27 @@ public class CitationGroundingVerifier {
 		 *  clause-scope, so it must be Tier-2 verified in its own call rather than co-batched. */
 		final boolean isolate;
 
+		/** Index of {@link #bestSentence} in the verify-call's sentence list, or -1 when there is
+		 *  none — lets the lazy cosine pass reuse the per-call sentence-vector cache. */
+		final int bestSentenceIdx;
+
+		/** True when the Tier-1 cosine verdict was deferred at claim-selection time (entailment
+		 *  mode, unambiguous claim sentence) and must be computed lazily by
+		 *  {@link #cosineVerdict} if Tier-2 yields no verdict for the reference. */
+		final boolean deferred;
+
 		Tier1Result(Boolean verdict, String bestSentence, String recordText, boolean isolate) {
+			this(verdict, bestSentence, recordText, isolate, -1, false);
+		}
+
+		Tier1Result(Boolean verdict, String bestSentence, String recordText, boolean isolate,
+				int bestSentenceIdx, boolean deferred) {
 			this.verdict = verdict;
 			this.bestSentence = bestSentence;
 			this.recordText = recordText;
 			this.isolate = isolate;
+			this.bestSentenceIdx = bestSentenceIdx;
+			this.deferred = deferred;
 		}
 	}
 

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
@@ -51,12 +51,16 @@ public class CitationGroundingVerifierTest {
 
 		private final Map<String, float[]> vectors = new HashMap<String, float[]>();
 
+		/** Number of embed() invocations — lets tests pin how much Tier-1 embedding work ran. */
+		int embedCalls;
+
 		void register(String text, float[] vector) {
 			vectors.put(text, vector);
 		}
 
 		@Override
 		public float[] embed(String text) {
+			embedCalls++;
 			float[] v = vectors.get(text);
 			return v != null ? v : new float[] { 0f, 0f };
 		}
@@ -599,6 +603,114 @@ public class CitationGroundingVerifierTest {
 		assertEquals(Boolean.FALSE, out.get(0).getGrounded(), "[1]: isolate Tier-2 NO overrides the Tier-1 pass");
 		assertEquals(Boolean.FALSE, out.get(1).getGrounded(), "[2]: isolate Tier-2 NO overrides the Tier-1 pass");
 		assertEquals(2, llm.batches, "each compound-sentence citation is verified in its own single-pair call");
+	}
+
+	// ---- Lazy Tier-1: no embedding work when Tier-2 is authoritative and the claim
+	// sentence is unambiguous (CPU-latency fix for the grounding tail) ----
+
+	@Test
+	public void tier2_singleCitingSentences_runNoTier1EmbedsWhenTier2Succeeds() {
+		// THE grounding-tail latency fix: a list-style answer where every citation has exactly one
+		// citing sentence needs no Tier-1 cosine at all — the claim statement is that sentence by
+		// definition (argmax over a single candidate), and Tier-2's verdict overrides Tier-1 anyway.
+		// On a CPU-only server each embed is a full BERT forward pass (~0.3-1s on e5-base), and a
+		// 9-citation answer was paying ~14-18 of them per query for verdicts that were then
+		// discarded. Statements must remain byte-identical to the eager path.
+		String answer = "Has diabetes [1]. Has hypertension [2].";
+		llm.verdict = Boolean.TRUE;
+
+		List<RecordReference> result = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2))),
+				Arrays.asList(mapping(1, "type 2 diabetes"), mapping(2, "essential hypertension")),
+				FLOOR, TIER2_ON);
+
+		assertEquals(0, embeddings.embedCalls,
+				"single-citing-sentence citations must not embed when Tier-2 yields verdicts");
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded());
+		assertEquals(Boolean.TRUE, result.get(1).getGrounded());
+		assertEquals(1, llm.batches, "still one batched Tier-2 call");
+		assertEquals(Arrays.asList("Has diabetes .", "Has hypertension ."),
+				llm.statementsPerCall.get(0),
+				"Tier-2 statements must be the stripped citing sentences, unchanged by laziness");
+	}
+
+	@Test
+	public void tier2_brokenEmbedder_singleCitingSentenceStillGetsTier2Verdict() {
+		// Deliberate behavior improvement pinned as spec: Tier-2 candidacy for an unambiguous
+		// claim sentence no longer depends on the Tier-1 embedder being healthy. Previously a
+		// broken/absent embedding model silently downgraded ALL grounding to "unverified" even
+		// though the authoritative Tier-2 LLM was available; now the LLM verdict still lands.
+		EmbeddingProvider throwing = new EmbeddingProvider() {
+
+			@Override
+			public float[] embed(String text) {
+				throw new RuntimeException("ONNX session unavailable");
+			}
+
+			@Override
+			public int getDimensions() {
+				return 2;
+			}
+		};
+		verifier.setEmbeddingProvider(throwing);
+		llm.verdict = Boolean.FALSE;
+
+		List<RecordReference> result = verifier.verify("Patient has cancer [3].",
+				new ArrayList<RecordReference>(Arrays.asList(reference(3))),
+				Arrays.asList(mapping(3, "grandmother had cancer")), FLOOR, TIER2_ON);
+
+		assertEquals(Boolean.FALSE, result.get(0).getGrounded(),
+				"Tier-2 verdict must land even when the Tier-1 embedder is broken");
+	}
+
+	@Test
+	public void tier2_multiCitingSentences_bestStatementStillChosenByCosine() {
+		// When MORE than one sentence cites the same record, the claim statement is still the
+		// best-matching sentence by cosine — the selection embeds must still run so the Tier-2
+		// statement is identical to the eager path's choice.
+		String answer = "An unrelated remark [1]. Type 2 diabetes is active [1].";
+		embeddings.register("An unrelated remark [1].", AXIS_B);
+		embeddings.register("Type 2 diabetes is active [1].", AXIS_A);
+		embeddings.register("type 2 diabetes", AXIS_A);
+		llm.verdict = Boolean.TRUE;
+
+		verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, "type 2 diabetes")), FLOOR, TIER2_ON);
+
+		assertTrue(embeddings.embedCalls > 0,
+				"ambiguous claim selection still requires Tier-1 embeds");
+		assertEquals(Arrays.asList("Type 2 diabetes is active ."), llm.statementsPerCall.get(0),
+				"the cosine-best citing sentence must be the Tier-2 statement");
+	}
+
+	@Test
+	public void tier2_batchFailure_lazyTier1VerdictMatchesEagerCosine() {
+		// When Tier-2 cannot verify (engine failure), the Tier-1 cosine verdict must be computed
+		// lazily and match what the eager path would have produced: registered on-topic pair ->
+		// TRUE, unregistered pair (cosine 0) -> FALSE.
+		StubLlmProvider throwing = new StubLlmProvider(null) {
+
+			@Override
+			public List<Boolean> entailsBatch(List<String> sources, List<String> statements) {
+				throw new RuntimeException("llama-server timed out");
+			}
+		};
+		verifier.setLlmProvider(throwing);
+		String answer = "Has diabetes [1]. Has asthma [2].";
+		embeddings.register("Has diabetes [1].", AXIS_A);
+		embeddings.register("type 2 diabetes", AXIS_A); // [1] on-topic -> TRUE
+		// [2]'s sentence and record left unregistered -> cosine 0 -> FALSE
+
+		List<RecordReference> result = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2))),
+				Arrays.asList(mapping(1, "type 2 diabetes"), mapping(2, "mild asthma")),
+				FLOOR, TIER2_ON);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(),
+				"lazy Tier-1 fallback must reproduce the eager cosine pass");
+		assertEquals(Boolean.FALSE, result.get(1).getGrounded(),
+				"lazy Tier-1 fallback must reproduce the eager cosine fail");
 	}
 
 	/** Index of the first {@code entailsBatch} call whose statement list contains {@code statement}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
@@ -664,6 +664,53 @@ public class CitationGroundingVerifierTest {
 	}
 
 	@Test
+	public void tier2_absentEmbedder_singleCitingSentenceStillGetsTier2Verdict() {
+		// The "absent" half of the broken-or-absent claim: a deployment with NO Tier-1 embedding
+		// model configured at all (e.g. lucene-only querystore, no ONNX files) must still get
+		// authoritative Tier-2 verdicts for unambiguous claim sentences. resolveEmbedder() returns
+		// null in that deployment shape; the lazy path must never touch it when Tier-2 succeeds.
+		verifier.setEmbeddingProvider(null);
+		llm.verdict = Boolean.TRUE;
+
+		List<RecordReference> result = verifier.verify("Has hypertension [1].",
+				new ArrayList<RecordReference>(Arrays.asList(reference(1))),
+				Arrays.asList(mapping(1, "essential hypertension")), FLOOR, TIER2_ON);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(),
+				"Tier-2 verdict must land even with no Tier-1 embedding model configured");
+	}
+
+	@Test
+	public void clauseScoped_isolateCitations_fallBackToLazyTier1OnEngineFailure() {
+		// The deferred x isolate combination: clause-scoped compound-sentence citations are
+		// single-candidate clauses (deferred), verified in isolate single-pair Tier-2 calls. When
+		// the engine fails, each must lazily get the Tier-1 cosine verdict of its OWN clause —
+		// [1]'s registered clause/record pair -> TRUE, [2]'s unregistered pair -> FALSE.
+		StubLlmProvider throwing = new StubLlmProvider(null) {
+
+			@Override
+			public List<Boolean> entailsBatch(List<String> sources, List<String> statements) {
+				throw new RuntimeException("llama-server timed out");
+			}
+		};
+		verifier.setLlmProvider(throwing);
+		String answer = "Has diabetes [1] and hypertension [2].";
+		embeddings.register("Has diabetes [1]", AXIS_A);   // [1]'s clause (cumulative prefix)
+		embeddings.register("type 2 diabetes", AXIS_A);    // [1]'s record -> cosine 1 -> TRUE
+		// [2]'s clause "Has diabetes [1] and hypertension [2]" and record left unregistered -> FALSE
+
+		List<RecordReference> result = verifier.verify(answer,
+				new ArrayList<RecordReference>(Arrays.asList(reference(1), reference(2))),
+				Arrays.asList(mapping(1, "type 2 diabetes"), mapping(2, "essential hypertension")),
+				FLOOR, TIER2_ON, true);
+
+		assertEquals(Boolean.TRUE, result.get(0).getGrounded(),
+				"[1]: lazy Tier-1 must score the clause's own registered pair");
+		assertEquals(Boolean.FALSE, result.get(1).getGrounded(),
+				"[2]: lazy Tier-1 must score the clause's own unregistered pair");
+	}
+
+	@Test
 	public void tier2_multiCitingSentences_bestStatementStillChosenByCosine() {
 		// When MORE than one sentence cites the same record, the claim statement is still the
 		// best-matching sentence by cosine — the selection embeds must still run so the Tier-2

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -230,7 +230,7 @@
 	<globalProperty>
 		<property>chartsearchai.grounding.entailment.enabled</property>
 		<defaultValue>false</defaultValue>
-		<description>When true (and chartsearchai.grounding.enabled is also on), the Tier-1 cosine verdict is confirmed by a Tier-2 entailment check: a yes/no LLM judgement of whether the cited record actually supports the answer sentence. This catches high-overlap-but-false citations ("patient has X [5]" where record 5 says a relative had X, or the record negates X) that cosine similarity cannot separate. An answer's citations are verified in a batched LLM call (capped per answer; see chartsearchai.grounding.clauseScoped for when a compound sentence's citations are instead verified individually), so it is a separate opt-in from the cheap Tier-1 pass. Default: false.</description>
+		<description>When true (and chartsearchai.grounding.enabled is also on), every cited record is confirmed by a Tier-2 entailment check: a yes/no LLM judgement of whether the record actually supports the answer sentence citing it. This catches high-overlap-but-false citations ("patient has X [5]" where record 5 says a relative had X, or the record negates X) that cosine similarity cannot separate. An answer's citations are verified in a batched LLM call (capped per answer; see chartsearchai.grounding.clauseScoped for when a compound sentence's citations are instead verified individually). The Tier-1 cosine pass is computed lazily in this mode — only for citations where the LLM check produced no verdict — so entailment grounding works even when no Tier-1 embedding model is configured. Default: false.</description>
 	</globalProperty>
 
 	<globalProperty>


### PR DESCRIPTION
## Summary

On CPU-only servers (like the chartsearchai.openmrs.org demo) the citation-grounding tail was the largest optimizable chunk of warm query latency — measured 6.7–15.1s per cited answer on the demo (~1.3s/citation), 4–14s locally under forced `-ngl 0`. Roughly half of that tail was Tier-1 cosine work: a full e5-base forward pass per cited record and per answer sentence (~14–18 passes for a 9-citation answer) producing verdicts that the authoritative Tier-2 entailment verdict then overrides for every reference it reaches.

With entailment enabled, Tier-1 now runs only where it still decides something:

- **Claim selection** embeds only when more than one sentence cites the record; the statement stays byte-identical to the eager path's cosine-best choice. The common list-answer case (each line cites its own record) selects deterministically with zero embedding work.
- **The Tier-1 fallback verdict** is computed lazily, after Tier-2, only for references whose Tier-2 check produced no verdict (cap overflow, engine failure) — same vectors, same floor, same result as the eager pass.

Tier-2 candidacy no longer requires a Tier-1 verdict, so a broken or **absent** Tier-1 embedding model no longer silently downgrades every citation to "unverified" when the LLM check is available (pinned as spec in tests). Entailment-disabled deployments keep the eager path untouched.

## Measured

CPU-only (`-ngl 0`) standalone, Gemma 4 E2B, 267-record demo patient: grounding tail **4.0s → 1.4s** on the matching 8-citation cell — the tail now equals just the Tier-2 LLM call. Verdicts agreed on all common citations across before/after captures; the one differing cell had a different model-written claim sentence (pre-existing `cache_prompt` greedy nondeterminism — grounding runs after answer generation and cannot influence it).

## Tests

TDD: the embed-count and broken-embedder tests fail on the pre-change code. 32/32 `CitationGroundingVerifierTest` (6 new: zero-embeds + byte-identical statements, broken embedder, absent embedder, lazy-fallback equivalence, multi-candidate selection equivalence, clause-scoped isolate fallback), ArchitectureGuardTest, LlmInferenceServiceTest/LlmProviderTest/LlmProviderEntailmentTest, omod suite 35/35, packaging verified. Hardened over three review rounds including an unbriefed adversarial pass; docs (constants javadoc, config.xml GP description, class javadoc) updated to match lazy semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)