### PR TITLE
Async grounding: emit done before the Tier-2 tail, verdicts in a trailing grounded event

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,8 +468,11 @@ SSE events:
 
 | Event | Description |
 |-------|-------------|
+| `thinking` | A chunk of the model's reasoning, emitted before the answer; render distinctly (e.g. a collapsible panel), never as the answer |
 | `token` | A chunk of the answer text as it is generated |
-| `done` | Final JSON with the complete answer, references (sorted most recent first, with `index`, `resourceType`, `resourceUuid`, `date`), `questionId`, and disclaimer |
+| `references` | The answer's citations the moment the answer is complete — before grounding verdicts exist; render as unverified until verdicts arrive |
+| `done` | Final JSON with the complete answer, references (sorted most recent first, with `index`, `resourceType`, `resourceUuid`, `date`, `grounded`), `questionId`, and disclaimer. With `chartsearchai.grounding.async=true`, `done` is emitted as soon as the answer is complete and its references carry no verdicts yet |
+| `grounded` | Only with `chartsearchai.grounding.async=true`: the references re-sent with their grounding verdicts (`grounded` true/false/null) once Tier-2 verification completes, with the same `questionId`. Keep consuming the stream after `done` to receive it |
 | `error` | Error message if something goes wrong |
 
 ### Warmup

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -360,6 +360,21 @@ public class ChartSearchAiConstants {
 	 */
 	public static final int GROUNDING_ENTAILMENT_MAX_CHECKS = 16;
 
+	/**
+	 * When {@code true} (and {@link #GP_GROUNDING_ENABLED} is also on), the streaming endpoint
+	 * emits its terminal {@code done} event as soon as the answer is complete — references
+	 * without verdicts — and delivers the grounding verdicts afterwards in a trailing
+	 * {@code grounded} SSE event. On CPU-only deployments the grounding pass adds seconds of
+	 * Tier-2 LLM work after the answer is already readable; this moves that tail off the user's
+	 * perceived completion. Clients must keep consuming the stream after {@code done} and apply
+	 * the {@code grounded} event's verdicts when it arrives (citations render as unverified until
+	 * then). The blocking {@code /search} endpoint is unaffected — its single response always
+	 * carries final verdicts. Default {@code false} (classic single grounded {@code done}).
+	 */
+	public static final String GP_GROUNDING_ASYNC = "chartsearchai.grounding.async";
+
+	public static final boolean DEFAULT_GROUNDING_ASYNC = false;
+
 	// Resource type identifiers used in embeddings and citations
 	public static final String RESOURCE_TYPE_OBS = "obs";
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
@@ -544,6 +544,25 @@ public class ChartSearchAiUtils {
 	}
 
 	/**
+	 * @return true when async grounding is enabled via
+	 *         {@link ChartSearchAiConstants#GP_GROUNDING_ASYNC} — the streaming endpoint then
+	 *         emits {@code done} before the grounding pass and delivers verdicts in a trailing
+	 *         {@code grounded} event. Fails safe to {@code false} (classic single grounded
+	 *         {@code done}) when no admin service is available.
+	 */
+	public static boolean isGroundingAsyncEnabled() {
+		try {
+			String value = org.openmrs.api.context.Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_GROUNDING_ASYNC,
+							String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_ASYNC));
+			return "true".equalsIgnoreCase(value.trim());
+		}
+		catch (RuntimeException e) {
+			return ChartSearchAiConstants.DEFAULT_GROUNDING_ASYNC;
+		}
+	}
+
+	/**
 	 * @return the cosine floor below which a citation is treated as ungrounded,
 	 *         read from {@link ChartSearchAiConstants#GP_GROUNDING_MIN_COSINE},
 	 *         falling back to {@link ChartSearchAiConstants#DEFAULT_GROUNDING_MIN_COSINE}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -80,6 +80,41 @@ public interface ChartSearchService {
 	}
 
 	/**
+	 * Streaming variant that additionally hands the caller the <em>complete but not yet
+	 * grounding-verified</em> answer the moment it exists, via {@code ungroundedAnswerConsumer} —
+	 * the seam that lets the REST layer finish the user-visible response (emit its {@code done}
+	 * event, persist the audit row) without waiting out the citation-grounding tail, which on
+	 * CPU-only deployments adds seconds of Tier-2 LLM work after the answer is already readable.
+	 *
+	 * <p>The consumer contract:</p>
+	 * <ul>
+	 *   <li>It fires at most ONCE, after the answer and its citation references are final but
+	 *       before grounding verification runs; the references it carries have {@code null}
+	 *       verdicts.</li>
+	 *   <li>It fires on the live inference path regardless of whether grounding is enabled —
+	 *       its meaning is "the answer is complete", not "grounding will follow".</li>
+	 *   <li>It does NOT fire when the implementation returns an answer that is already final —
+	 *       e.g. a cached answer, whose verdicts were attached when it was first computed. A
+	 *       caller that emitted nothing from the consumer must therefore fall back to treating
+	 *       the returned {@link ChartAnswer} as the single, final result.</li>
+	 * </ul>
+	 *
+	 * <p>This overload is deliberately abstract, not a default: every implementation —
+	 * especially delegating wrappers like the caching router — must decide explicitly how to
+	 * route the consumer. A defaulted implementation that silently dropped it would re-create
+	 * the consumer-loss bug class that the citations channel hit before (see the history on the
+	 * five-arg overload).</p>
+	 *
+	 * @param ungroundedAnswerConsumer called at most once with the complete answer whose
+	 *        references carry no grounding verdicts yet; not called for already-final answers
+	 * @return the complete answer with grounded source references, exactly as the five-arg
+	 *         overload returns
+	 */
+	ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer,
+			Consumer<String> reasoningConsumer, Consumer<List<RecordReference>> citationsConsumer,
+			Consumer<ChartAnswer> ungroundedAnswerConsumer);
+
+	/**
 	 * Pre-warm any patient-specific caches (serialized chart, LLM prompt cache) so the
 	 * first real query on this patient does not pay cold-start cost. Implementations
 	 * that don't support warmup may return immediately. Callers should treat this as

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
@@ -89,6 +89,15 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 	public ChartAnswer searchStreaming(Patient patient, String question,
 			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
 			Consumer<List<RecordReference>> citationsConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer,
+				citationsConsumer, ungrounded -> { });
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+			Consumer<List<RecordReference>> citationsConsumer,
+			Consumer<ChartAnswer> ungroundedAnswerConsumer) {
 		int ttlMinutes = getCacheTtlMinutes();
 
 		if (ttlMinutes > 0) {
@@ -99,20 +108,28 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 				// Cache hit: the answer is returned instantly with no LLM call, so there is no
 				// live reasoning to stream — only replay the cached answer. Its references are
 				// already grounded, so also surface them on the citations channel for protocol
-				// parity with the live path.
+				// parity with the live path. The ungrounded-answer consumer is deliberately NOT
+				// fired: its contract is "an answer exists whose grounding is still pending",
+				// and a cached answer is already final — the caller treats the return value as
+				// the single result (see the interface javadoc).
 				tokenConsumer.accept(cached.getAnswer());
 				citationsConsumer.accept(cached.getReferences());
 				return cached;
 			}
 
 			ChartAnswer answer = llmService.searchStreaming(patient, question, tokenConsumer,
-					reasoningConsumer, citationsConsumer);
+					reasoningConsumer, citationsConsumer, ungroundedAnswerConsumer);
 			putCache(cacheKey, answer);
 			return answer;
 		}
 
 		return llmService.searchStreaming(patient, question, tokenConsumer, reasoningConsumer,
-				citationsConsumer);
+				citationsConsumer, ungroundedAnswerConsumer);
+	}
+
+	/** Test seam: production wires the inference service via {@link Autowired}. */
+	void setLlmService(ChartSearchService llmService) {
+		this.llmService = llmService;
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -186,6 +186,12 @@ public class LlmInferenceService implements ChartSearchService {
 		return ChartSearchAiUtils.isQueryStoreEnabled();
 	}
 
+	/** Test seam wrapping {@link ChartSearchAiUtils#isGroundingEnabled()}; production
+	 *  delegates, tests override to exercise the grounding path without an OpenMRS context. */
+	protected boolean resolveGroundingEnabled() {
+		return ChartSearchAiUtils.isGroundingEnabled();
+	}
+
 	/**
 	 * Pure-logic decision for whether the current pipeline mode produces a
 	 * question-independent chart prefix that warmup can usefully prime. Warmup
@@ -239,6 +245,15 @@ public class LlmInferenceService implements ChartSearchService {
 	public ChartAnswer searchStreaming(Patient patient, String question,
 			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
 			Consumer<List<RecordReference>> citationsConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer,
+				citationsConsumer, ungrounded -> { });
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+			Consumer<List<RecordReference>> citationsConsumer,
+			Consumer<ChartAnswer> ungroundedAnswerConsumer) {
 		// LOG FORMAT — stable contract: same field set as search() with op=searchStreaming
 		// in the log tag, plus groundMs (Tier-2 grounding is now timed separately so the tail is
 		// visible). Streaming is the path the frontend actually uses by default, so this is what
@@ -269,6 +284,14 @@ public class LlmInferenceService implements ChartSearchService {
 			List<RecordReference> cited = extractCitedReferences(response.getAnswer(),
 					response.getCitations(), chart.getMappings());
 			citationsConsumer.accept(cited);
+
+			// The answer is complete: hand the whole (not yet grounding-verified) result to the
+			// caller before the grounding pass, so the REST layer can finish the user-visible
+			// response (emit "done", persist the audit row) without waiting out the Tier-2 tail.
+			// Fires regardless of whether grounding is enabled — see the interface contract.
+			ungroundedAnswerConsumer.accept(new ChartAnswer(response.getAnswer(), cited,
+					response.getInputTokens(), response.getOutputTokens(),
+					response.getCachedTokens()));
 
 			long groundStart = System.currentTimeMillis();
 			List<RecordReference> references = groundReferences(response.getAnswer(), cited,
@@ -313,7 +336,7 @@ public class LlmInferenceService implements ChartSearchService {
 	 */
 	private List<RecordReference> groundReferences(String answer, List<RecordReference> references,
 			List<RecordMapping> mappings) {
-		if (references == null || references.isEmpty() || !ChartSearchAiUtils.isGroundingEnabled()) {
+		if (references == null || references.isEmpty() || !resolveGroundingEnabled()) {
 			return references;
 		}
 		return citationGroundingVerifier.verify(answer, references, mappings);

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouterTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouterTest.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 
 /**
  * Unit tests for {@link ChartSearchServiceRouter#buildCacheKey}. The router caches the full
@@ -34,9 +36,16 @@ public class ChartSearchServiceRouterTest {
 
 		final Map<String, String> gps = new HashMap<String, String>();
 
+		int cacheTtlMinutes;
+
 		@Override
 		protected String gp(String property, String defaultValue) {
 			return gps.containsKey(property) ? gps.get(property) : defaultValue;
+		}
+
+		@Override
+		protected int getCacheTtlMinutes() {
+			return cacheTtlMinutes;
 		}
 	}
 
@@ -99,5 +108,96 @@ public class ChartSearchServiceRouterTest {
 		router.gps.put(ChartSearchAiConstants.GP_GROUNDING_ENTAILMENT_ENABLED, "true");
 		assertNotEquals(entailmentOff, router.buildCacheKey(p, "q"),
 				"toggling the Tier-2 entailment flag changes verdicts, so it must change the key");
+	}
+
+	// ---- async-grounding consumer routing (6-arg searchStreaming) ----
+
+	/**
+	 * Delegate that mimics {@code LlmInferenceService}'s live behavior for the async seam: it
+	 * streams a token, surfaces citations, fires the ungrounded-answer consumer, then returns the
+	 * grounded answer.
+	 */
+	private static class StubDelegate implements org.openmrs.module.chartsearchai.api.ChartSearchService {
+
+		int streamingCalls;
+
+		final ChartAnswer grounded = new ChartAnswer("Has TB [8].",
+				java.util.Arrays.asList(new RecordReference(8, "condition", "u8", null, Boolean.TRUE)));
+
+		private final ChartAnswer ungrounded = new ChartAnswer("Has TB [8].",
+				java.util.Arrays.asList(new RecordReference(8, "condition", "u8", null)));
+
+		@Override
+		public ChartAnswer search(Patient patient, String question) {
+			return grounded;
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question,
+				java.util.function.Consumer<String> tokenConsumer) {
+			return searchStreaming(patient, question, tokenConsumer, r -> { }, c -> { }, a -> { });
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question,
+				java.util.function.Consumer<String> tokenConsumer,
+				java.util.function.Consumer<String> reasoningConsumer,
+				java.util.function.Consumer<java.util.List<RecordReference>> citationsConsumer,
+				java.util.function.Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+			streamingCalls++;
+			tokenConsumer.accept("Has TB [8].");
+			citationsConsumer.accept(ungrounded.getReferences());
+			ungroundedAnswerConsumer.accept(ungrounded);
+			return grounded;
+		}
+
+		@Override
+		public void warmup(Patient patient) {
+		}
+	}
+
+	private static StubRouter routerWith(StubDelegate delegate, int ttlMinutes) {
+		StubRouter router = new StubRouter();
+		router.cacheTtlMinutes = ttlMinutes;
+		router.setLlmService(delegate);
+		return router;
+	}
+
+	@Test
+	public void searchStreaming_passThroughForwardsUngroundedConsumer() {
+		StubDelegate delegate = new StubDelegate();
+		StubRouter router = routerWith(delegate, 0);
+		java.util.List<ChartAnswer> seen = new java.util.ArrayList<ChartAnswer>();
+
+		ChartAnswer answer = router.searchStreaming(patient("p1"), "tb?",
+				t -> { }, r -> { }, c -> { }, seen::add);
+
+		assertEquals(1, seen.size(), "uncached path must forward the ungrounded-answer consumer");
+		assertEquals(Boolean.TRUE, answer.getReferences().get(0).getGrounded());
+	}
+
+	@Test
+	public void searchStreaming_cacheHitDoesNotFireUngroundedConsumer() {
+		StubDelegate delegate = new StubDelegate();
+		StubRouter router = routerWith(delegate, 5);
+		java.util.List<ChartAnswer> seen = new java.util.ArrayList<ChartAnswer>();
+
+		router.searchStreaming(patient("p1"), "tb?", t -> { }, r -> { }, c -> { }, seen::add);
+		assertEquals(1, seen.size(), "first call is a miss and must fire the consumer");
+
+		java.util.List<String> replayedTokens = new java.util.ArrayList<String>();
+		java.util.List<java.util.List<RecordReference>> replayedCitations =
+				new java.util.ArrayList<java.util.List<RecordReference>>();
+		ChartAnswer hit = router.searchStreaming(patient("p1"), "tb?",
+				replayedTokens::add, r -> { }, replayedCitations::add, seen::add);
+
+		assertEquals(1, delegate.streamingCalls, "second call must be served from the cache");
+		assertEquals(1, seen.size(),
+				"a cached answer is already grounded — there is no pending-grounding stage, so the "
+						+ "ungrounded-answer consumer must NOT fire on a cache hit");
+		assertEquals(1, replayedTokens.size(), "cache hit still replays the answer token");
+		assertEquals(1, replayedCitations.size(), "cache hit still replays the citations");
+		assertEquals(Boolean.TRUE, hit.getReferences().get(0).getGrounded(),
+				"the cached answer keeps its verdicts");
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceAsyncGroundingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceAsyncGroundingTest.java
@@ -1,0 +1,181 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
+import org.openmrs.module.chartsearchai.api.impl.LlmProvider.LlmResponse;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * Locks the async-grounding seam on {@link LlmInferenceService#searchStreaming}: the
+ * 6-arg overload's {@code ungroundedAnswerConsumer} must fire exactly once, BEFORE the
+ * grounding verifier runs, carrying the complete answer whose references have no
+ * grounding verdicts yet — that is what lets the REST layer emit its {@code done}
+ * event without waiting out the Tier-2 grounding tail. The returned {@link ChartAnswer}
+ * still carries the verifier's verdicts, exactly as the synchronous path does.
+ */
+public class LlmInferenceServiceAsyncGroundingTest {
+
+	private TestableService service;
+
+	private RecordingVerifier verifier;
+
+	/** Interleaving log: "consumer" and "verify" entries prove the fire-before-grounding order. */
+	private final List<String> sequence = new ArrayList<String>();
+
+	@BeforeEach
+	public void setUp() {
+		service = new TestableService();
+		service.setChartBuildingStrategy(new StubStrategy());
+		service.setLlmProvider(new StubProvider());
+		verifier = new RecordingVerifier();
+		service.setCitationGroundingVerifier(verifier);
+	}
+
+	private static Patient patient() {
+		Patient p = new Patient();
+		p.setPatientId(1);
+		p.setUuid("uuid-1");
+		return p;
+	}
+
+	@Test
+	public void searchStreaming_firesUngroundedConsumerOnceBeforeGrounding() {
+		List<ChartAnswer> seen = new ArrayList<ChartAnswer>();
+
+		ChartAnswer finalAnswer = service.searchStreaming(patient(), "any infections?",
+				token -> { }, reasoning -> { }, citations -> { },
+				ungrounded -> {
+					sequence.add("consumer");
+					seen.add(ungrounded);
+				});
+
+		assertEquals(1, seen.size(), "ungrounded-answer consumer must fire exactly once");
+		assertEquals(Arrays.asList("consumer", "verify"), sequence,
+				"the consumer must fire BEFORE the grounding verifier runs — that ordering is "
+						+ "the entire point of the async seam");
+
+		ChartAnswer ungrounded = seen.get(0);
+		assertEquals("Active Tuberculosis [8]. CD4 988.0 [9].", ungrounded.getAnswer(),
+				"consumer must carry the complete answer text");
+		assertEquals(2, ungrounded.getReferences().size());
+		for (RecordReference ref : ungrounded.getReferences()) {
+			assertNull(ref.getGrounded(),
+					"references handed to the consumer must carry no verdicts yet");
+		}
+
+		assertEquals(2, finalAnswer.getReferences().size());
+		for (RecordReference ref : finalAnswer.getReferences()) {
+			assertEquals(Boolean.TRUE, ref.getGrounded(),
+					"the returned answer must still carry the verifier's verdicts");
+		}
+	}
+
+	@Test
+	public void searchStreaming_fiveArgOverloadStillGroundsSynchronously() {
+		ChartAnswer answer = service.searchStreaming(patient(), "any infections?",
+				token -> { }, reasoning -> { }, citations -> { });
+
+		assertEquals(1, verifier.invocations, "5-arg overload must still ground before returning");
+		for (RecordReference ref : answer.getReferences()) {
+			assertEquals(Boolean.TRUE, ref.getGrounded());
+		}
+	}
+
+	@Test
+	public void searchStreaming_groundingDisabledStillFiresConsumerAndSkipsVerifier() {
+		service.groundingEnabled = false;
+		List<ChartAnswer> seen = new ArrayList<ChartAnswer>();
+
+		ChartAnswer finalAnswer = service.searchStreaming(patient(), "any infections?",
+				token -> { }, reasoning -> { }, citations -> { }, seen::add);
+
+		assertEquals(1, seen.size(),
+				"consumer contract is 'the answer is complete', not 'grounding will follow'");
+		assertEquals(0, verifier.invocations, "grounding disabled -> verifier never runs");
+		for (RecordReference ref : finalAnswer.getReferences()) {
+			assertNull(ref.getGrounded(), "grounding disabled -> verdicts stay null");
+		}
+	}
+
+	/** Context-free service: GP-backed resolvers overridden, grounding forced on by default. */
+	private final class TestableService extends LlmInferenceService {
+
+		boolean groundingEnabled = true;
+
+		@Override
+		protected boolean resolveWarmupEnabled() {
+			return false;
+		}
+
+		@Override
+		protected boolean resolveQueryStoreEnabled() {
+			return false;
+		}
+
+		@Override
+		protected boolean resolveGroundingEnabled() {
+			return groundingEnabled;
+		}
+	}
+
+	private final class RecordingVerifier extends CitationGroundingVerifier {
+
+		int invocations;
+
+		@Override
+		public List<RecordReference> verify(String answer, List<RecordReference> references,
+				List<RecordMapping> mappings) {
+			invocations++;
+			sequence.add("verify");
+			List<RecordReference> annotated = new ArrayList<RecordReference>();
+			for (RecordReference ref : references) {
+				annotated.add(ref.withGrounded(Boolean.TRUE));
+			}
+			return annotated;
+		}
+	}
+
+	private static final class StubStrategy extends ChartBuildingStrategy {
+
+		@Override
+		PatientChart buildChart(Patient patient, String question) {
+			List<RecordMapping> mappings = Arrays.asList(
+					new RecordMapping(8, "condition", "00000000-0000-0000-0000-000000000008", null),
+					new RecordMapping(9, "obs", "00000000-0000-0000-0000-000000000009", null));
+			return new PatientChart("8. Tuberculosis\n9. CD4 988.0", mappings,
+					Collections.<Integer>emptyList());
+		}
+	}
+
+	private static final class StubProvider extends LlmProvider {
+
+		@Override
+		public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices,
+				String question, Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer) {
+			return new LlmResponse("Active Tuberculosis [8]. CD4 988.0 [9].", Arrays.asList(8, 9));
+		}
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletResponse;
@@ -33,6 +34,7 @@ import org.openmrs.api.context.ContextAuthenticationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
 import org.openmrs.module.chartsearchai.util.DateFormatUtil;
 import org.openmrs.module.chartsearchai.api.ChartSearchService;
 import org.openmrs.module.chartsearchai.api.ChartTooLargeException;
@@ -268,7 +270,15 @@ public class ChartSearchAiRestController {
 	 *   <li>{@code thinking} — a chunk of the model's reasoning (chain-of-thought), emitted
 	 *       before the answer; render distinctly (e.g. a collapsible panel), not as the answer</li>
 	 *   <li>{@code token} — a chunk of the answer text</li>
-	 *   <li>{@code done} — final JSON with answer, references, and disclaimer</li>
+	 *   <li>{@code references} — the answer's citations the moment the answer is complete,
+	 *       before grounding verdicts exist; render as unverified until verdicts arrive</li>
+	 *   <li>{@code done} — final JSON with answer, references, questionId, and disclaimer.
+	 *       With async grounding off (the default) the references carry their grounding
+	 *       verdicts; with {@code chartsearchai.grounding.async=true} they do not yet</li>
+	 *   <li>{@code grounded} — only with async grounding: the references re-sent with their
+	 *       grounding verdicts attached, after the Tier-2 verification tail completes; carries
+	 *       the same {@code questionId} as {@code done}. Clients must keep consuming the stream
+	 *       after {@code done} to receive it</li>
 	 *   <li>{@code error} — an error message if something goes wrong</li>
 	 * </ul>
 	 */
@@ -359,54 +369,110 @@ public class ChartSearchAiRestController {
 		String searchMode = !"false".equalsIgnoreCase(preFilterProp.trim())
 				? "pre-filter" : "full-chart";
 
+		streamAnswer(out, patient, sanitizedQuestion, user, searchMode, isAsyncGroundingActive());
+	}
+
+	/**
+	 * Whether the streaming endpoint should emit {@code done} before the grounding pass and
+	 * deliver verdicts in a trailing {@code grounded} event. Only meaningful when grounding
+	 * itself is on — with grounding disabled there is no tail to move off the response path.
+	 * Resolved here (not in {@link #streamAnswer}) so the orchestration stays free of
+	 * {@code Context} reads and unit-testable.
+	 */
+	private static boolean isAsyncGroundingActive() {
+		return ChartSearchAiUtils.isGroundingAsyncEnabled() && ChartSearchAiUtils.isGroundingEnabled();
+	}
+
+	/**
+	 * The SSE orchestration for one streaming search: runs the service call with the token /
+	 * thinking / references channels wired to the output stream, then emits the terminal events.
+	 *
+	 * <p>With {@code asyncGrounding} off, the classic shape: one {@code done} event after the
+	 * service returns, carrying the grounded references. With it on, {@code done} is emitted the
+	 * moment the answer is complete (references without verdicts, audit row already saved so
+	 * {@code questionId} is present) and a trailing {@code grounded} event delivers the
+	 * verdict-annotated references once verification finishes — the user's perceived completion
+	 * no longer waits out the grounding tail. If the service returns without ever surfacing an
+	 * ungrounded answer (a cache hit returns an already-final answer), the classic {@code done}
+	 * is emitted instead and no {@code grounded} event follows.</p>
+	 *
+	 * <p>Package-private and free of {@code Context} reads so event-order behavior is unit-tested
+	 * directly (see {@code ChartSearchAiStreamEventOrderTest}); {@code searchStream} resolves all
+	 * configuration before delegating here.</p>
+	 */
+	void streamAnswer(final OutputStream out, Patient patient, String sanitizedQuestion, User user,
+			String searchMode, boolean asyncGrounding) {
 		try {
 			long startTime = System.currentTimeMillis();
 
-			// Three channels: "token" carries the answer; "thinking" carries the model's reasoning
+			// Carries the early-done state from the consumer (fired mid-call) to the post-return
+			// code: [0] = the saved questionId (null if audit failed), and whether done was sent
+			// is tracked by earlyDoneSent. Single-element arrays because the consumer lambda needs
+			// effectively-final capture.
+			final String[] earlyQuestionId = new String[1];
+			final boolean[] earlyDoneSent = new boolean[1];
+
+			// Async grounding: the moment the (not yet grounding-verified) answer exists, persist
+			// the audit row and emit "done" — the user's perceived completion no longer waits out
+			// the grounding tail. The audit's responseTimeMs deliberately measures to THIS point
+			// (what the user experienced); the [timing] service log still carries groundMs.
+			// Serialization + write failures unwind like any mid-stream disconnect, via the same
+			// RuntimeException(IOException) shape writeSseEventOrThrow uses.
+			Consumer<ChartAnswer> ungroundedConsumer = !asyncGrounding ? ungrounded -> { }
+					: ungrounded -> {
+						if (earlyDoneSent[0]) {
+							// Interface contract is at-most-once; stay idempotent anyway — a
+							// duplicate done would corrupt every client's completion handling.
+							log.warn("Ungrounded-answer consumer fired more than once; ignoring");
+							return;
+						}
+						earlyQuestionId[0] = saveAuditLog(user, patient, sanitizedQuestion,
+								ungrounded, searchMode, System.currentTimeMillis() - startTime);
+						try {
+							writeSseEvent(out, "done",
+									doneEventJson(ungrounded, earlyQuestionId[0]));
+						}
+						catch (IOException e) {
+							log.debug("Client disconnected during streaming (done)");
+							throw new RuntimeException("Client disconnected", e);
+						}
+						earlyDoneSent[0] = true;
+					};
+
+			// Four channels: "token" carries the answer; "thinking" carries the model's reasoning
 			// (chain-of-thought), emitted first so the UI can show live progress and the rationale
 			// instead of a dead spinner; "references" carries the answer's citations the moment the
 			// answer is done — BEFORE the grounding pass — so the UI can render clickable citations
-			// immediately and not wait on Tier-2 verification. The final "done" event re-sends the
-			// same references with their grounding verdicts attached. The frontend must render
-			// "thinking" distinctly (e.g. a collapsible panel), never as the answer; until "done"
-			// arrives it must show "references" citations as unverified. All unwind on client
+			// immediately and not wait on Tier-2 verification. The terminal events re-send the
+			// references with grounding verdicts attached: in the classic shape on "done", or — when
+			// async grounding is active — on a trailing "grounded" event after an early "done". The
+			// frontend must render "thinking" distinctly (e.g. a collapsible panel), never as the
+			// answer; citations must show as unverified until verdicts arrive. All unwind on client
 			// disconnect via writeSseEventOrThrow.
 			ChartAnswer chartAnswer = chartSearchService.searchStreaming(
 					patient, sanitizedQuestion,
 					token -> writeSseEventOrThrow(out, "token", token),
 					reasoning -> writeSseEventOrThrow(out, "thinking", reasoning),
-					citations -> sendReferencesEvent(out, citations));
+					citations -> sendReferencesEvent(out, citations),
+					ungroundedConsumer);
 
-			long responseTimeMs = System.currentTimeMillis() - startTime;
-
-			ChartSearchAuditLog auditLog = new ChartSearchAuditLog();
-			auditLog.setUser(user);
-			auditLog.setPatient(patient);
-			auditLog.setQuestion(sanitizedQuestion);
-			auditLog.setAnswer(chartAnswer.getAnswer());
-			auditLog.setReferenceCount(chartAnswer.getReferences().size());
-			auditLog.setSearchMode(searchMode);
-			auditLog.setResponseTimeMs(responseTimeMs);
-			auditLog.setInputTokens(chartAnswer.getInputTokens() > 0 ? chartAnswer.getInputTokens() : null);
-			auditLog.setOutputTokens(chartAnswer.getOutputTokens() > 0 ? chartAnswer.getOutputTokens() : null);
-			auditLog.setDateCreated(new Date());
-			try {
-				auditLogService.saveAuditLog(auditLog);
+			if (!earlyDoneSent[0]) {
+				// Classic shape: async off, or the service returned an already-final answer (cache
+				// hit) without surfacing an ungrounded stage — audit and emit the single done.
+				String questionId = saveAuditLog(user, patient, sanitizedQuestion, chartAnswer,
+						searchMode, System.currentTimeMillis() - startTime);
+				writeSseEvent(out, "done", doneEventJson(chartAnswer, questionId));
+			} else {
+				// done already went out before grounding; deliver the verdicts in the trailing
+				// "grounded" event. Same reference serialization as done, so the client can
+				// replace its reference list wholesale; questionId correlates the two events.
+				Map<String, Object> groundedData = new HashMap<String, Object>();
+				groundedData.put("references", serializeReferences(chartAnswer.getReferences()));
+				if (earlyQuestionId[0] != null) {
+					groundedData.put("questionId", earlyQuestionId[0]);
+				}
+				writeSseEvent(out, "grounded", new ObjectMapper().writeValueAsString(groundedData));
 			}
-			catch (Exception e2) {
-				log.warn("Failed to save audit log for streaming query", e2);
-			}
-
-			Map<String, Object> doneData = new HashMap<String, Object>();
-			doneData.put("answer", chartAnswer.getAnswer());
-			doneData.put("disclaimer", DISCLAIMER);
-
-			doneData.put("references", serializeReferences(chartAnswer.getReferences()));
-			if (auditLog.getAuditLogId() != null) {
-				doneData.put("questionId", String.valueOf(auditLog.getAuditLogId()));
-			}
-
-			writeSseEvent(out, "done", new ObjectMapper().writeValueAsString(doneData));
 		}
 		catch (ChartTooLargeException e) {
 			log.warn("Chart too large for LLM context during streaming for patient [id={}]: {}",
@@ -452,6 +518,57 @@ public class ChartSearchAiRestController {
 		catch (IOException e) {
 			log.debug("Could not flush SSE stream, client likely disconnected");
 		}
+	}
+
+	/**
+	 * Persists the audit row for a streaming answer and returns its id as the client-facing
+	 * {@code questionId}, or {@code null} when the save failed — audit failures are logged and
+	 * never break the response, exactly as before the async-grounding split. Shared by the
+	 * classic post-return path and the async early-{@code done} path so both emit identical
+	 * audit rows and {@code done} payloads.
+	 */
+	private String saveAuditLog(User user, Patient patient, String question, ChartAnswer answer,
+			String searchMode, long responseTimeMs) {
+		ChartSearchAuditLog auditLog = new ChartSearchAuditLog();
+		auditLog.setUser(user);
+		auditLog.setPatient(patient);
+		auditLog.setQuestion(question);
+		auditLog.setAnswer(answer.getAnswer());
+		auditLog.setReferenceCount(answer.getReferences().size());
+		auditLog.setSearchMode(searchMode);
+		auditLog.setResponseTimeMs(responseTimeMs);
+		auditLog.setInputTokens(answer.getInputTokens() > 0 ? answer.getInputTokens() : null);
+		auditLog.setOutputTokens(answer.getOutputTokens() > 0 ? answer.getOutputTokens() : null);
+		auditLog.setDateCreated(new Date());
+		try {
+			auditLogService.saveAuditLog(auditLog);
+		}
+		catch (Exception e) {
+			log.warn("Failed to save audit log for streaming query", e);
+		}
+		return auditLog.getAuditLogId() != null ? String.valueOf(auditLog.getAuditLogId()) : null;
+	}
+
+	/** Serializes the {@code done} event payload: answer, disclaimer, references, questionId. */
+	private String doneEventJson(ChartAnswer answer, String questionId) throws IOException {
+		Map<String, Object> doneData = new HashMap<String, Object>();
+		doneData.put("answer", answer.getAnswer());
+		doneData.put("disclaimer", DISCLAIMER);
+		doneData.put("references", serializeReferences(answer.getReferences()));
+		if (questionId != null) {
+			doneData.put("questionId", questionId);
+		}
+		return new ObjectMapper().writeValueAsString(doneData);
+	}
+
+	/** Test seam: production wires {@link ChartSearchService} via {@code Autowired}. */
+	void setChartSearchService(ChartSearchService chartSearchService) {
+		this.chartSearchService = chartSearchService;
+	}
+
+	/** Test seam: production wires {@link AuditLogService} via {@code Autowired}. */
+	void setAuditLogService(AuditLogService auditLogService) {
+		this.auditLogService = auditLogService;
 	}
 
 	@RequestMapping(value = "/auditlog", method = RequestMethod.GET)

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -234,6 +234,12 @@
 	</globalProperty>
 
 	<globalProperty>
+		<property>chartsearchai.grounding.async</property>
+		<defaultValue>false</defaultValue>
+		<description>When true (and chartsearchai.grounding.enabled is also on), the streaming search endpoint emits its terminal "done" event as soon as the answer is complete — its references carry no grounding verdicts yet — and delivers the verdicts afterwards in a trailing "grounded" SSE event. On CPU-only deployments the grounding pass adds seconds of Tier-2 LLM work after the answer is already readable; enabling this moves that tail off the user's perceived completion time. Clients must keep consuming the SSE stream after "done" and apply the "grounded" event's verdicts when it arrives (citations render as unverified until then). The blocking /search endpoint is unaffected and always returns final verdicts. Default: false (the classic single "done" carrying final verdicts).</description>
+	</globalProperty>
+
+	<globalProperty>
 		<property>chartsearchai.grounding.clauseScoped</property>
 		<defaultValue>false</defaultValue>
 		<description>When true, citation grounding is clause-scoped: in a sentence that cites multiple records, each citation is checked against the answer text up to and including its own [N] marker, rather than the whole compound sentence. This grounds a citation that supports its own clause but not a later clause cited by a different record — e.g. "Hearing Loss was noted as a condition [89] and diagnosed as a provisional condition [91]", where [89] (an active condition) does not support the "provisional diagnosis" clause that [91] backs. The clause is the cumulative prefix through the marker, so it keeps the sentence subject when the subject precedes the first marker (the normal case) and still flags family-history/negation flips in later clauses. Default: false (sentence-scoped). Only affects which text a citation is verified against; never changes the answer or which records are cited.</description>

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiStreamEventOrderTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiStreamEventOrderTest.java
@@ -1,0 +1,322 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.web.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.module.chartsearchai.api.AuditLogService;
+import org.openmrs.module.chartsearchai.api.ChartSearchService;
+import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Behavioral tests for the SSE event order emitted by the controller's streaming
+ * orchestration ({@code streamAnswer}), driven with a stubbed {@link ChartSearchService}
+ * and a captured output stream — no Spring context, matching this test package's
+ * conventions.
+ *
+ * <p>The async-grounding contract under test: when async grounding is active, {@code done}
+ * is emitted as soon as the answer exists (its references carry NO verdicts), and a trailing
+ * {@code grounded} event delivers the verdict-annotated references afterwards — so the user's
+ * perceived completion no longer waits out the Tier-2 grounding tail. When async grounding is
+ * off, the classic single grounded {@code done} is preserved byte-for-byte in shape. When the
+ * service returns without ever firing the ungrounded-answer consumer (a cache hit — the cached
+ * answer is already final), the controller must fall back to the classic {@code done} even in
+ * async mode, and emit no {@code grounded} event.</p>
+ */
+public class ChartSearchAiStreamEventOrderTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private ChartSearchAiRestController controller;
+
+	private ByteArrayOutputStream out;
+
+	@BeforeEach
+	public void setUp() {
+		controller = new ChartSearchAiRestController();
+		controller.setAuditLogService(new StubAuditLogService());
+		out = new ByteArrayOutputStream();
+	}
+
+	private static Patient patient() {
+		Patient p = new Patient();
+		p.setPatientId(7);
+		p.setUuid("uuid-7");
+		return p;
+	}
+
+	private static User user() {
+		return new User(3);
+	}
+
+	/** One parsed SSE event: {@code event:} type plus the concatenated {@code data:} payload. */
+	private static final class SseEvent {
+
+		final String type;
+
+		final String data;
+
+		SseEvent(String type, String data) {
+			this.type = type;
+			this.data = data;
+		}
+	}
+
+	private List<SseEvent> emittedEvents() {
+		List<SseEvent> events = new ArrayList<SseEvent>();
+		for (String block : new String(out.toByteArray(), StandardCharsets.UTF_8).split("\n\n")) {
+			String type = null;
+			StringBuilder data = new StringBuilder();
+			for (String line : block.split("\n")) {
+				if (line.startsWith("event: ")) {
+					type = line.substring(7).trim();
+				} else if (line.startsWith("data: ")) {
+					data.append(line.substring(6));
+				}
+			}
+			if (type != null) {
+				events.add(new SseEvent(type, data.toString()));
+			}
+		}
+		return events;
+	}
+
+	private List<String> eventTypes() {
+		List<String> types = new ArrayList<String>();
+		for (SseEvent e : emittedEvents()) {
+			types.add(e.type);
+		}
+		return types;
+	}
+
+	private SseEvent eventOfType(String type) {
+		for (SseEvent e : emittedEvents()) {
+			if (e.type.equals(type)) {
+				return e;
+			}
+		}
+		return null;
+	}
+
+	@Test
+	public void asyncGrounding_emitsDoneBeforeGroundedAndVerdictsArriveInGroundedEvent()
+			throws Exception {
+		controller.setChartSearchService(new LiveStubService());
+
+		controller.streamAnswer(out, patient(), "any infections?", user(), "full-chart", true);
+
+		List<String> types = eventTypes();
+		int doneIdx = types.indexOf("done");
+		int groundedIdx = types.indexOf("grounded");
+		assertTrue(doneIdx >= 0, "done event must be emitted; got " + types);
+		assertTrue(groundedIdx >= 0, "grounded event must be emitted; got " + types);
+		assertTrue(doneIdx < groundedIdx, "done must precede grounded; got " + types);
+
+		JsonNode done = MAPPER.readTree(eventOfType("done").data);
+		assertEquals("Has TB [8].", done.get("answer").asText());
+		assertEquals("42", done.get("questionId").asText(),
+				"done must still carry the audit questionId so feedback works immediately");
+		JsonNode doneRef = done.get("references").get(0);
+		assertTrue(doneRef.get("grounded") == null || doneRef.get("grounded").isNull(),
+				"async done must carry the references WITHOUT verdicts (grounding still pending)");
+
+		JsonNode grounded = MAPPER.readTree(eventOfType("grounded").data);
+		assertEquals("42", grounded.get("questionId").asText(),
+				"grounded must carry the same questionId so the client can correlate");
+		assertTrue(grounded.get("references").get(0).get("grounded").asBoolean(),
+				"the grounded event must deliver the verifier's verdicts");
+	}
+
+	@Test
+	public void syncGrounding_keepsClassicSingleDoneWithVerdicts() throws Exception {
+		controller.setChartSearchService(new LiveStubService());
+
+		controller.streamAnswer(out, patient(), "any infections?", user(), "full-chart", false);
+
+		List<String> types = eventTypes();
+		assertFalse(types.contains("grounded"),
+				"sync mode must not emit a grounded event; got " + types);
+		JsonNode done = MAPPER.readTree(eventOfType("done").data);
+		assertTrue(done.get("references").get(0).get("grounded").asBoolean(),
+				"sync done must carry the final verdicts exactly as today");
+		assertEquals("42", done.get("questionId").asText());
+	}
+
+	@Test
+	public void asyncGrounding_cacheHitFallsBackToClassicDone() throws Exception {
+		// A cache hit returns an already-grounded answer without ever firing the
+		// ungrounded-answer consumer — the controller must then emit the classic done
+		// (with verdicts) and no grounded event, even though async mode is on.
+		controller.setChartSearchService(new CacheHitStubService());
+
+		controller.streamAnswer(out, patient(), "any infections?", user(), "full-chart", true);
+
+		List<String> types = eventTypes();
+		assertEquals(1, frequency(types, "done"), "exactly one done event; got " + types);
+		assertFalse(types.contains("grounded"),
+				"no grounded event when the answer was final at return; got " + types);
+		JsonNode done = MAPPER.readTree(eventOfType("done").data);
+		assertTrue(done.get("references").get(0).get("grounded").asBoolean(),
+				"the cached answer's verdicts ride in done as before");
+	}
+
+	@Test
+	public void asyncGrounding_emitsExactlyOneDone() throws Exception {
+		controller.setChartSearchService(new LiveStubService());
+
+		controller.streamAnswer(out, patient(), "any infections?", user(), "full-chart", true);
+
+		assertEquals(1, frequency(eventTypes(), "done"),
+				"async mode must not double-emit done; got " + eventTypes());
+	}
+
+	@Test
+	public void asyncGrounding_misbehavingServiceDoubleFireStillEmitsOneDone() throws Exception {
+		// The interface contract is at-most-once, but a delegating wrapper bug could fire the
+		// consumer twice; the controller must stay idempotent — a duplicate done event would
+		// corrupt every client's completion handling.
+		controller.setChartSearchService(new LiveStubService() {
+
+			@Override
+			public ChartAnswer searchStreaming(Patient patient, String question,
+					Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+					Consumer<List<RecordReference>> citationsConsumer,
+					Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+				ungroundedAnswerConsumer.accept(ungroundedAnswer());
+				ungroundedAnswerConsumer.accept(ungroundedAnswer());
+				return groundedAnswer();
+			}
+		});
+
+		controller.streamAnswer(out, patient(), "any infections?", user(), "full-chart", true);
+
+		assertEquals(1, frequency(eventTypes(), "done"),
+				"a misbehaving double-fire must not double-emit done; got " + eventTypes());
+		assertEquals(1, frequency(eventTypes(), "grounded"));
+	}
+
+	private static int frequency(List<String> list, String value) {
+		int n = 0;
+		for (String s : list) {
+			if (s.equals(value)) {
+				n++;
+			}
+		}
+		return n;
+	}
+
+	private static ChartSearchService.ChartAnswer ungroundedAnswer() {
+		return new ChartSearchService.ChartAnswer("Has TB [8].",
+				Arrays.asList(new ChartSearchService.RecordReference(8, "condition", "u8", null)));
+	}
+
+	private static ChartSearchService.ChartAnswer groundedAnswer() {
+		return new ChartSearchService.ChartAnswer("Has TB [8].",
+				Arrays.asList(new ChartSearchService.RecordReference(8, "condition", "u8", null,
+						Boolean.TRUE)));
+	}
+
+	/** Live-path stub: streams a token, fires citations + the ungrounded answer, returns grounded. */
+	private static class LiveStubService implements ChartSearchService {
+
+		@Override
+		public ChartAnswer search(Patient patient, String question) {
+			return groundedAnswer();
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question,
+				Consumer<String> tokenConsumer) {
+			return searchStreaming(patient, question, tokenConsumer, r -> { }, c -> { }, a -> { });
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question,
+				Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+				Consumer<List<RecordReference>> citationsConsumer,
+				Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+			tokenConsumer.accept("Has TB [8].");
+			citationsConsumer.accept(ungroundedAnswer().getReferences());
+			ungroundedAnswerConsumer.accept(ungroundedAnswer());
+			return groundedAnswer();
+		}
+
+		@Override
+		public void warmup(Patient patient) {
+		}
+	}
+
+	/** Cache-hit stub: never fires the ungrounded consumer; returns the final answer directly. */
+	private static class CacheHitStubService extends LiveStubService {
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question,
+				Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+				Consumer<List<RecordReference>> citationsConsumer,
+				Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+			tokenConsumer.accept("Has TB [8].");
+			citationsConsumer.accept(groundedAnswer().getReferences());
+			return groundedAnswer();
+		}
+	}
+
+	private static class StubAuditLogService implements AuditLogService {
+
+		@Override
+		public ChartSearchAuditLog saveAuditLog(ChartSearchAuditLog auditLog) {
+			auditLog.setAuditLogId(42);
+			return auditLog;
+		}
+
+		@Override
+		public ChartSearchAuditLog getAuditLog(Integer auditLogId) {
+			return null;
+		}
+
+		@Override
+		public List<ChartSearchAuditLog> getAuditLogs(Patient patient, User user,
+				java.util.Date fromDate, java.util.Date toDate, Integer startIndex, Integer limit) {
+			return java.util.Collections.emptyList();
+		}
+
+		@Override
+		public Long getAuditLogCount(Patient patient, User user, java.util.Date fromDate,
+				java.util.Date toDate) {
+			return 0L;
+		}
+
+		@Override
+		public long getQueryCountByUserSince(User user, java.util.Date since) {
+			return 0L;
+		}
+
+		@Override
+		public int deleteAuditLogsBefore(java.util.Date before) {
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

On the CPU-only demo, the citation-grounding pass adds 5–15s of Tier-2 LLM work *after* the answer has fully streamed — the user watches a finished answer while the response refuses to complete. With `chartsearchai.grounding.async=true` (default `false`), the streaming endpoint now emits `done` the moment the answer is complete (references without verdicts, audit row saved so `questionId` is present) and delivers the verdict-annotated references afterwards in a trailing `grounded` SSE event with the same `questionId`. Perceived completion stops paying for the grounding tail; verdicts arrive as badge updates moments later. The blocking `/search` endpoint is unchanged and always returns final verdicts.

Companion frontend: openmrs/openmrs-esm-chartsearchai#18 (applies the trailing verdicts to the completed message).

## Design

- `ChartSearchService` gains an abstract 6-arg `searchStreaming` overload with an ungrounded-answer consumer. Deliberately abstract, not a default — a defaulted implementation that silently dropped the consumer would re-create the consumer-loss bug class the citations channel hit before (#33). Contract: fires at most once, before grounding, never for already-final answers.
- `LlmInferenceService` fires the consumer between the citations callback and the grounding pass; `groundMs` timing is unchanged.
- `ChartSearchServiceRouter` forwards the consumer on live paths and deliberately does NOT fire it on cache hits (cached answers are final); the controller then falls back to the classic single grounded `done`.
- The controller's SSE orchestration is extracted into a Context-free, seam-injectable `streamAnswer` method, enabling direct behavioral tests of event order; the async branch is idempotent against a double-firing implementation. In async mode the audit `responseTimeMs` measures to the early `done` (what the user experienced).

## Tests

8 new tests, written red-first: service seam (fires once, before grounding, also when grounding disabled), router (cache hit must not fire; pass-through must forward), controller event order (done-before-grounded with verdict placement, sync shape unchanged, cache-hit fallback, exactly-one-done, double-fire idempotence). Full api + omod suites green; README SSE table updated (also documents the previously missing `references` event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)