### PR TITLE
Reasoning-cap knob (default off) + measured negative result for E2B@400

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -375,6 +375,27 @@ public class ChartSearchAiConstants {
 
 	public static final boolean DEFAULT_GROUNDING_ASYNC = false;
 
+	/**
+	 * When {@code > 0}, the {@code reasoning} scratchpad in the chart-answer schema is capped at
+	 * this many characters via a grammar-enforced {@code maxLength} — bounding the dominant
+	 * decode cost on CPU-only servers (the model otherwise thinks for 3–27s before any answer
+	 * token). The answer itself is never capped. {@code 0} (default) leaves the schema exactly
+	 * as before. Because truncating the model's chain of thought can change its answers, any
+	 * non-zero value must first clear the 32-cell answer-quality gold standard
+	 * ({@code eval/drift-metric/metric_gold.standalone.json}): mean F1, abstention accuracy and
+	 * off-topic-citation count must not regress versus the uncapped baseline.
+	 *
+	 * <p><strong>Measured negative result (2026-06-12), Gemma 4 E2B at 400 chars:</strong>
+	 * meanF1 0.464&rarr;0.428, abstention 1.00&rarr;0.91 (a false citation on an absent-topic
+	 * cell), off-topic citations 41&rarr;47 — the gate failed on all three axes, so NO certified
+	 * value exists for E2B. The mechanism is structural: a binding cap cuts the chain of thought
+	 * mid-derivation and the answer degrades; a non-binding cap saves nothing. Do not enable
+	 * without a fresh gate run for the specific model and value.
+	 */
+	public static final String GP_LLM_REASONING_MAX_CHARS = "chartsearchai.llm.reasoningMaxChars";
+
+	public static final int DEFAULT_LLM_REASONING_MAX_CHARS = 0;
+
 	// Resource type identifiers used in embeddings and citations
 	public static final String RESOURCE_TYPE_OBS = "obs";
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
@@ -563,6 +563,25 @@ public class ChartSearchAiUtils {
 	}
 
 	/**
+	 * @return the grammar-enforced character cap for the chart-answer {@code reasoning}
+	 *         scratchpad, from {@link ChartSearchAiConstants#GP_LLM_REASONING_MAX_CHARS};
+	 *         {@code 0} = uncapped. Fails safe to {@code 0} (uncapped — today's behavior) on a
+	 *         missing admin service, an unparseable value, or a negative value.
+	 */
+	public static int getReasoningMaxChars() {
+		try {
+			String value = org.openmrs.api.context.Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_LLM_REASONING_MAX_CHARS,
+							String.valueOf(ChartSearchAiConstants.DEFAULT_LLM_REASONING_MAX_CHARS));
+			int parsed = Integer.parseInt(value.trim());
+			return Math.max(parsed, 0);
+		}
+		catch (RuntimeException e) {
+			return ChartSearchAiConstants.DEFAULT_LLM_REASONING_MAX_CHARS;
+		}
+	}
+
+	/**
 	 * @return the cosine floor below which a citation is treated as ungrounded,
 	 *         read from {@link ChartSearchAiConstants#GP_GROUNDING_MIN_COSINE},
 	 *         falling back to {@link ChartSearchAiConstants#DEFAULT_GROUNDING_MIN_COSINE}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartAnswerResponseFormat.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartAnswerResponseFormat.java
@@ -33,8 +33,27 @@ final class ChartAnswerResponseFormat {
 	}
 
 	static ObjectNode build(ObjectMapper mapper) {
+		return build(mapper, 0);
+	}
+
+	/**
+	 * As {@link #build(ObjectMapper)} but with an optional grammar-enforced length cap on the
+	 * {@code reasoning} scratchpad ({@code maxChars > 0}; {@code 0} = uncapped, byte-identical
+	 * to the classic schema). The reasoning field is the dominant decode cost on CPU-only
+	 * servers — the model thinks for 3–27s before any answer token — and {@code maxLength}
+	 * compiles into the GBNF grammar (verified against the bundled llama-server: the cut is
+	 * exact). The {@code answer} is NEVER capped: it is the clinical content, and the system
+	 * prompt requires complete enumeration. Gated by
+	 * {@code chartsearchai.llm.reasoningMaxChars} (default 0) and certified by the 32-cell
+	 * answer-quality gold standard in {@code eval/drift-metric/} before any deployment enables
+	 * it.
+	 */
+	static ObjectNode build(ObjectMapper mapper, int reasoningMaxChars) {
 		ObjectNode reasoningProp = mapper.createObjectNode();
 		reasoningProp.put("type", "string");
+		if (reasoningMaxChars > 0) {
+			reasoningProp.put("maxLength", reasoningMaxChars);
+		}
 
 		ObjectNode answerProp = mapper.createObjectNode();
 		answerProp.put("type", "string");

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -492,7 +492,12 @@ public class LocalLlmEngine implements LlmEngine {
 	String buildRequestBody(String systemPrompt, String userMessage, boolean stream,
 			int maxTokens) {
 		return buildRequestBody(systemPrompt, userMessage, stream, maxTokens,
-				ChartAnswerResponseFormat.build(MAPPER));
+				ChartAnswerResponseFormat.build(MAPPER, resolveReasoningMaxChars()));
+	}
+
+	/** Test seam wrapping {@link ChartSearchAiUtils#getReasoningMaxChars()} (fail-safe 0). */
+	int resolveReasoningMaxChars() {
+		return ChartSearchAiUtils.getReasoningMaxChars();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -185,7 +186,8 @@ public class RemoteLlmEngine implements LlmEngine {
 		}
 
 		root.set("response_format",
-				responseFormat != null ? responseFormat : ChartAnswerResponseFormat.build(MAPPER));
+				responseFormat != null ? responseFormat
+						: ChartAnswerResponseFormat.build(MAPPER, resolveReasoningMaxChars()));
 		root.set("messages", ChatMessages.systemAndUser(MAPPER, systemPrompt, userMessage));
 
 		try {
@@ -199,6 +201,12 @@ public class RemoteLlmEngine implements LlmEngine {
 	InferenceResult parseResponse(String responseBody) throws IOException {
 		return LlmResponseParser.parseResponse(responseBody, log);
 	}
+
+	/** Test seam wrapping {@link ChartSearchAiUtils#getReasoningMaxChars()} (fail-safe 0). */
+	int resolveReasoningMaxChars() {
+		return ChartSearchAiUtils.getReasoningMaxChars();
+	}
+
 
 	InferenceResult parseStreamingResponse(InputStream inputStream,
 			Consumer<String> tokenConsumer) throws IOException {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartAnswerResponseFormatTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartAnswerResponseFormatTest.java
@@ -52,4 +52,27 @@ public class ChartAnswerResponseFormatTest {
 		assertTrue(required.contains("answer"), "answer must be required");
 		assertTrue(required.contains("citations"), "citations must be required");
 	}
+
+	@Test
+	public void build_withReasoningCap_addsMaxLengthToReasoningOnly() {
+		// The reasoning scratchpad is the dominant decode cost on CPU-only servers (3-27s of
+		// thinking before any answer token). A grammar-enforced maxLength bounds it; the probe
+		// against the bundled llama-server confirmed json_schema maxLength is enforced exactly.
+		// The ANSWER must never be capped — it is the clinical content.
+		JsonNode props = ChartAnswerResponseFormat.build(new ObjectMapper(), 400)
+				.get("json_schema").get("schema").get("properties");
+		assertEquals(400, props.get("reasoning").get("maxLength").asInt(),
+				"the cap must land on the reasoning property");
+		assertTrue(props.get("answer").get("maxLength") == null,
+				"the answer must never be length-capped");
+	}
+
+	@Test
+	public void build_withZeroCap_matchesUncappedSchema() {
+		// 0 = disabled (the GP default): the schema must be byte-identical to the classic one so
+		// existing deployments see no behavior change whatsoever.
+		assertEquals(ChartAnswerResponseFormat.build(new ObjectMapper()),
+				ChartAnswerResponseFormat.build(new ObjectMapper(), 0),
+				"cap=0 must produce the exact uncapped schema");
+	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
@@ -32,6 +32,33 @@ public class LocalLlmEngineTest {
 	private final LocalLlmEngine engine = new LocalLlmEngine();
 
 	@Test
+	public void buildRequestBody_appliesReasoningCapFromConfiguration() throws IOException {
+		LocalLlmEngine capped = new LocalLlmEngine() {
+
+			@Override
+			int resolveReasoningMaxChars() {
+				return 400;
+			}
+		};
+		String body = capped.buildRequestBody("sys", "usr", false);
+		JsonNode props = MAPPER.readTree(body).get("response_format").get("json_schema")
+				.get("schema").get("properties");
+		assertEquals(400, props.get("reasoning").get("maxLength").asInt(),
+				"the configured reasoning cap must reach the request schema");
+		assertTrue(props.get("answer").get("maxLength") == null, "answer is never capped");
+	}
+
+	@Test
+	public void buildRequestBody_omitsReasoningCapByDefault() throws IOException {
+		// No OpenMRS context in this test -> the GP resolver fails safe to 0 -> no maxLength.
+		String body = engine.buildRequestBody("sys", "usr", false);
+		JsonNode reasoning = MAPPER.readTree(body).get("response_format").get("json_schema")
+				.get("schema").get("properties").get("reasoning");
+		assertTrue(reasoning.get("maxLength") == null,
+				"default (cap=0 / no context) must leave the schema uncapped");
+	}
+
+	@Test
 	public void buildRequestBody_shouldUseJsonSchemaStrictMode() throws IOException {
 		String body = engine.buildRequestBody("system prompt", "user message", false);
 		JsonNode root = MAPPER.readTree(body);

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -108,6 +108,12 @@
 	</globalProperty>
 
 	<globalProperty>
+		<property>chartsearchai.llm.reasoningMaxChars</property>
+		<defaultValue>0</defaultValue>
+		<description>When greater than 0, caps the model's "reasoning" scratchpad at this many characters via a grammar-enforced maxLength in the chart-answer schema. The reasoning phase is the dominant decode cost on CPU-only servers (3-27 seconds of thinking before any answer text); capping it bounds that cost. The answer itself is never capped. 0 (default) leaves the schema exactly as before. IMPORTANT: truncating the model's chain of thought can change its answers — only enable a value that has cleared the 32-cell answer-quality gold standard (eval/drift-metric/metric_gold.standalone.json) with no regression in mean F1, abstention accuracy, or off-topic citations versus the uncapped baseline. Measured 2026-06-12: Gemma 4 E2B at 400 FAILED that gate on all three axes (meanF1 0.464 to 0.428, abstention 1.00 to 0.91, off-topic citations 41 to 47) — no certified value exists; leave at 0 unless a fresh gate run for your model and value passes.</description>
+	</globalProperty>
+
+	<globalProperty>
 		<property>chartsearchai.rateLimitPerMinute</property>
 		<defaultValue>10</defaultValue>
 		<description>Maximum number of AI chart search queries a single user can make per minute. Set to 0 to disable rate limiting.</description>


### PR DESCRIPTION
Adds `chartsearchai.llm.reasoningMaxChars` (default 0 = byte-identical schema, test-pinned; the answer field is never capped) — and documents the measured **negative result** that is this PR's real payload.

Run through the restored 32-cell gold standard with thresholds set before the experiment (baseline captured twice, identical: meanF1 0.464 · abstention 1.00 · drift 41):

| metric | uncapped | E2B @ 400 chars | verdict |
|---|---|---|---|
| meanF1 | 0.464 | 0.428 | ✗ |
| abstention | 1.00 | 0.91 (false citation on an absent cell) | ✗ |
| off-topic citations | 41 | 47 | ✗ |

A binding cap cuts the chain of thought mid-derivation and answers degrade; a non-binding cap saves nothing. No certified value exists for E2B; the GP description and constants javadoc record this so the knob can't be enabled blind. It ships because the experiment is now reproducible in minutes for other models against the same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)