### PR TITLE
Fix EndToEndSearchTest provider swap after retrieval moved to ChartBuildingStrategy

### DIFF
--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/EndToEndSearchTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/EndToEndSearchTest.java
@@ -164,17 +164,21 @@ public class EndToEndSearchTest extends BaseModuleContextSensitiveTest {
 	}
 
 	/**
-	 * Swaps the {@code embeddingProvider} field on both the service and the
-	 * indexer so that the real ONNX model is used for both query embedding
-	 * and patient indexing. Returns the original providers for restoration.
+	 * Swaps the {@code embeddingProvider} field on the retrieval pipeline and the
+	 * indexer so that the real ONNX model is used for both query embedding and
+	 * patient indexing. Returns the original providers for restoration.
+	 *
+	 * <p>Query embedding moved out of {@link LlmInferenceService} into
+	 * {@link ChartBuildingStrategy} (which {@code service.findSimilar} now delegates
+	 * to), so the provider is swapped there rather than on the service.</p>
 	 */
 	private Object[] swapEmbeddingProviders(Object realProvider) throws Exception {
-		Object serviceTarget = unwrapProxy(service);
-		java.lang.reflect.Field serviceField =
-				LlmInferenceService.class.getDeclaredField("embeddingProvider");
-		serviceField.setAccessible(true);
-		Object originalServiceProvider = serviceField.get(serviceTarget);
-		serviceField.set(serviceTarget, realProvider);
+		Object strategyTarget = chartBuildingStrategyTarget();
+		java.lang.reflect.Field strategyField =
+				ChartBuildingStrategy.class.getDeclaredField("embeddingProvider");
+		strategyField.setAccessible(true);
+		Object originalStrategyProvider = strategyField.get(strategyTarget);
+		strategyField.set(strategyTarget, realProvider);
 
 		Object indexerTarget = unwrapProxy(embeddingIndexer);
 		java.lang.reflect.Field indexerField =
@@ -183,21 +187,34 @@ public class EndToEndSearchTest extends BaseModuleContextSensitiveTest {
 		Object originalIndexerProvider = indexerField.get(indexerTarget);
 		indexerField.set(indexerTarget, realProvider);
 
-		return new Object[] { originalServiceProvider, originalIndexerProvider };
+		return new Object[] { originalStrategyProvider, originalIndexerProvider };
 	}
 
 	private void restoreEmbeddingProviders(Object[] originals) throws Exception {
-		Object serviceTarget = unwrapProxy(service);
-		java.lang.reflect.Field serviceField =
-				LlmInferenceService.class.getDeclaredField("embeddingProvider");
-		serviceField.setAccessible(true);
-		serviceField.set(serviceTarget, originals[0]);
+		Object strategyTarget = chartBuildingStrategyTarget();
+		java.lang.reflect.Field strategyField =
+				ChartBuildingStrategy.class.getDeclaredField("embeddingProvider");
+		strategyField.setAccessible(true);
+		strategyField.set(strategyTarget, originals[0]);
 
 		Object indexerTarget = unwrapProxy(embeddingIndexer);
 		java.lang.reflect.Field indexerField =
 				EmbeddingIndexer.class.getDeclaredField("embeddingProvider");
 		indexerField.setAccessible(true);
 		indexerField.set(indexerTarget, originals[1]);
+	}
+
+	/**
+	 * Resolves the real {@link ChartBuildingStrategy} bean that {@code service}
+	 * delegates retrieval to, unwrapping AOP proxies so reflective field writes
+	 * land on the actual target the production search path uses.
+	 */
+	private Object chartBuildingStrategyTarget() throws Exception {
+		Object serviceTarget = unwrapProxy(service);
+		java.lang.reflect.Field strategyRef =
+				LlmInferenceService.class.getDeclaredField("chartBuildingStrategy");
+		strategyRef.setAccessible(true);
+		return unwrapProxy(strategyRef.get(serviceTarget));
 	}
 
 	/**


### PR DESCRIPTION
## What
The eval-tagged `EndToEndSearchTest` reflectively swapped the `embeddingProvider` field on `LlmInferenceService`, but the retrieval refactor moved query embedding out of `LlmInferenceService` into `ChartBuildingStrategy` (which `service.findSimilar` now delegates to). The stale field reference threw `NoSuchFieldException`, erroring the two methods that swap providers (`embeddingIndexer_shouldStoreNonZeroVectors`, `search_vitalsQuery_shouldReturnVitalsAnswer`).

## Fix
Retarget `swapEmbeddingProviders`/`restoreEmbeddingProviders` to `ChartBuildingStrategy.embeddingProvider`, reached via the service's `chartBuildingStrategy` field and AOP-unwrapped so the write lands on the real singleton target the production search path reads. The `EmbeddingIndexer` swap is unchanged (that field still exists).

## Why it's safe
No assertion was weakened and no expected value changed — the original assertions (67 records, non-zero vectors, vitals-only obs references, round-trip cosine 1.0, non-empty answer) all still run and pass. The swap is **load-bearing**: the test context's default `chartSearchAi.embeddingProvider` is the hash-based `primary` `StubEmbeddingProvider`, so a wrong-target swap would *fail* the vitals/round-trip assertions rather than pass them.

## Verification
`EndToEndSearchTest`: **4 run, 0 failures, 0 errors, 0 skipped** (rerun twice; ChartBuildingStrategy is a singleton so swap/restore hit the same target, and both callers guard the swap with try/finally so no provider leaks across tests).

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)