### PR TITLE
Phase 0.5 (#51): align platform to 2.9.0-SNAPSHOT so querystore co-loads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	</modules>
 
 	<properties>
-		<openmrsPlatformVersion>2.8.0</openmrsPlatformVersion>
+		<openmrsPlatformVersion>2.9.0-SNAPSHOT</openmrsPlatformVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
## Phase 0.5 of the querystore migration (#51): align platform so querystore co-loads

**Scope: the platform bump only.** This is the keystone the rest of the migration stacks on, kept deliberately minimal for fast review. (Eval harnesses + the `RelevanceCutoff` prototype that were previously bundled here have been moved to a separate branch — they're Phase-0 measurement scaffolding, not production wiring, and shouldn't land on main until the cutoff is actually used.)

### The change
`openmrsPlatformVersion` **2.8.0 → 2.9.0-SNAPSHOT** (one line). Lucene stays **8.11.2**.

- querystore-api requires the core #6084 service-event classes (`VoidServiceEvent`/`UnvoidServiceEvent`), absent on 2.8.0. Its provided-scope `moduleApplicationContext.xml` is component-scanned by the OpenMRS test framework, so on 2.8.0 the Spring context fails to load — silently breaking **every** context-sensitive test whenever querystore-api is on the classpath.
- 2.9.0-SNAPSHOT is what the standalone runs and what querystore targets. **Not** 3.0 — its Lucene 9 collides on the Codec ServiceLoader (per querystore's own pom note); 8.11.2 matches core's transitive Hibernate-Search line.
- `require_version` in `config.xml` derives from the property, so the module's declared requirement updates too.

### Verified
- Full reactor (api + omod) compiles clean against 2.9 and packages the `.omod`.
- **All tests pass, 0 failures** — 657 api + 40 omod. No 2.8→2.9 regressions; this also **repairs** the previously-red context-sensitive tests (they were silently broken on 2.8.0 whenever querystore-api was on the classpath).
- chartsearchai + querystore now co-load in a context-sensitive test.

Once this merges, Phase 1 (remove the duplicated indexing/sync layer) rebases onto a clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
