### PR TITLE
Fix legacy backfill-task cleanup failing on the JobRunr scheduler (#51)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiModuleActivator.java
@@ -157,8 +157,11 @@ public class ChartSearchAiModuleActivator extends BaseModuleActivator implements
 	 * Removes the "Chart Search AI - Embedding Backfill" scheduled task left behind by
 	 * pre-querystore versions. Its task class ({@code EmbeddingIndexTask}) was deleted when
 	 * chartsearchai stopped maintaining its own embedding store, so an upgraded deployment would
-	 * otherwise keep a {@link TaskDefinition} pointing at a class that no longer loads. Idempotent:
-	 * a no-op on fresh installs.
+	 * otherwise keep a {@link TaskDefinition} pointing at a class that no longer loads.
+	 *
+	 * <p>Idempotent and best-effort: a no-op on fresh installs, and if the scheduler cannot remove
+	 * the task (e.g. a JobRunr job left stuck in a {@code DELETED} state), it logs a WARN and leaves
+	 * the harmless task in place rather than failing module startup.
 	 */
 	void removeLegacyBackfillTask() {
 		SchedulerService schedulerService = Context.getSchedulerService();
@@ -167,19 +170,22 @@ public class ChartSearchAiModuleActivator extends BaseModuleActivator implements
 			return;
 		}
 		try {
-			schedulerService.shutdownTask(existing);
-		}
-		catch (Exception e) {
-			// A non-running task (the backfill never auto-started) can throw here; deletion below
-			// still proceeds. Logged at debug because it is expected on the common path.
-			log.debug("Legacy backfill task was not running at shutdown", e);
-		}
-		try {
+			// deleteTask both stops the task and removes its definition. Do NOT call shutdownTask
+			// first: on the platform-2.9 JobRunr scheduler, deleteTask internally shuts the task
+			// down, so a prior shutdownTask leaves the underlying job already DELETED and the
+			// internal shutdown then throws IllegalJobStateChangeException (DELETED -> DELETED),
+			// aborting the delete and leaving the legacy task behind.
 			schedulerService.deleteTask(existing.getId());
 			log.info("Removed legacy embedding backfill task (its EmbeddingIndexTask class no longer exists)");
 		}
 		catch (Exception e) {
-			log.error("Failed to delete legacy embedding backfill task", e);
+			// Non-fatal: the leftover task is harmless (it cannot run — its class is gone), so a
+			// failed auto-removal must not noise up startup with an ERROR/stack. WARN with an
+			// actionable next step. (Platform-2.9's JobRunr scheduler can leave a job stuck in a
+			// DELETED state that deleteTask cannot re-delete; the task can be removed by hand.)
+			log.warn("Could not auto-remove the legacy '{}' scheduled task (its EmbeddingIndexTask "
+					+ "class no longer exists). It is harmless and cannot run; delete it manually from "
+					+ "Manage Scheduler if desired. Cause: {}", LEGACY_BACKFILL_TASK_NAME, e.toString());
 		}
 	}
 


### PR DESCRIPTION
## Fix: legacy backfill-task cleanup fails on the JobRunr scheduler

Follow-up bugfix to #53. The `removeLegacyBackfillTask` cleanup added in #53 **does not work on platform 2.9's JobRunr-backed scheduler** — it errors on every module startup and leaves the legacy task in place.

### Root cause
`removeLegacyBackfillTask` called `shutdownTask(existing)` and then `deleteTask(id)`. On 2.9, `JobRunrSchedulerService.deleteTask` *internally* shuts the task down too, so the prior `shutdownTask` leaves the underlying JobRunr job already `DELETED`; the internal shutdown then throws:

```
org.jobrunr.jobs.states.IllegalJobStateChangeException: A job cannot change state from DELETED to DELETED.
  at org.openmrs.scheduler.jobrunr.JobRunrSchedulerService.deleteTask(...)
  at ...ChartSearchAiModuleActivator.removeLegacyBackfillTask(...)
```

The `deleteTask` aborts, the legacy task survives, and startup logs an ERROR + stack every time.

### Fix
- Drop the explicit `shutdownTask` call — `deleteTask` already shuts down internally.
- Downgrade the unrecoverable path to a **non-fatal WARN** with an actionable message (the leftover task is harmless: its `EmbeddingIndexTask` class is gone, so it cannot run; it can be deleted by hand from Manage Scheduler).

### Verified on the standalone (refapp 3.7 / JobRunr)
Reproduced the realistic upgrade path: deployed a pre-#53 build to register the backfill task in a normal state, then deployed this fix and restarted → **the task is removed cleanly, no JobRunr exception, module up**.

### Why #53's unit test missed it
`ChartSearchAiModuleActivatorTest` seeds a task and asserts it's removed — and passes — but the in-test scheduler is **not** JobRunr, so it can't reproduce the `DELETED → DELETED` behavior. This class of bug is only observable against the real scheduler; standalone verification caught it. (Noted as a known harness limitation rather than papered over with a test that can't actually exercise the path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
