### PR TITLE
ci: pin a portable x86-64 ISA baseline for the published natives

### DIFF
--- a/.github/workflows/publish-natives.yml
+++ b/.github/workflows/publish-natives.yml
@@ -40,7 +40,15 @@ jobs:
             # We ship only the binary (no sibling libs), so don't link OpenSSL - it
             # isn't needed for local inference and libssl.so.3/libcrypto.so.3 would be
             # missing on minimal hosts. (Matches every other leg; see the Windows x64 note.)
-            cmake_extra: '-DLLAMA_OPENSSL=OFF'
+            # Pin a portable x86-64 ISA baseline instead of GGML_NATIVE's default (-march=native),
+            # which tunes the binary to THIS Intel runner's CPU (incl. AVX-512). That published
+            # binary then risks SIGILL on hosts lacking those extensions - e.g. the AMD EPYC Milan
+            # demo box is AVX2-only (no AVX-512). AVX2+FMA+F16C (~x86-64-v3 sans AVX-512) is the
+            # practical floor for any host that can run a local LLM and is what the demo already
+            # uses, so this is portability/safety, not a perf change. Mirrors the ARM legs pinning
+            # armv8.2-a. (For peak-per-host later: GGML_BACKEND_DL + GGML_CPU_ALL_VARIANTS, but that
+            # ships multiple .so variants and breaks the single-self-contained-binary assumption.)
+            cmake_extra: '-DLLAMA_OPENSSL=OFF -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON'
           - os: ubuntu-22.04-arm
             platform: Linux
             arch: aarch64
@@ -63,9 +71,13 @@ jobs:
             #   GGML_OPENMP=OFF            - drop vcomp140.dll (matches the Windows ARM64 leg)
             #   CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded - static CRT, drop msvcp140 /
             #                                vcruntime140 / vcruntime140_1
+            #   GGML_NATIVE=OFF + AVX/AVX2/FMA/F16C - pin a portable x86-64 baseline instead of
+            #                                -march=native, which would tune the .exe to this Intel
+            #                                runner (incl. AVX-512) and risk SIGILL on AVX2-only or
+            #                                AMD hosts. Same baseline as the Linux x86_64 leg.
             # Result: imports only in-box Windows DLLs (kernel32, advapi32, ws2_32,
             # crypt32, and the Win10/11 UCRT api-ms-win-crt-*). Verified with objdump.
-            cmake_extra: '-DLLAMA_OPENSSL=OFF -DGGML_OPENMP=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded'
+            cmake_extra: '-DLLAMA_OPENSSL=OFF -DGGML_OPENMP=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON'
           - os: windows-2022
             platform: Windows
             arch: aarch64


### PR DESCRIPTION
## Problem

The two **x86_64** legs of `publish-natives.yml` (Linux and Windows) are the only matrix legs that leave `GGML_NATIVE` at its default (**ON**). cmake therefore builds them with `-march=native`, tuning the published binary to the **GitHub runner's Intel CPU** — which can bake in AVX-512. Every other leg already pins a baseline:

| Leg | ISA pin today |
|---|---|
| Mac aarch64 | `GGML_NATIVE=OFF` + `armv8.2-a` |
| Mac x86_64 | `GGML_NATIVE=OFF` |
| Linux aarch64 | `GGML_NATIVE=OFF` + `armv8.2-a` |
| **Linux x86_64** | **(none — `-march=native`)** ⬅ |
| **Windows x86_64** | **(none — `-march=native`)** ⬅ |

A binary tuned to the *build* host is a latent **SIGILL hazard** on any *deployment* CPU that lacks those extensions.

## Evidence

The `chartsearchai.openmrs.org` demo runs on an **AMD EPYC Milan (Zen 3), AVX2-only** (no AVX-512/VNNI/AMX) — measured directly via a CPU-flags breadcrumb. It works today only because the current runner's `-march=native` happened not to emit AVX-512; a future runner bump could publish a binary that **crashes on the demo box** with no code change on our side.

## Fix

Pin `GGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON` on both x86_64 legs — the **~x86-64-v3 (sans AVX-512)** baseline. That's the practical floor for any host that can run a local LLM, and is exactly what the demo already uses.

- **Portability/safety, not perf.** It can only drop a *possible* AVX-512 path on Intel hosts (where llama.cpp's AVX-512 CPU gains are marginal and can even downclock), in exchange for a binary guaranteed to run on every x86-64-v3 host. Mirrors the ARM legs choosing `armv8.2-a` over native.
- **No packaging change.** Still a single self-contained binary (no new `.so`/`.dll`), so the existing "Verify the binary is self-contained" step is unaffected.

## Out of scope

For true peak-per-host, the right tool is runtime CPU dispatch (`GGML_BACKEND_DL` + `GGML_CPU_ALL_VARIANTS`), but that ships multiple backend variant libraries and would need packaging/extraction changes (`libs.txt`, `LlamaServerBinary`). Deliberately left for a separate change.

## Validation

YAML parses clean. The build itself should be confirmed by **dispatching this workflow on the branch** (the `publish` job only deploys from `main`, so a branch dispatch builds every platform and uploads the binaries as artifacts without republishing) — verifying the x86_64 and Windows-x64 legs still compile and the resulting binaries run. No runtime/module code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)