### PR TITLE
Progressive reasoning: stream a fast preview before the full-chart answer

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -111,6 +111,31 @@ public class ChartSearchAiConstants {
 	public static final String GP_WARMUP_ENABLED = "chartsearchai.warmupEnabled";
 
 	/**
+	 * When {@code true}, a streaming query first runs a fast "preview" reasoning pass over only the
+	 * querystore top-K query-relevant records and streams that reasoning to the thinking channel,
+	 * ahead of the unchanged full-chart answer. The focused chart is a few hundred tokens versus the
+	 * full chart's several thousand, so on a GPU-less host its prefill — and thus
+	 * time-to-first-reasoning — is far smaller. The committed answer is still the full-chart call
+	 * (the preview answer is discarded), so response quality is unchanged. Default {@code false}
+	 * (opt-in): the two passes serialize on llama-server's single slot, so it trades a marginally
+	 * longer time-to-final-answer for a much shorter time-to-first-reasoning. See
+	 * {@code LlmInferenceService.maybeEmitPreliminaryReasoning}.
+	 */
+	public static final String GP_PROGRESSIVE_REASONING_ENABLED = "chartsearchai.progressiveReasoning.enabled";
+
+	public static final boolean DEFAULT_PROGRESSIVE_REASONING_ENABLED = false;
+
+	/**
+	 * Number of top-ranked querystore records the progressive-reasoning preview pass reasons over.
+	 * Smaller = faster preview prefill but less context for the preliminary reasoning; the committed
+	 * full-chart answer is unaffected either way. Kept distinct from {@link #GP_QUERYSTORE_TOP_K}
+	 * (the focus-hint size) so the two can be tuned independently.
+	 */
+	public static final String GP_PROGRESSIVE_REASONING_TOP_K = "chartsearchai.progressiveReasoning.topK";
+
+	public static final int DEFAULT_PROGRESSIVE_REASONING_TOP_K = 15;
+
+	/**
 	 * When {@code true}, every cited record is checked for grounding after the
 	 * LLM answers: the record's text must be semantically close enough to the
 	 * answer sentence(s) that cite it, otherwise the citation is flagged as

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -118,8 +118,9 @@ public interface ChartSearchService {
 	/**
 	 * Streaming variant that additionally routes the progressive-reasoning PREVIEW pass's reasoning
 	 * to {@code preliminaryReasoningConsumer} — a separate channel from {@code reasoningConsumer} —
-	 * so a caller can render it as provisional ("preliminary, verifying…") and replace it the moment
-	 * the committed full-chart reasoning begins arriving on {@code reasoningConsumer}. Only fires when
+	 * so a caller can render it as provisional (clearly an in-progress preview, not the answer) and
+	 * replace it the moment the committed full-chart reasoning begins arriving on
+	 * {@code reasoningConsumer}. Only fires when
 	 * {@code chartsearchai.progressiveReasoning.enabled} is on (otherwise the preliminary channel is
 	 * never called and this behaves exactly like the six-arg overload).
 	 *

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -130,6 +130,11 @@ public interface ChartSearchService {
 	 * the preliminary channel explicitly, the same discipline the six-arg overload's abstractness
 	 * enforces for the ungrounded-answer channel.
 	 *
+	 * <p><strong>Override discipline:</strong> an implementation whose six-arg overload delegates
+	 * <em>up</em> to this seven-arg (as the inference service and the caching router do) MUST also
+	 * override this seven-arg — relying on this default while the six-arg delegates up would recurse
+	 * (default → six-arg → this default → …).
+	 *
 	 * @param preliminaryReasoningConsumer called with each preview-reasoning fragment; never called
 	 *        when progressive reasoning is off or no relevant records are found
 	 */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -116,6 +116,31 @@ public interface ChartSearchService {
 			Consumer<ChartAnswer> ungroundedAnswerConsumer);
 
 	/**
+	 * Streaming variant that additionally routes the progressive-reasoning PREVIEW pass's reasoning
+	 * to {@code preliminaryReasoningConsumer} — a separate channel from {@code reasoningConsumer} —
+	 * so a caller can render it as provisional ("preliminary, verifying…") and replace it the moment
+	 * the committed full-chart reasoning begins arriving on {@code reasoningConsumer}. Only fires when
+	 * {@code chartsearchai.progressiveReasoning.enabled} is on (otherwise the preliminary channel is
+	 * never called and this behaves exactly like the six-arg overload).
+	 *
+	 * <p>The default delegates to the six-arg overload, which routes any preview reasoning to
+	 * {@code reasoningConsumer} (merged, not separated) — so an implementation that does not override
+	 * this still SHOWS preview reasoning, it just does not split it onto its own channel. Concrete
+	 * streaming implementations and delegating wrappers (the caching router) override this to route
+	 * the preliminary channel explicitly, the same discipline the six-arg overload's abstractness
+	 * enforces for the ungrounded-answer channel.
+	 *
+	 * @param preliminaryReasoningConsumer called with each preview-reasoning fragment; never called
+	 *        when progressive reasoning is off or no relevant records are found
+	 */
+	default ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer,
+			Consumer<String> reasoningConsumer, Consumer<List<RecordReference>> citationsConsumer,
+			Consumer<ChartAnswer> ungroundedAnswerConsumer, Consumer<String> preliminaryReasoningConsumer) {
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, citationsConsumer,
+				ungroundedAnswerConsumer);
+	}
+
+	/**
 	 * Pre-warm any patient-specific caches (serialized chart, LLM prompt cache) so the
 	 * first real query on this patient does not pay cold-start cost. Implementations
 	 * that don't support warmup may return immediately. Callers should treat this as

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartBuildingStrategy.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartBuildingStrategy.java
@@ -35,6 +35,16 @@ class ChartBuildingStrategy {
 		return queryStoreChartBuilder.build(patient, question);
 	}
 
+	/**
+	 * Builds a small "focused" chart of only the querystore top-K records most relevant to the
+	 * question, for the progressive-reasoning preview pass. Unlike {@link #buildChart}, this is
+	 * query-dependent and is never the committed answer's context — see
+	 * {@code LlmInferenceService.maybeEmitPreliminaryReasoning}.
+	 */
+	PatientChart buildFocusedChart(Patient patient, String question) {
+		return queryStoreChartBuilder.buildFocused(patient, question);
+	}
+
 	boolean usePreFilter() {
 		return PipelineSettings.usePreFilter();
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
@@ -98,6 +98,16 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
 			Consumer<List<RecordReference>> citationsConsumer,
 			Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+		// No separate preliminary channel: route preview reasoning (if any) to the reasoning channel.
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, citationsConsumer,
+				ungroundedAnswerConsumer, reasoningConsumer);
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+			Consumer<List<RecordReference>> citationsConsumer,
+			Consumer<ChartAnswer> ungroundedAnswerConsumer, Consumer<String> preliminaryReasoningConsumer) {
 		int ttlMinutes = getCacheTtlMinutes();
 
 		if (ttlMinutes > 0) {
@@ -118,13 +128,14 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 			}
 
 			ChartAnswer answer = llmService.searchStreaming(patient, question, tokenConsumer,
-					reasoningConsumer, citationsConsumer, ungroundedAnswerConsumer);
+					reasoningConsumer, citationsConsumer, ungroundedAnswerConsumer,
+					preliminaryReasoningConsumer);
 			putCache(cacheKey, answer);
 			return answer;
 		}
 
 		return llmService.searchStreaming(patient, question, tokenConsumer, reasoningConsumer,
-				citationsConsumer, ungroundedAnswerConsumer);
+				citationsConsumer, ungroundedAnswerConsumer, preliminaryReasoningConsumer);
 	}
 
 	/** Test seam: production wires the inference service via {@link Autowired}. */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -53,6 +53,10 @@ public class LlmInferenceService implements ChartSearchService {
 
 	private static final Logger log = LoggerFactory.getLogger(LlmInferenceService.class);
 
+	/** Sink for the progressive-reasoning preview pass's answer tokens: the preview's answer is never
+	 *  shown — only its reasoning surfaces, and only the full-chart pass is committed. */
+	private static final Consumer<String> DISCARD_TOKENS = token -> { };
+
 	@Autowired
 	private LlmProvider llmProvider;
 
@@ -227,6 +231,52 @@ public class LlmInferenceService implements ChartSearchService {
 		return patient.getUuid();
 	}
 
+	/** Test seam wrapping {@link PipelineSettings#progressiveReasoningEnabled()}; production
+	 *  delegates, tests override to exercise the preview path without an OpenMRS context. */
+	protected boolean resolveProgressiveReasoningEnabled() {
+		return PipelineSettings.progressiveReasoningEnabled();
+	}
+
+	/**
+	 * Progressive reasoning (stage 1): when {@code chartsearchai.progressiveReasoning.enabled}, run a
+	 * fast LLM pass over ONLY the querystore top-K focused chart and stream its reasoning to the
+	 * {@code reasoningConsumer} ("thinking" channel), ahead of the unchanged full-chart answer. The
+	 * focused chart is a few hundred tokens vs the full chart's several thousand, so on a GPU-less
+	 * host its prefill — and thus time-to-first-reasoning — is far smaller. Quality is unaffected:
+	 * the preview's answer tokens are discarded ({@link #DISCARD_TOKENS}); only the full-chart pass
+	 * (run by the caller after this) is committed; and the preview uses a {@code null} KV scope so it
+	 * does no on-disk KV I/O and never writes the patient's persisted full-chart KV entry. (It does
+	 * occupy llama-server's single slot, so the full pass that follows restores the full-chart KV
+	 * from disk rather than reusing warm RAM — keep {@code chartsearchai.llm.kvCacheDir} enabled.)
+	 * A preview failure is
+	 * swallowed — the full-chart answer is authoritative and must never be blocked by this optional
+	 * speed-up. Returns the elapsed wall time (the {@code previewMs} timing field), or 0 when the
+	 * gate is off or the focused chart has no records.
+	 */
+	private long maybeEmitPreliminaryReasoning(Patient patient, String question,
+			Consumer<String> reasoningConsumer) {
+		long start = System.currentTimeMillis();
+		try {
+			if (!resolveProgressiveReasoningEnabled()) {
+				return 0L;
+			}
+			PatientChart focused = chartBuildingStrategy.buildFocusedChart(patient, question);
+			if (focused != null && !focused.getMappings().isEmpty()) {
+				llmProvider.searchStreaming(focused.getText(), focused.getFocusIndices(), question,
+						DISCARD_TOKENS, reasoningConsumer, null);
+			}
+		}
+		catch (RuntimeException e) {
+			// The preview is an optional speed-up; if anything fails (including reading the gate GP
+			// when no OpenMRS context is available) skip it. The full-chart answer is authoritative
+			// and must never be blocked by it.
+			log.warn("Preliminary reasoning skipped for patient [id={}]: {}",
+					patient == null ? null : patient.getPatientId(), e.getMessage());
+			return 0L;
+		}
+		return System.currentTimeMillis() - start;
+	}
+
 	@Override
 	public ChartAnswer searchStreaming(Patient patient, String question,
 			Consumer<String> tokenConsumer) {
@@ -253,11 +303,13 @@ public class LlmInferenceService implements ChartSearchService {
 			Consumer<List<RecordReference>> citationsConsumer,
 			Consumer<ChartAnswer> ungroundedAnswerConsumer) {
 		// LOG FORMAT — stable contract: same field set as search() with op=searchStreaming
-		// in the log tag, plus groundMs (Tier-2 grounding is now timed separately so the tail is
-		// visible). Streaming is the path the frontend actually uses by default, so this is what
-		// demo operators see in their logs. try/finally so exceptions still emit a timing line.
+		// in the log tag, plus previewMs (progressive-reasoning preview pass) and groundMs (Tier-2
+		// grounding, timed separately so the tail is visible). Streaming is the path the frontend
+		// actually uses by default, so this is what demo operators see in their logs. try/finally
+		// so exceptions still emit a timing line.
 		long buildStart = System.currentTimeMillis();
 		long buildMs = 0;
+		long previewMs = 0;
 		long llmMs = 0;
 		long groundMs = 0;
 		long inputTokens = 0;
@@ -267,6 +319,12 @@ public class LlmInferenceService implements ChartSearchService {
 			PatientChart chart = chartBuildingStrategy.buildChart(patient, question);
 			chart = drugReferenceInjector.inject(chart, patient, question);
 			buildMs = System.currentTimeMillis() - buildStart;
+
+			// Progressive reasoning: stream a fast preview reasoning from the focused top-K chart to
+			// the thinking channel before the full-chart answer prefills. No-op (returns 0) when the
+			// gate is off. Runs after the full chart is built so the patient's querystore index is
+			// already warm when the preview's searchByPatient runs (a cold patient pays it once).
+			previewMs = maybeEmitPreliminaryReasoning(patient, question, reasoningConsumer);
 
 			long llmStart = System.currentTimeMillis();
 			LlmResponse response = llmProvider.searchStreaming(
@@ -305,9 +363,9 @@ public class LlmInferenceService implements ChartSearchService {
 			return answer;
 		}
 		finally {
-			log.info("[timing] searchStreaming patient={} chartBuildMs={} llmMs={} groundMs={} totalMs={} inputTokens={} cachedTokens={} outcome={}",
+			log.info("[timing] searchStreaming patient={} chartBuildMs={} previewMs={} llmMs={} groundMs={} totalMs={} inputTokens={} cachedTokens={} outcome={}",
 					patient == null ? null : patient.getPatientId(),
-					buildMs, llmMs, groundMs, buildMs + llmMs + groundMs,
+					buildMs, previewMs, llmMs, groundMs, buildMs + previewMs + llmMs + groundMs,
 					inputTokens, cachedTokens, outcome);
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -239,8 +239,9 @@ public class LlmInferenceService implements ChartSearchService {
 
 	/**
 	 * Progressive reasoning (stage 1): when {@code chartsearchai.progressiveReasoning.enabled}, run a
-	 * fast LLM pass over ONLY the querystore top-K focused chart and stream its reasoning to the
-	 * {@code reasoningConsumer} ("thinking" channel), ahead of the unchanged full-chart answer. The
+	 * fast LLM pass over ONLY the querystore top-K focused chart and stream its reasoning to
+	 * {@code previewReasoningConsumer} — the dedicated preliminary channel on the 7-arg path (or the
+	 * reasoning channel via the 6-arg overload) — ahead of the unchanged full-chart answer. The
 	 * focused chart is a few hundred tokens vs the full chart's several thousand, so on a GPU-less
 	 * host its prefill — and thus time-to-first-reasoning — is far smaller. Quality is unaffected:
 	 * the preview's answer tokens are discarded ({@link #DISCARD_TOKENS}); only the full-chart pass
@@ -254,7 +255,7 @@ public class LlmInferenceService implements ChartSearchService {
 	 * gate is off or the focused chart has no records.
 	 */
 	private long maybeEmitPreliminaryReasoning(Patient patient, String question,
-			Consumer<String> reasoningConsumer) {
+			Consumer<String> previewReasoningConsumer) {
 		long start = System.currentTimeMillis();
 		try {
 			if (!resolveProgressiveReasoningEnabled()) {
@@ -263,7 +264,7 @@ public class LlmInferenceService implements ChartSearchService {
 			PatientChart focused = chartBuildingStrategy.buildFocusedChart(patient, question);
 			if (focused != null && !focused.getMappings().isEmpty()) {
 				llmProvider.searchStreaming(focused.getText(), focused.getFocusIndices(), question,
-						DISCARD_TOKENS, reasoningConsumer, null);
+						DISCARD_TOKENS, previewReasoningConsumer, null);
 			}
 		}
 		catch (RuntimeException e) {
@@ -332,7 +333,7 @@ public class LlmInferenceService implements ChartSearchService {
 			buildMs = System.currentTimeMillis() - buildStart;
 
 			// Progressive reasoning: stream a fast preview reasoning from the focused top-K chart to
-			// the thinking channel before the full-chart answer prefills. No-op (returns 0) when the
+			// the preliminary channel before the full-chart answer prefills. No-op (returns 0) when the
 			// gate is off. Runs after the full chart is built so the patient's querystore index is
 			// already warm when the preview's searchByPatient runs (a cold patient pays it once).
 			previewMs = maybeEmitPreliminaryReasoning(patient, question, preliminaryReasoningConsumer);

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -302,6 +302,17 @@ public class LlmInferenceService implements ChartSearchService {
 			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
 			Consumer<List<RecordReference>> citationsConsumer,
 			Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+		// No separate preliminary channel requested: route the progressive-reasoning preview (if any)
+		// to the reasoning channel, exactly as before the preliminary channel existed.
+		return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, citationsConsumer,
+				ungroundedAnswerConsumer, reasoningConsumer);
+	}
+
+	@Override
+	public ChartAnswer searchStreaming(Patient patient, String question,
+			Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+			Consumer<List<RecordReference>> citationsConsumer,
+			Consumer<ChartAnswer> ungroundedAnswerConsumer, Consumer<String> preliminaryReasoningConsumer) {
 		// LOG FORMAT — stable contract: same field set as search() with op=searchStreaming
 		// in the log tag, plus previewMs (progressive-reasoning preview pass) and groundMs (Tier-2
 		// grounding, timed separately so the tail is visible). Streaming is the path the frontend
@@ -324,7 +335,7 @@ public class LlmInferenceService implements ChartSearchService {
 			// the thinking channel before the full-chart answer prefills. No-op (returns 0) when the
 			// gate is off. Runs after the full chart is built so the patient's querystore index is
 			// already warm when the preview's searchByPatient runs (a cold patient pays it once).
-			previewMs = maybeEmitPreliminaryReasoning(patient, question, reasoningConsumer);
+			previewMs = maybeEmitPreliminaryReasoning(patient, question, preliminaryReasoningConsumer);
 
 			long llmStart = System.currentTimeMillis();
 			LlmResponse response = llmProvider.searchStreaming(

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PipelineSettings.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PipelineSettings.java
@@ -40,8 +40,28 @@ final class PipelineSettings {
 	}
 
 	static int getQueryStoreTopK() {
-		String value = Context.getAdministrationService()
-				.getGlobalProperty(ChartSearchAiConstants.GP_QUERYSTORE_TOP_K);
+		return readPositiveInt(ChartSearchAiConstants.GP_QUERYSTORE_TOP_K,
+				ChartSearchAiConstants.DEFAULT_QUERYSTORE_TOP_K, "queryStoreTopK");
+	}
+
+	static boolean progressiveReasoningEnabled() {
+		String mode = Context.getAdministrationService().getGlobalProperty(
+				ChartSearchAiConstants.GP_PROGRESSIVE_REASONING_ENABLED,
+				String.valueOf(ChartSearchAiConstants.DEFAULT_PROGRESSIVE_REASONING_ENABLED));
+		return "true".equalsIgnoreCase(mode.trim());
+	}
+
+	static int getProgressiveReasoningTopK() {
+		return readPositiveInt(ChartSearchAiConstants.GP_PROGRESSIVE_REASONING_TOP_K,
+				ChartSearchAiConstants.DEFAULT_PROGRESSIVE_REASONING_TOP_K, "progressiveReasoningTopK");
+	}
+
+	/** Reads a strictly-positive integer global property, or returns {@code defaultValue} when the
+	 *  property is unset, blank, non-numeric, or not positive. A non-numeric value is logged at WARN
+	 *  ({@code label} names the setting). The parse/validation contract lives here so the two topK
+	 *  getters (querystore focus-hint and progressive-reasoning preview) cannot drift apart. */
+	private static int readPositiveInt(String gpKey, int defaultValue, String label) {
+		String value = Context.getAdministrationService().getGlobalProperty(gpKey);
 		if (value != null && !value.trim().isEmpty()) {
 			try {
 				int parsed = Integer.parseInt(value.trim());
@@ -50,9 +70,9 @@ final class PipelineSettings {
 				}
 			}
 			catch (NumberFormatException e) {
-				log.warn("Invalid queryStoreTopK value '{}', using default", value);
+				log.warn("Invalid {} value '{}', using default", label, value);
 			}
 		}
-		return ChartSearchAiConstants.DEFAULT_QUERYSTORE_TOP_K;
+		return defaultValue;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
@@ -171,6 +171,64 @@ class QueryStoreChartBuilder {
 		return chart;
 	}
 
+	/**
+	 * Builds a focused chart of only the top-K querystore records most relevant to {@code question},
+	 * for the progressive-reasoning preview pass. Uses the SAME relevance ranking the preFilter focus
+	 * hint uses ({@link QueryStoreService#searchByPatient}), but here the K records ARE the chart (a
+	 * few hundred tokens) rather than a hint over the full chart — so the preview's prefill is small.
+	 * Returns an empty chart on a null/blank question, missing patient, unavailable querystore, or an
+	 * empty hit list; the caller treats an empty focused chart as "no preview".
+	 */
+	PatientChart buildFocused(Patient patient, String question) {
+		long buildStart = System.currentTimeMillis();
+		// Every exit emits a [timing] querystoreFocusedBuild line (outcome=skipped|unavailable|error|ok),
+		// matching build()'s contract so a dashboard grepping outcome= doesn't undercount focused-build
+		// failures.
+		if (patient == null || patient.getUuid() == null || question == null || question.trim().isEmpty()) {
+			log.info("[timing] querystoreFocusedBuild patient={} hits=0 rpcMs=0 serializeMs=0 totalMs={} outcome=skipped",
+					patient == null ? null : patient.getPatientId(), System.currentTimeMillis() - buildStart);
+			return chartSerializer.serialize(patient, Collections.<SerializedRecord>emptyList());
+		}
+
+		QueryStoreService queryStore;
+		try {
+			queryStore = resolveQueryStoreService();
+		}
+		catch (APIException | LinkageError e) {
+			// The full-chart build() runs first on the same request and logs the actionable
+			// "check the querystore module" remediation; here we only record the outcome for parity.
+			log.info("[timing] querystoreFocusedBuild patient={} hits=0 rpcMs=0 serializeMs=0 totalMs={} outcome=unavailable",
+					patient.getPatientId(), System.currentTimeMillis() - buildStart);
+			return chartSerializer.serialize(patient, Collections.<SerializedRecord>emptyList());
+		}
+
+		long rpcStart = System.currentTimeMillis();
+		List<QueryDocument> hits;
+		try {
+			String preprocessedQuestion = QueryPreprocessor.stripQueryStopwords(question);
+			hits = queryStore.searchByPatient(patient.getUuid(), preprocessedQuestion,
+					resolveProgressiveReasoningTopK());
+		}
+		catch (RuntimeException e) {
+			log.warn("QueryStore.searchByPatient failed for focused build [uuid={}] — returning empty focused chart",
+					patient.getUuid(), e);
+			log.info("[timing] querystoreFocusedBuild patient={} hits=0 rpcMs={} serializeMs=0 totalMs={} outcome=error errorClass={}",
+					patient.getPatientId(), System.currentTimeMillis() - rpcStart,
+					System.currentTimeMillis() - buildStart, e.getClass().getSimpleName());
+			return chartSerializer.serialize(patient, Collections.<SerializedRecord>emptyList());
+		}
+		long rpcMs = System.currentTimeMillis() - rpcStart;
+
+		List<SerializedRecord> records = toSerializedRecords(hits);
+		long serializeStart = System.currentTimeMillis();
+		PatientChart chart = chartSerializer.serialize(patient, records);
+		long serializeMs = System.currentTimeMillis() - serializeStart;
+		log.info("[timing] querystoreFocusedBuild patient={} hits={} rpcMs={} serializeMs={} totalMs={} outcome=ok",
+				patient.getPatientId(), records.size(), rpcMs, serializeMs,
+				System.currentTimeMillis() - buildStart);
+		return chart;
+	}
+
 	/** Collects {@code resource_uuid}s from a hit list, skipping nulls and malformed docs.
 	 *  These uuids are mapped to 1-based chart indices in {@code PatientChartSerializer.serialize}
 	 *  to render the LLM-facing focus hint. */
@@ -242,6 +300,11 @@ class QueryStoreChartBuilder {
 	/** Seam for tests: production reads the global property. */
 	protected int resolveQueryStoreTopK() {
 		return PipelineSettings.getQueryStoreTopK();
+	}
+
+	/** Seam for tests: production reads the global property. */
+	protected int resolveProgressiveReasoningTopK() {
+		return PipelineSettings.getProgressiveReasoningTopK();
 	}
 
 	/** Seam for tests: production reads the global property. */

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouterTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouterTest.java
@@ -291,4 +291,51 @@ public class ChartSearchServiceRouterTest {
 		assertEquals(Boolean.TRUE, hit.getReferences().get(0).getGrounded(),
 				"the cached answer keeps its verdicts");
 	}
+
+	// ---- progressive-reasoning preliminary channel (7-arg searchStreaming) ----
+
+	/** Delegate that overrides the 7-arg to echo the preliminary consumer, so a test can prove the
+	 *  router threads it through to the inference service rather than dropping it — the consumer-loss
+	 *  bug class the abstract 6-arg overload exists to prevent. */
+	private static class SevenArgDelegate extends StubDelegate {
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question,
+				java.util.function.Consumer<String> tokenConsumer,
+				java.util.function.Consumer<String> reasoningConsumer,
+				java.util.function.Consumer<java.util.List<RecordReference>> citationsConsumer,
+				java.util.function.Consumer<ChartAnswer> ungroundedAnswerConsumer,
+				java.util.function.Consumer<String> preliminaryReasoningConsumer) {
+			preliminaryReasoningConsumer.accept("PREVIEW");
+			return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, citationsConsumer,
+					ungroundedAnswerConsumer);
+		}
+	}
+
+	@Test
+	public void searchStreaming_passThroughForwardsPreliminaryConsumer() {
+		SevenArgDelegate delegate = new SevenArgDelegate();
+		StubRouter router = routerWith(delegate, 0);
+		java.util.List<String> preliminary = new java.util.ArrayList<String>();
+
+		router.searchStreaming(patient("p1"), "tb?", t -> { }, r -> { }, c -> { }, a -> { }, preliminary::add);
+
+		assertEquals(java.util.Collections.singletonList("PREVIEW"), preliminary,
+				"the uncached path must thread the preliminary consumer to the delegate's 7-arg — dropping "
+				+ "it would silently lose preview separation in production (controller -> router -> service)");
+	}
+
+	@Test
+	public void searchStreaming_cacheHitDoesNotFirePreliminaryConsumer() {
+		SevenArgDelegate delegate = new SevenArgDelegate();
+		StubRouter router = routerWith(delegate, 5);
+		java.util.List<String> preliminary = new java.util.ArrayList<String>();
+
+		router.searchStreaming(patient("p1"), "tb?", t -> { }, r -> { }, c -> { }, a -> { }, preliminary::add);
+		assertEquals(1, preliminary.size(), "first call misses — the preview pass runs and fires preliminary");
+
+		router.searchStreaming(patient("p1"), "tb?", t -> { }, r -> { }, c -> { }, a -> { }, preliminary::add);
+		assertEquals(1, preliminary.size(),
+				"a cache hit replays the final answer with no preview pass — preliminary must NOT fire again");
+	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceProgressiveReasoningTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceProgressiveReasoningTest.java
@@ -159,6 +159,30 @@ public class LlmInferenceServiceProgressiveReasoningTest {
 		assertEquals("FULL-ANSWER [8]", answer.getAnswer());
 	}
 
+	@Test
+	public void searchStreaming_routesPreviewToPreliminaryChannel_onThe7ArgOverload() {
+		// The 7-arg overload splits preview reasoning onto its own "preliminary" channel so the UI can
+		// render it as provisional and REPLACE it when the committed full-chart reasoning arrives —
+		// the fix for a wrong preview misleading the clinician. The 6-arg overload (above) keeps the
+		// merged-into-thinking behavior.
+		service.progressiveEnabled = true;
+		List<String> preliminary = new ArrayList<String>();
+
+		ChartAnswer answer = service.searchStreaming(patient(), "any infections?",
+				answerTokens::add, reasonings::add, citations -> { }, ungrounded -> { },
+				preliminary::add);
+
+		assertEquals(Collections.singletonList("PREVIEW-REASONING"), preliminary,
+				"preview reasoning must go to the dedicated preliminary channel, separate from the "
+						+ "reasoning channel");
+		assertEquals(Collections.singletonList("FULL-REASONING"), reasonings,
+				"the committed full-chart reasoning stays on the reasoning channel — NOT merged with "
+						+ "the preview");
+		assertEquals(Collections.singletonList("FULL-ANSWER"), answerTokens,
+				"the preview answer is still discarded; only the full-chart answer reaches the clinician");
+		assertEquals("FULL-ANSWER [8]", answer.getAnswer());
+	}
+
 	/** Context-free service: GP-backed resolvers overridden so no OpenMRS Context is needed. */
 	private final class TestableService extends LlmInferenceService {
 

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceProgressiveReasoningTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceProgressiveReasoningTest.java
@@ -1,0 +1,241 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.impl.LlmProvider.LlmResponse;
+import org.openmrs.module.chartsearchai.reference.DrugReferenceInjector;
+import org.openmrs.module.chartsearchai.reference.DrugSafetyValidator;
+import org.openmrs.module.chartsearchai.reference.SafetyWarning;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * Locks the progressive-reasoning seam on {@link LlmInferenceService#searchStreaming}
+ * (the 6-arg overload). When {@code chartsearchai.progressiveReasoning.enabled} is on, a
+ * fast stage-1 "preview" pass runs over only the querystore top-K focused chart and streams
+ * its reasoning to the existing "thinking" channel BEFORE the unchanged full-chart answer
+ * runs. This cuts perceived time-to-first-reasoning on a GPU-less host (the full chart is a
+ * multi-thousand-token prefill; the focused chart is a few hundred) without changing the
+ * committed answer.
+ *
+ * <p>Quality is preserved <em>by construction</em> and these tests pin every leg of that:
+ * <ul>
+ *   <li>the preview runs on the FOCUSED chart, the answer on the FULL chart;</li>
+ *   <li>the preview uses a {@code null} KV-cache scope so it cannot read or overwrite the
+ *       patient's full-chart KV entry;</li>
+ *   <li>the preview's <em>answer</em> tokens are discarded — only its reasoning reaches the
+ *       clinician — so the returned {@link ChartAnswer} is byte-identical to the full-chart
+ *       call;</li>
+ *   <li>when the gate is off, no focused chart is built and only the full-chart call runs.</li>
+ * </ul>
+ */
+public class LlmInferenceServiceProgressiveReasoningTest {
+
+	private static final String FULL_TEXT = "1. Full chart record A\n2. Full chart record B";
+
+	private static final String FOCUSED_TEXT = "1. Focused top-K record";
+
+	private TestableService service;
+
+	private StubStrategy strategy;
+
+	private StubProvider provider;
+
+	/** Reasoning chunks in arrival order — proves preview reasoning precedes the final reasoning. */
+	private final List<String> reasonings = new ArrayList<String>();
+
+	/** Answer tokens the clinician actually sees — must contain ONLY the full-chart answer. */
+	private final List<String> answerTokens = new ArrayList<String>();
+
+	@BeforeEach
+	public void setUp() {
+		strategy = new StubStrategy();
+		provider = new StubProvider();
+		service = new TestableService();
+		service.setChartBuildingStrategy(strategy);
+		service.setLlmProvider(provider);
+		service.setDrugReferenceInjector(new DrugReferenceInjector() {
+
+			@Override
+			public PatientChart inject(PatientChart chart, Patient patient, String question) {
+				return chart;
+			}
+		});
+		service.setDrugSafetyValidator(new DrugSafetyValidator() {
+
+			@Override
+			public List<SafetyWarning> validate(String answer, String question, Patient patient) {
+				return Collections.emptyList();
+			}
+		});
+	}
+
+	private static Patient patient() {
+		Patient p = new Patient();
+		p.setPatientId(1);
+		p.setUuid("uuid-1");
+		return p;
+	}
+
+	private ChartAnswer run() {
+		return service.searchStreaming(patient(), "any infections?",
+				answerTokens::add, reasonings::add, citations -> { }, ungrounded -> { });
+	}
+
+	@Test
+	public void searchStreaming_emitsPreviewReasoningFromFocusedChartBeforeFullAnswer() {
+		service.progressiveEnabled = true;
+
+		ChartAnswer answer = run();
+
+		// Two LLM passes: stage-1 preview on the focused chart, then stage-2 on the full chart.
+		assertEquals(Arrays.asList(FOCUSED_TEXT, FULL_TEXT), provider.texts,
+				"progressive on must run the preview over the FOCUSED chart first, then the FULL chart");
+		assertEquals(Arrays.asList(null, "uuid-1"), provider.scopes,
+				"the preview must use a null KV scope (so it can't collide with the patient's "
+						+ "full-chart KV); the full pass scopes to the patient UUID");
+		assertEquals(1, strategy.buildFocusedChartCalls, "the focused chart must be built exactly once");
+
+		assertEquals(Arrays.asList("PREVIEW-REASONING", "FULL-REASONING"), reasonings,
+				"preview reasoning must reach the thinking channel BEFORE the final reasoning — "
+						+ "that ordering is the entire point of progressive reasoning");
+
+		// Quality preserved by construction: the preview answer is discarded; only the full-chart
+		// answer is shown and returned.
+		assertEquals(Collections.singletonList("FULL-ANSWER"), answerTokens,
+				"the preview answer tokens must NOT reach the clinician — only the full-chart answer");
+		assertEquals("FULL-ANSWER [8]", answer.getAnswer(),
+				"the committed answer must be the unchanged full-chart result");
+	}
+
+	@Test
+	public void searchStreaming_runsOnlyFullChart_whenProgressiveDisabled() {
+		service.progressiveEnabled = false;
+
+		ChartAnswer answer = run();
+
+		assertEquals(Collections.singletonList(FULL_TEXT), provider.texts,
+				"progressive off must run a single full-chart pass — no preview");
+		assertEquals(0, strategy.buildFocusedChartCalls,
+				"progressive off must not build the focused chart at all");
+		assertEquals(Collections.singletonList("FULL-REASONING"), reasonings);
+		assertEquals("FULL-ANSWER [8]", answer.getAnswer());
+	}
+
+	@Test
+	public void searchStreaming_skipsPreview_whenFocusedChartIsEmpty() {
+		service.progressiveEnabled = true;
+		strategy.focusedChartEmpty = true;
+
+		ChartAnswer answer = run();
+
+		assertTrue(strategy.buildFocusedChartCalls >= 1,
+				"the focused chart is attempted when progressive is on");
+		assertEquals(Collections.singletonList(FULL_TEXT), provider.texts,
+				"an empty focused chart yields no preview LLM call — there is nothing to reason over");
+		assertFalse(reasonings.contains("PREVIEW-REASONING"),
+				"no preview reasoning when the focused chart is empty");
+		assertEquals("FULL-ANSWER [8]", answer.getAnswer());
+	}
+
+	/** Context-free service: GP-backed resolvers overridden so no OpenMRS Context is needed. */
+	private final class TestableService extends LlmInferenceService {
+
+		boolean progressiveEnabled;
+
+		@Override
+		protected boolean resolveWarmupEnabled() {
+			return false;
+		}
+
+		@Override
+		protected boolean resolveGroundingEnabled() {
+			return false;
+		}
+
+		@Override
+		protected boolean resolveProgressiveReasoningEnabled() {
+			return progressiveEnabled;
+		}
+	}
+
+	private final class StubStrategy extends ChartBuildingStrategy {
+
+		int buildFocusedChartCalls = 0;
+
+		boolean focusedChartEmpty = false;
+
+		@Override
+		PatientChart buildChart(Patient patient, String question) {
+			List<RecordMapping> mappings = Arrays.asList(
+					new RecordMapping(8, "condition", "00000000-0000-0000-0000-000000000008", null),
+					new RecordMapping(9, "obs", "00000000-0000-0000-0000-000000000009", null));
+			return new PatientChart(FULL_TEXT, mappings, Collections.<Integer>emptyList());
+		}
+
+		@Override
+		PatientChart buildFocusedChart(Patient patient, String question) {
+			buildFocusedChartCalls++;
+			if (focusedChartEmpty) {
+				return new PatientChart("", Collections.<RecordMapping>emptyList(),
+						Collections.<Integer>emptyList());
+			}
+			List<RecordMapping> mappings = Collections.singletonList(
+					new RecordMapping(1, "condition", "00000000-0000-0000-0000-000000000008", null));
+			return new PatientChart(FOCUSED_TEXT, mappings, Collections.<Integer>emptyList());
+		}
+
+		@Override
+		boolean usePreFilter() {
+			return false;
+		}
+	}
+
+	private final class StubProvider extends LlmProvider {
+
+		/** Chart text passed to each LLM pass, in order. */
+		final List<String> texts = new ArrayList<String>();
+
+		/** KV-cache scope passed to each LLM pass, in order. */
+		final List<String> scopes = new ArrayList<String>();
+
+		@Override
+		public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices,
+				String question, Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+				String cacheScope) {
+			texts.add(numberedRecords);
+			scopes.add(cacheScope);
+			// The preview pass is the one with a null KV scope; it emits an answer that MUST be
+			// discarded by the caller, plus reasoning that MUST surface on the thinking channel.
+			if (cacheScope == null) {
+				reasoningConsumer.accept("PREVIEW-REASONING");
+				tokenConsumer.accept("PREVIEW-ANSWER-DISCARDED");
+				return new LlmResponse("PREVIEW-ANSWER-DISCARDED", Arrays.asList(1));
+			}
+			reasoningConsumer.accept("FULL-REASONING");
+			tokenConsumer.accept("FULL-ANSWER");
+			return new LlmResponse("FULL-ANSWER [8]", Arrays.asList(8, 9));
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderTest.java
@@ -454,6 +454,90 @@ public class QueryStoreChartBuilderTest {
 				"second surviving record should be valid2 (Obs obs-1)");
 	}
 
+	// ---- buildFocused: the progressive-reasoning preview's focused top-K chart ----
+	// buildFocused is the query-dependent variant used ONLY by the preview pass: the
+	// searchByPatient top-K hits ARE the chart (small prefill), and it never fetches the full
+	// chart. These pin that contract plus the guards and the focus-RPC failure degradation.
+
+	@Test
+	public void buildFocused_shouldReturnSearchHitsAsTheChart_andNotFetchFullChart() {
+		QueryDocument hit1 = new QueryDocument();
+		hit1.setResourceType("Condition");
+		hit1.setResourceUuid("cond-1");
+		hit1.setText("Hypertension");
+		QueryDocument hit2 = new QueryDocument();
+		hit2.setResourceType("Obs");
+		hit2.setResourceUuid("obs-1");
+		hit2.setText("Systolic blood pressure: 140 mmHg");
+		queryStore.stubHits = new ArrayList<>();
+		queryStore.stubHits.add(hit1);
+		queryStore.stubHits.add(hit2);
+
+		PatientChart chart = builder.buildFocused(patient(1), "blood pressure?");
+
+		assertEquals(2, chart.getMappings().size(),
+				"the focused chart IS the searchByPatient top-K hits, serialized as records");
+		assertEquals("cond-1", chart.getMappings().get(0).getResourceUuid(),
+				"order preserved from the ranked hits");
+		assertEquals("obs-1", chart.getMappings().get(1).getResourceUuid());
+		assertEquals(1, queryStore.searchByPatientCalls,
+				"buildFocused ranks the focused set via searchByPatient");
+		assertEquals(0, queryStore.getPatientChartCalls,
+				"buildFocused must NOT fetch the full chart — keeping the prefix small is the whole "
+						+ "point of the preview pass");
+	}
+
+	@Test
+	public void buildFocused_shouldRequestProgressiveTopK_notQueryStoreTopK() {
+		// The preview's focused-set size is its OWN knob (progressiveReasoning.topK), independent of
+		// the focus-hint size (querystore.topK=10 here). A regression that reused the wrong knob would
+		// silently change preview cost/quality without any other test failing.
+		builder.progressiveTopK = 7;
+
+		builder.buildFocused(patient(1), "any infections?");
+
+		assertEquals(7, queryStore.lastSearchTopK,
+				"buildFocused must size the focused set by progressiveReasoning.topK, not querystore.topK");
+	}
+
+	@Test
+	public void buildFocused_shouldReturnEmptyChartAndSkipSearch_whenQuestionBlankOrNull() {
+		assertEquals(0, builder.buildFocused(patient(1), "   ").getMappings().size(),
+				"a blank question has no ranking signal — empty focused chart, no preview");
+		assertEquals(0, builder.buildFocused(patient(1), null).getMappings().size(),
+				"a null question must not NPE — empty focused chart");
+		assertEquals(0, queryStore.searchByPatientCalls,
+				"blank/null question must short-circuit before spending a searchByPatient RPC");
+	}
+
+	@Test
+	public void buildFocused_shouldReturnEmptyChartAndSkipSearch_whenPatientOrUuidIsNull() {
+		assertEquals(0, builder.buildFocused(null, "q").getMappings().size(),
+				"null patient must not NPE — empty focused chart");
+		Patient noUuid = new Patient();
+		noUuid.setPatientId(99);
+		noUuid.setUuid(null);
+		assertEquals(0, builder.buildFocused(noUuid, "q").getMappings().size(),
+				"a patient without a uuid cannot be ranked — empty focused chart");
+		assertEquals(0, queryStore.searchByPatientCalls,
+				"missing patient/uuid must short-circuit before any querystore RPC");
+	}
+
+	@Test
+	public void buildFocused_shouldReturnEmptyChart_whenSearchByPatientThrows() {
+		// A focus-RPC failure must degrade to an empty focused chart (the caller treats that as
+		// "no preview") and NEVER propagate — the authoritative full-chart answer must not be
+		// blocked by the optional preview pass.
+		queryStore.throwOnSearch = true;
+
+		PatientChart chart = builder.buildFocused(patient(1), "any allergies?");
+
+		assertEquals(0, chart.getMappings().size(),
+				"a focus-RPC failure degrades to an empty focused chart, not a propagated throw");
+		assertEquals(1, queryStore.searchByPatientCalls,
+				"the failure happened inside searchByPatient — it was reached, then swallowed");
+	}
+
 	/**
 	 * Subclass that bypasses {@code Context.getService} so this test runs without
 	 * a live OpenMRS context. The {@code resolve*} overrides are the seam — every
@@ -472,6 +556,8 @@ public class QueryStoreChartBuilderTest {
 
 		boolean dedupGroupLabels = false;
 
+		int progressiveTopK = 5;
+
 		TestableQueryStoreChartBuilder(QueryStoreService stub) {
 			this.stub = stub;
 		}
@@ -484,6 +570,11 @@ public class QueryStoreChartBuilderTest {
 		@Override
 		protected int resolveQueryStoreTopK() {
 			return 10;
+		}
+
+		@Override
+		protected int resolveProgressiveReasoningTopK() {
+			return progressiveTopK;
 		}
 
 		@Override
@@ -503,6 +594,8 @@ public class QueryStoreChartBuilderTest {
 
 		int getPatientChartCalls = 0;
 
+		int lastSearchTopK = -1;
+
 		List<QueryDocument> stubHits = new ArrayList<QueryDocument>();
 
 		List<QueryDocument> stubChart = new ArrayList<QueryDocument>();
@@ -518,6 +611,7 @@ public class QueryStoreChartBuilderTest {
 		@Override
 		public List<QueryDocument> searchByPatient(String patientUuid, String question, int topK) {
 			searchByPatientCalls++;
+			lastSearchTopK = topK;
 			if (throwOnSearch) {
 				throw new RuntimeException("simulated focus-hint RPC failure");
 			}

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -269,6 +269,11 @@ public class ChartSearchAiRestController {
 	 *
 	 * <p>SSE event types:</p>
 	 * <ul>
+	 *   <li>{@code preliminary} — only with {@code chartsearchai.progressiveReasoning.enabled}: a
+	 *       chunk of the fast PREVIEW reasoning over the focused top-K chart, streamed before the
+	 *       full-chart answer. Render as provisional ("preliminary, verifying…") and REPLACE it when
+	 *       the first {@code thinking} (or {@code token}) event arrives — the preview can be wrong
+	 *       until the committed full-chart pass corrects it</li>
 	 *   <li>{@code thinking} — a chunk of the model's reasoning (chain-of-thought), emitted
 	 *       before the answer; render distinctly (e.g. a collapsible panel), not as the answer</li>
 	 *   <li>{@code token} — a chunk of the answer text</li>
@@ -441,9 +446,11 @@ public class ChartSearchAiRestController {
 						earlyDoneSent[0] = true;
 					};
 
-			// Four channels: "token" carries the answer; "thinking" carries the model's reasoning
-			// (chain-of-thought), emitted first so the UI can show live progress and the rationale
-			// instead of a dead spinner; "references" carries the answer's citations the moment the
+			// Five channels: "token" carries the answer; "thinking" carries the committed full-chart
+			// reasoning (chain-of-thought), emitted first so the UI can show live progress and the
+			// rationale instead of a dead spinner; "preliminary" carries the optional progressive
+			// preview reasoning (only when progressiveReasoning.enabled) — streamed ahead of, and to
+			// be REPLACED by, "thinking"; "references" carries the answer's citations the moment the
 			// answer is done — BEFORE the grounding pass — so the UI can render clickable citations
 			// immediately and not wait on Tier-2 verification. The terminal events re-send the
 			// references with grounding verdicts attached: in the classic shape on "done", or — when
@@ -456,7 +463,8 @@ public class ChartSearchAiRestController {
 					token -> writeSseEventOrThrow(out, "token", token),
 					reasoning -> writeSseEventOrThrow(out, "thinking", reasoning),
 					citations -> sendReferencesEvent(out, citations),
-					ungroundedConsumer);
+					ungroundedConsumer,
+					preliminary -> writeSseEventOrThrow(out, "preliminary", preliminary));
 
 			if (!earlyDoneSent[0]) {
 				// Classic shape: async off, or the service returned an already-final answer (cache

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -271,9 +271,9 @@ public class ChartSearchAiRestController {
 	 * <ul>
 	 *   <li>{@code preliminary} — only with {@code chartsearchai.progressiveReasoning.enabled}: a
 	 *       chunk of the fast PREVIEW reasoning over the focused top-K chart, streamed before the
-	 *       full-chart answer. Render as provisional ("preliminary, verifying…") and REPLACE it when
-	 *       the first {@code thinking} (or {@code token}) event arrives — the preview can be wrong
-	 *       until the committed full-chart pass corrects it</li>
+	 *       full-chart answer. Render as provisional (clearly an in-progress preview, not the answer)
+	 *       and REPLACE it when the first {@code thinking} (or {@code token}) event arrives — the
+	 *       preview can be wrong until the committed full-chart pass corrects it</li>
 	 *   <li>{@code thinking} — a chunk of the model's reasoning (chain-of-thought), emitted
 	 *       before the answer; render distinctly (e.g. a collapsible panel), not as the answer</li>
 	 *   <li>{@code token} — a chunk of the answer text</li>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -152,6 +152,18 @@
 	</globalProperty>
 
 	<globalProperty>
+		<property>chartsearchai.progressiveReasoning.enabled</property>
+		<defaultValue>false</defaultValue>
+		<description>When true, a streaming AI query first streams a fast "preliminary" reasoning pass over only the top chartsearchai.progressiveReasoning.topK querystore records (a few hundred tokens) to the thinking channel, ahead of the unchanged full-chart answer. On a GPU-less host the full chart is a multi-thousand-token prefill (tens of seconds to minutes to the first token); the focused preview prefills in a second or two, so the clinician sees reasoning almost immediately. The committed answer is still the full-chart call (the preview's answer is discarded), so response quality is unchanged. Default: false (opt-in): the two passes share llama-server's single slot, trading a marginally longer time-to-final-answer for a much shorter time-to-first-reasoning. Affects only the streaming search endpoint.</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.progressiveReasoning.topK</property>
+		<defaultValue>15</defaultValue>
+		<description>Number of top querystore records the progressive-reasoning preview pass reasons over (see chartsearchai.progressiveReasoning.enabled). Smaller = faster preview prefill but less context for the preliminary reasoning; the committed full-chart answer is unaffected. Kept separate from chartsearchai.querystore.topK so the two can be tuned independently. Default: 15.</description>
+	</globalProperty>
+
+	<globalProperty>
 		<property>chartsearchai.grounding.enabled</property>
 		<defaultValue>false</defaultValue>
 		<description>When true, every cited record is checked for grounding after the LLM answers: the record's text must be semantically close enough to the answer sentence(s) that cite it, otherwise the citation is flagged as unverified. Index validation alone (does [N] map to a real retrieved record?) cannot catch the dangerous case of a real record cited for a claim it does not actually support. Default: false (opt-in).</description>

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiStreamEventOrderTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiStreamEventOrderTest.java
@@ -240,6 +240,37 @@ public class ChartSearchAiStreamEventOrderTest {
 						Boolean.TRUE)));
 	}
 
+	@Test
+	public void streamAnswer_emitsPreliminaryEvent_whenServiceStreamsPreviewReasoning() throws Exception {
+		controller.setChartSearchService(new PreliminaryStubService());
+
+		controller.streamAnswer(out, patient(), "any infections?", user(), "full-chart", true);
+
+		List<String> types = eventTypes();
+		assertTrue(types.contains("preliminary"),
+				"the controller must surface progressive preview reasoning on a 'preliminary' SSE event, "
+						+ "distinct from 'thinking', so the UI can render it provisionally");
+		assertEquals("Quick look: [8] mentions TB.", eventOfType("preliminary").data);
+		assertTrue(types.indexOf("preliminary") < types.indexOf("token"),
+				"the preview must arrive before the committed answer token");
+	}
+
+	/** Preview-path stub: emits a preliminary reasoning chunk on the 7-arg's preliminary channel
+	 *  before the committed answer, to exercise the controller's "preliminary" SSE wiring. */
+	private static class PreliminaryStubService extends LiveStubService {
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question,
+				Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+				Consumer<List<RecordReference>> citationsConsumer,
+				Consumer<ChartAnswer> ungroundedAnswerConsumer,
+				Consumer<String> preliminaryReasoningConsumer) {
+			preliminaryReasoningConsumer.accept("Quick look: [8] mentions TB.");
+			return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, citationsConsumer,
+					ungroundedAnswerConsumer);
+		}
+	}
+
 	/** Live-path stub: streams a token, fires citations + the ungrounded answer, returns grounded. */
 	private static class LiveStubService implements ChartSearchService {
 


### PR DESCRIPTION
## What

Adds **progressive reasoning** (global property, default off): on a streaming query, a fast "preview" pass reasons over only the querystore top-K focused chart and streams that reasoning to the client **before** the unchanged full-chart answer. It also adds a dedicated **`preliminary` SSE channel** so the preview is distinguishable from the committed reasoning (consumed by the frontend counterpart below).

## Why

On a GPU-less deployment the first query for an uncached patient can take ~2 minutes to show *any* reasoning, because the full chart is a multi-thousand-token prefill. The preview prefills only a few hundred tokens, so reasoning appears in seconds.

**Quality is preserved by construction:** the committed answer is the identical full-chart call; the preview's answer is discarded; the preview uses a `null` KV-cache scope so it cannot disturb the patient's full-chart KV entry.

## How

- GPs: `chartsearchai.progressiveReasoning.enabled` (default `false`), `chartsearchai.progressiveReasoning.topK` (default `15`).
- Stage 1: `QueryStoreChartBuilder.buildFocused` (querystore `searchByPatient` top-K) → `LlmInferenceService.maybeEmitPreliminaryReasoning`, run before the unchanged full-chart stage 2.
- A 7-arg `searchStreaming` overload carries a `preliminaryReasoningConsumer`, threaded through the caching router and emitted by the REST controller as a `preliminary` SSE event. The existing 6-arg overload merges the preview into the `thinking` channel (backward compatible), so existing callers are unaffected.
- `previewMs` added to the `[timing] searchStreaming` log line.

## Trade-off

llama-server runs a single slot, so the two passes serialize — time-to-**final**-answer is marginally longer; only time-to-**first-reasoning** improves. That's why it's opt-in / default-off.

## Testing

- New unit tests: preview→`preliminary` channel separation; `buildFocused` (top-K, input guards, RPC-failure degradation); the router threads the preliminary consumer on a miss and does **not** fire it on a cache hit; the controller emits a `preliminary` event before the answer token.
- Full suite green: **490 api + 41 omod** tests.
- Verified live on a local standalone (cold query): SSE order `preliminary@4.1s → thinking@31.3s → token@32.4s`.

Frontend counterpart (renders the preview as provisional and replaces it when the committed reasoning arrives): openmrs/openmrs-esm-chartsearchai#20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
