### PR TITLE
Resumable KV-prefill prewarm bootstrap with eviction-exempt pinning

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,83 @@
+# Chart Search AI — Onboarding
+
+An OpenMRS module that lets clinicians ask natural-language questions about a patient's chart and get answers with source citations. A local (or remote) LLM answers over a chart assembled by the **querystore** module, which owns retrieval and embeddings.
+
+## Get oriented fast
+
+- **Read first:** `CLAUDE.md` (project rules — TDD, root-cause-over-patch, and the **API-surface rules** below), `README.md` (setup + platform notes), `docs/adr.md` (decision log).
+- **Retrieval lives in querystore, not here.** chartsearchai has no in-process embedding/Lucene/scoring pipeline. Retrieval and citation grounding both use querystore's e5-base-v2 model. Retrieval changes and retrieval-quality eval belong in `openmrs-module-querystore`.
+- **Two engines:** `chartsearchai.llm.engine` = `local` (bundled `llama-server` subprocess, default — data stays on the host) or `remote` (OpenAI-compatible API). A **local** LLM is a hard requirement for production.
+
+## Build & test
+
+```bash
+mvn install                       # full build (api + omod), produces omod/target/chartsearchai-*.omod
+mvn -pl api test                  # api unit tests
+mvn test                          # api + omod
+mvn -pl api test -Dtest=ClassName # one test class
+```
+
+Tests must call the **real production pipeline** with real datasets — no mocks/reimplementations of pipeline logic (see `CLAUDE.md`). Follow TDD: write the failing test first.
+
+## Run it locally
+
+A configured standalone lives at `test/referenceapplication-standalone-3.7.0-SNAPSHOT` (RefApp 3.7, port **8081**, login `admin` / `Admin123`):
+
+```bash
+cd test/referenceapplication-standalone-3.7.0-SNAPSHOT
+nohup java -jar openmrs-standalone.jar &     # nohup so it survives the shell
+# REST base once up: http://localhost:8081/openmrs/ws/rest/v1
+```
+
+To redeploy after a build: stop it (`pkill -9 -f openmrs-standalone.jar; pkill -9 -f mariadbd; pkill -9 -f llama-server` — the embedded MariaDB must be killed too or the next boot can't lock the DB), copy `omod/target/chartsearchai-*.omod` into `appdata/modules/`, restart. Local GGUF models live under `MODELS/`; the standalone bundles Gemma E2B/E4B.
+
+## API-surface rules (do not bypass)
+
+These are the only correct entry points — never reimplement their logic inline:
+
+- **Prefixed text:** `ChartSearchAiUtils.buildPrefixedText(resourceType, text)`
+- **Cosine similarity:** `ChartSearchAiUtils.cosineSimilarity()`
+- **Chart assembly:** `ChartBuildingStrategy.buildChart()` → `QueryStoreChartBuilder.build()` (querystore owns retrieval)
+- **Global-property reads:** `ChartSearchAiUtils.getBooleanGlobalProperty` / `getStringGlobalProperty` (fail-safe on a missing context)
+- **Test datasets / category hints:** `TestDatasetHelper.*`
+
+## REST endpoints
+
+Base path: `/ws/rest/v1/chartsearchai`. Every endpoint gates on a privilege up front.
+
+| Method | Path | Privilege | Purpose |
+|---|---|---|---|
+| POST | `/search` | AI Query Patient Data | Blocking answer `{patient, question}` → answer + citations |
+| POST | `/search/stream` | AI Query Patient Data | Same, as Server-Sent Events. Event types: `preliminary`, `thinking`, `token`, `references`, `grounded`, `done`, `error` |
+| POST | `/warmup` | AI Query Patient Data | Fire-and-forget per-patient KV prewarm on chart open (202) |
+| **POST** | **`/prewarm`** | **Manage AI Prewarm** | **Bulk KV-prewarm bootstrap (202 + status)** |
+| **GET** | **`/prewarmstatus`** | **Manage AI Prewarm** | **Bulk-prewarm progress/status** |
+| GET | `/auditlog` | View AI Audit Logs | Query the AI audit log |
+| POST | `/feedback` | AI Query Patient Data | Submit thumbs-up/down on an answer |
+
+### KV warmup & the prewarm bootstrap
+
+Cold full-chart prefill is the dominant first-query latency cost (~10–20s even on GPU). The local engine persists each patient's prefilled KV to disk (`<appdata>/chartsearchai/kvcache`, one `.bin` per chart hash) so subsequent queries restore it (~ms) instead of re-prefilling.
+
+- **`/warmup`** (reactive) — the frontend fires this on chart open so the clinician's first query is warm. LRU-capped by `chartsearchai.llm.kvCacheMaxEntries` (default 16).
+- **`/prewarm`** (bulk bootstrap, **opt-in, default off**) — a resumable background sweep that pre-fills and **pins** every patient's KV so a first query on a *never-opened* patient is also warm. Pinned entries (`<name>.bin.pin` sidecar) are **exempt from the LRU cap** — durable for hosts with disk for the whole population.
+
+**`POST /prewarm`** body (all optional): `{"scope": "all", "action": "start" | "restart" | "stop"}` — returns **202** with the current status. `start` resumes from the persisted cursor; `restart` sweeps from the beginning; `stop` cancels. Only `scope: "all"` is implemented (others → 400). A resumable cursor is persisted to `<appdata>/chartsearchai/prewarm-progress.json`, so a crash/restart continues where it stopped.
+
+**`GET /prewarmstatus`** → `{status, running, scope, total, done, failed, cursorPatientId, currentPatientId, pinnedOnDisk, startedAt, updatedAt}` where `status` ∈ `IDLE | RUNNING | COMPLETED | STOPPED`.
+
+Example:
+```bash
+A=$(printf 'admin:Admin123' | base64); B=http://localhost:8081/openmrs/ws/rest/v1
+curl -s -H "Authorization: Basic $A" -H 'Content-Type: application/json' \
+     -X POST "$B/chartsearchai/prewarm" -d '{"action":"start"}'
+curl -s -H "Authorization: Basic $A" "$B/chartsearchai/prewarmstatus"
+```
+
+**Relevant global properties** (all default off/unbounded):
+- `chartsearchai.prewarm.enabled` — master switch for the endpoints + sweep.
+- `chartsearchai.prewarm.autostart` — resume the sweep on module startup.
+- `chartsearchai.prewarm.throttleMs` — pause between patients (default 500) so the single inference slot isn't monopolised.
+- `chartsearchai.llm.kvCache.maxPinnedEntries` — cap the pinned corpus (`0` = unlimited).
+
+> Note: a pinned entry becomes stale when that patient's chart changes; the next query re-prefills and re-saves it as an ordinary (unpinned) entry, so the pinned corpus erodes over time — re-run the sweep to refresh it. Only meaningful with `engine=local`.

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -15,6 +15,12 @@ public class ChartSearchAiConstants {
 
 	public static final String PRIV_VIEW_AUDIT_LOGS = "View AI Audit Logs";
 
+	/** Admin/system privilege for the bulk KV-prewarm bootstrap endpoints (trigger + status). Distinct
+	 *  from the per-patient {@link #PRIV_QUERY_PATIENT_DATA} clinician action because a sweep prefills
+	 *  every patient's chart and monopolises the single inference slot — a system operation, not a
+	 *  clinical one. */
+	public static final String PRIV_MANAGE_PREWARM = "Manage AI Prewarm";
+
 	public static final String GP_LLM_MODEL_FILE_PATH = "chartsearchai.llm.modelFilePath";
 
 	public static final String GP_EMBEDDING_PRE_FILTER = "chartsearchai.embedding.preFilter";
@@ -92,11 +98,25 @@ public class ChartSearchAiConstants {
 	 * Maximum number of persisted KV-cache files to retain in {@link #GP_LLM_KV_CACHE_DIR}. Each
 	 * file is large (tens to a few hundred MB, proportional to the chart's token count), so the
 	 * oldest entries are evicted (by last-modified time) once this many exist. Only consulted when
-	 * the cache directory is configured.
+	 * the cache directory is configured. Entries pinned by the prewarm bootstrap
+	 * ({@link #GP_PREWARM_ENABLED}) are EXEMPT from this cap — they are neither counted nor evicted;
+	 * bound them separately with {@link #GP_LLM_KV_CACHE_MAX_PINNED_ENTRIES}.
 	 */
 	public static final String GP_LLM_KV_CACHE_MAX_ENTRIES = "chartsearchai.llm.kvCacheMaxEntries";
 
 	public static final int DEFAULT_LLM_KV_CACHE_MAX_ENTRIES = 16;
+
+	/**
+	 * Upper bound on the number of <em>pinned</em> KV entries the prewarm bootstrap may create
+	 * ({@code 0} = unlimited, the default). Pinned entries are exempt from {@link #GP_LLM_KV_CACHE_MAX_ENTRIES}
+	 * (the LRU cap), so a deployment with disk for every patient keeps them all warm. This is the
+	 * safety valve for hosts that want a prewarm corpus but still bound its disk footprint: when set
+	 * {@code > 0} and reached, the sweep logs once and stops pinning further entries (it never
+	 * silently evicts already-pinned ones). Only consulted by the prewarm sweep.
+	 */
+	public static final String GP_LLM_KV_CACHE_MAX_PINNED_ENTRIES = "chartsearchai.llm.kvCache.maxPinnedEntries";
+
+	public static final int DEFAULT_LLM_KV_CACHE_MAX_PINNED_ENTRIES = 0;
 
 	public static final String GP_RATE_LIMIT_PER_MINUTE = "chartsearchai.rateLimitPerMinute";
 
@@ -109,6 +129,34 @@ public class ChartSearchAiConstants {
 	public static final int DEFAULT_CACHE_MAX_SIZE = 100;
 
 	public static final String GP_WARMUP_ENABLED = "chartsearchai.warmupEnabled";
+
+	/**
+	 * Master switch for the bulk KV-prewarm bootstrap (the {@code /prewarm} + {@code /prewarmstatus}
+	 * endpoints and the background sweep). Default {@code false}: the feature is opt-in because a
+	 * full-database sweep prefills every patient (10–20s each) on the single inference slot and grows
+	 * the on-disk pinned KV corpus without bound (see {@link #GP_LLM_KV_CACHE_MAX_PINNED_ENTRIES}).
+	 * The per-patient chart-open warmup is unaffected by this flag.
+	 */
+	public static final String GP_PREWARM_ENABLED = "chartsearchai.prewarm.enabled";
+
+	public static final boolean DEFAULT_PREWARM_ENABLED = false;
+
+	/**
+	 * When {@code true} (and {@link #GP_PREWARM_ENABLED} is on), the prewarm sweep resumes/starts on
+	 * module startup from its persisted cursor — the analog of {@code querystore.bootstrap.autostart}.
+	 * Default {@code false}.
+	 */
+	public static final String GP_PREWARM_AUTOSTART = "chartsearchai.prewarm.autostart";
+
+	public static final boolean DEFAULT_PREWARM_AUTOSTART = false;
+
+	/**
+	 * Milliseconds the prewarm sweep pauses between patients, so the single inference slot is not
+	 * monopolised and live clinician warmup/query traffic can interleave. Default {@code 500}.
+	 */
+	public static final String GP_PREWARM_THROTTLE_MS = "chartsearchai.prewarm.throttleMs";
+
+	public static final long DEFAULT_PREWARM_THROTTLE_MS = 500L;
 
 	/**
 	 * When {@code true}, a streaming query first runs a fast "preview" reasoning pass over only the

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiModuleActivator.java
@@ -18,6 +18,7 @@ import org.openmrs.module.DaemonToken;
 import org.openmrs.module.DaemonTokenAware;
 import org.openmrs.module.chartsearchai.api.AuditLogPurgeTask;
 import org.openmrs.module.chartsearchai.api.impl.LlmProvider;
+import org.openmrs.module.chartsearchai.api.impl.PrewarmBootstrapService;
 import org.openmrs.module.chartsearchai.api.impl.WarmupExecutor;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.scheduler.TaskDefinition;
@@ -47,6 +48,37 @@ public class ChartSearchAiModuleActivator extends BaseModuleActivator implements
 		}
 		catch (APIException e) {
 			log.warn("Could not propagate DaemonToken to WarmupExecutor", e);
+		}
+		PrewarmBootstrapService prewarm = null;
+		try {
+			prewarm = Context.getRegisteredComponent(
+					"chartSearchAi.prewarmBootstrapService", PrewarmBootstrapService.class);
+			prewarm.setDaemonToken(token);
+		}
+		catch (APIException e) {
+			log.warn("Could not propagate DaemonToken to PrewarmBootstrapService", e);
+		}
+		// Autostart is best-effort and MUST NOT break module startup: it reads a GP and launches a
+		// background sweep, either of which could throw if invoked before services are fully ready.
+		// Kept in its own broad catch (separate from token propagation above) so a failure here never
+		// prevents the token from being set or the module from starting.
+		if (prewarm != null) {
+			try {
+				maybeAutostartPrewarm(prewarm);
+			}
+			catch (Exception e) {
+				log.warn("Prewarm autostart failed (module startup continues)", e);
+			}
+		}
+	}
+
+	/** Resumes/starts the prewarm sweep on startup when chartsearchai.prewarm.autostart is true (the
+	 *  enabled gate is enforced inside {@link PrewarmBootstrapService#trigger}). */
+	private void maybeAutostartPrewarm(PrewarmBootstrapService prewarm) {
+		boolean autostart = ChartSearchAiUtils.getBooleanGlobalProperty(
+				ChartSearchAiConstants.GP_PREWARM_AUTOSTART, ChartSearchAiConstants.DEFAULT_PREWARM_AUTOSTART);
+		if (autostart) {
+			prewarm.trigger(PrewarmBootstrapService.SCOPE_ALL, "start");
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -158,6 +158,20 @@ public interface ChartSearchService {
 	}
 
 	/**
+	 * As {@link #warmup(Patient)} but, when {@code pin} is true, marks the persisted KV entry as
+	 * pinned — exempt from the LRU cap ({@code kvCacheMaxEntries}) — so the prewarm bootstrap can
+	 * build a durable warm corpus that the ad-hoc chart-open/query pool will not evict. The default
+	 * ignores {@code pin} and delegates to {@link #warmup(Patient)} for implementations that don't
+	 * persist KV.
+	 *
+	 * @param patient the patient whose chart to warm up
+	 * @param pin true to exempt the saved entry from cap-based eviction (prewarm-bootstrap corpus)
+	 */
+	default void warmup(Patient patient, boolean pin) {
+		warmup(patient);
+	}
+
+	/**
 	 * Whether this service keeps an answer cache that is currently active. Only the caching router
 	 * returns {@code true}; a plain inference service has no cache. Lets the write-side AOP indexing
 	 * advice decide whether a chart write needs to invalidate anything <em>before</em> resolving the

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/ChartSearchServiceRouter.java
@@ -183,6 +183,11 @@ public class ChartSearchServiceRouter implements ChartSearchService {
 		llmService.warmup(patient);
 	}
 
+	@Override
+	public void warmup(Patient patient, boolean pin) {
+		llmService.warmup(patient, pin);
+	}
+
 	/**
 	 * Test seam: resolves a global property. Overridable so {@link #buildCacheKey} can be unit-tested
 	 * (which GPs are folded into the key) without standing up an OpenMRS context.

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmEngine.java
@@ -109,6 +109,21 @@ public interface LlmEngine {
 	}
 
 	/**
+	 * As {@link #warmup(String, String, int, String)} but, when {@code pin} is true, asks an engine
+	 * that persists KV to disk to mark the saved entry as <em>pinned</em>: exempt from the LRU cap
+	 * ({@code kvCacheMaxEntries}), so the prewarm bootstrap can build a durable warm corpus for every
+	 * patient on hosts with the disk for it, without the ad-hoc warmup/query pool evicting it. The
+	 * default ignores {@code pin} and delegates to the 4-arg form, so engines that don't persist KV
+	 * (and existing callers/tests) are unaffected.
+	 *
+	 * @param pin true to exempt the saved entry from cap-based eviction
+	 */
+	default void warmup(String systemPrompt, String userMessage, int timeoutSeconds, String cacheScope,
+			boolean pin) {
+		warmup(systemPrompt, userMessage, timeoutSeconds, cacheScope);
+	}
+
+	/**
 	 * Whether this engine benefits from a warmup call. Used by callers to decide
 	 * whether to pay any pre-warmup work (chart serialization, etc.).
 	 */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -148,6 +148,11 @@ public class LlmInferenceService implements ChartSearchService {
 
 	@Override
 	public void warmup(Patient patient) {
+		warmup(patient, false);
+	}
+
+	@Override
+	public void warmup(Patient patient, boolean pin) {
 		// Two operational kill switches first, each as its own early-return so the downstream
 		// usePreFilter() GP read is not evaluated when warmup is fundamentally impossible.
 		if (!resolveWarmupEnabled()) {
@@ -166,8 +171,10 @@ public class LlmInferenceService implements ChartSearchService {
 		PatientChart chart = chartBuildingStrategy.buildChart(patient, "");
 		// Pass the patient UUID as the KV-cache scope so the local engine can replace this patient's
 		// stale on-disk entry when their chart changes, instead of leaving an orphan per chart version.
+		// pin=true (prewarm bootstrap) exempts the saved entry from the LRU cap so it joins the durable
+		// warm corpus; the chart-open path passes pin=false.
 		llmProvider.warmup(chartTextOrPlaceholder(chart),
-				patient == null ? null : patient.getUuid());
+				patient == null ? null : patient.getUuid(), pin);
 	}
 
 	/** Test seam wrapping the static {@link #isWarmupEnabled()}; production delegates,

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -610,10 +610,19 @@ public class LlmProvider {
 	 * changed chart replaces the subject's stale entry rather than orphaning it.
 	 */
 	public void warmup(String numberedRecords, String cacheScope) {
+		warmup(numberedRecords, cacheScope, false);
+	}
+
+	/**
+	 * Pinning variant of {@link #warmup(String, String)}. When {@code pin} is true, the saved KV entry
+	 * is exempt from the LRU cap so it survives as part of the prewarm-bootstrap corpus. Used by the
+	 * background prewarm sweep; the chart-open path uses {@code pin=false}.
+	 */
+	public void warmup(String numberedRecords, String cacheScope, boolean pin) {
 		String systemPrompt = getSystemPrompt();
 		String userMessage = buildUserMessage(numberedRecords, "");
 		int timeoutSeconds = getTimeoutSeconds();
-		getActiveEngine().warmup(systemPrompt, userMessage, timeoutSeconds, cacheScope);
+		getActiveEngine().warmup(systemPrompt, userMessage, timeoutSeconds, cacheScope, pin);
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -315,6 +315,12 @@ public class LocalLlmEngine implements LlmEngine {
 	@Override
 	public synchronized void warmup(String systemPrompt, String userMessage, int timeoutSeconds,
 			String cacheScope) {
+		warmup(systemPrompt, userMessage, timeoutSeconds, cacheScope, false);
+	}
+
+	@Override
+	public synchronized void warmup(String systemPrompt, String userMessage, int timeoutSeconds,
+			String cacheScope, boolean pin) {
 		ensureServerRunning();
 
 		// Disk-persisted KV cache (on by default). When enabled, a patient's prefilled chart KV is
@@ -336,6 +342,11 @@ public class LocalLlmEngine implements LlmEngine {
 		if (cacheKey != null && new File(cacheDir, cacheKey).isFile()
 				&& restoreSlot(cacheKey, timeoutSeconds)) {
 			log.warn("Warmup restored KV cache from disk: {}", cacheKey);
+			// A prewarm pass over a patient already prefilled by an earlier query finds the .bin on
+			// disk and only needs to pin it (no re-prefill) so it joins the durable corpus.
+			if (pin) {
+				writePinMarker(new File(cacheDir), cacheKey);
+			}
 			// Record residency so a query right after this warmup reuses the RAM pool rather than
 			// redundantly restoring from disk again.
 			ramResidentKeys.add(cacheKey);
@@ -376,7 +387,7 @@ public class LocalLlmEngine implements LlmEngine {
 			// patient's query.
 			if (cacheKey != null) {
 				ramResidentKeys.add(cacheKey);
-				persistKvEntry(cacheKey, cacheScope, cacheDir, timeoutSeconds);
+				persistKvEntry(cacheKey, cacheScope, cacheDir, timeoutSeconds, pin);
 			}
 			resetIdleTimer();
 		}
@@ -486,16 +497,50 @@ public class LocalLlmEngine implements LlmEngine {
 			if (!f.delete()) {
 				log.warn("Could not delete superseded KV-cache file {}", f);
 			}
+			// A superseded entry may carry a prewarm pin marker; delete it too, or it would pin a
+			// .bin that no longer exists (and skew the pinned-corpus accounting).
+			File pin = new File(dir, f.getName() + PIN_SUFFIX);
+			if (pin.exists() && !pin.delete()) {
+				log.warn("Could not delete orphaned KV pin marker {}", pin);
+			}
+		}
+	}
+
+	/** Suffix of the zero-byte sidecar that marks a {@code .bin} as pinned (exempt from the LRU cap).
+	 *  Written by the prewarm bootstrap so a host with disk for every patient keeps a durable,
+	 *  uncapped warm corpus, while ad-hoc warmup/query entries stay under {@code kvCacheMaxEntries}. */
+	static final String PIN_SUFFIX = ".pin";
+
+	/** Marks {@code cacheKey} as pinned by writing its zero-byte sidecar, so {@link #evictOldestKvEntries}
+	 *  never reclaims it. Idempotent; a write failure is logged and left non-fatal (the entry simply
+	 *  stays subject to the cap). */
+	static void writePinMarker(File dir, String cacheKey) {
+		File pin = new File(dir, cacheKey + PIN_SUFFIX);
+		if (pin.exists()) {
+			return;
+		}
+		try {
+			java.nio.file.Files.write(pin.toPath(), new byte[0]);
+		}
+		catch (IOException e) {
+			log.warn("Could not write KV pin marker {}: {}", pin, e.getMessage());
 		}
 	}
 
 	/**
-	 * Keeps at most {@code maxEntries} {@code .bin} files in {@code dir}, deleting the oldest (by
-	 * last-modified time) first. Each persisted KV file is large (proportional to the chart's token
-	 * count), so this bounds disk use. Non-{@code .bin} files are never touched.
+	 * Keeps at most {@code maxEntries} <em>unpinned</em> {@code .bin} files in {@code dir}, deleting
+	 * the oldest (by last-modified time) first. Each persisted KV file is large (proportional to the
+	 * chart's token count), so this bounds disk use for the ad-hoc warmup/query pool. Pinned entries
+	 * (a {@code <name>.pin} sidecar exists) are the prewarm bootstrap's durable corpus — they are
+	 * neither counted toward {@code maxEntries} nor evicted, so the cap never reclaims them.
+	 * Non-{@code .bin} files (including the {@code .pin} sidecars themselves) are never touched.
 	 */
 	static void evictOldestKvEntries(File dir, int maxEntries) {
-		File[] files = dir.listFiles((d, name) -> name.endsWith(".bin"));
+		// Pinned entries (a <name>.pin sidecar exists) are the prewarm bootstrap's durable corpus:
+		// excluded from the candidate list so they are neither counted toward the cap nor deleted.
+		// The cap therefore governs only the ad-hoc (chart-open warmup + query-save) pool.
+		File[] files = dir.listFiles((d, name) ->
+				name.endsWith(".bin") && !new File(d, name + PIN_SUFFIX).exists());
 		if (files == null || files.length <= maxEntries) {
 			return;
 		}
@@ -557,8 +602,22 @@ public class LocalLlmEngine implements LlmEngine {
 	 * active ({@code cacheKey} and {@code cacheDir} non-null).
 	 */
 	private void persistKvEntry(String cacheKey, String cacheScope, String cacheDir, int timeoutSeconds) {
+		persistKvEntry(cacheKey, cacheScope, cacheDir, timeoutSeconds, false);
+	}
+
+	/**
+	 * As {@link #persistKvEntry(String, String, String, int)} but, when {@code pin} is true, marks the
+	 * saved entry as pinned (prewarm-bootstrap corpus) BEFORE the cap is applied, so it is exempt from
+	 * eviction. The pin write precedes {@link #evictOldestKvEntries} so the just-saved entry cannot be
+	 * reclaimed by the same call.
+	 */
+	private void persistKvEntry(String cacheKey, String cacheScope, String cacheDir, int timeoutSeconds,
+			boolean pin) {
 		if (saveSlot(cacheKey, timeoutSeconds)) {
 			purgeKvScopeEntries(new File(cacheDir), cacheScope, cacheKey);
+			if (pin) {
+				writePinMarker(new File(cacheDir), cacheKey);
+			}
 			evictOldestKvEntries(new File(cacheDir), getKvCacheMaxEntries());
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PrewarmBootstrapService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PrewarmBootstrapService.java
@@ -1,0 +1,324 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
+import org.openmrs.module.DaemonToken;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
+import org.openmrs.module.chartsearchai.api.ChartSearchService;
+import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Background "prewarm bootstrap": sweeps patients one-by-one and pre-fills (and pins) each one's
+ * chart KV cache, so the first AI query on a patient never visited this process still lands warm.
+ * It is the LLM-prefill analog of querystore's index bootstrap — a daemon-thread sweep with a
+ * resumable cursor persisted to {@code <appdata>/chartsearchai/prewarm-progress.json}, so a crash
+ * or restart continues where it stopped rather than re-prefilling from scratch.
+ *
+ * <p>Distinct from {@link WarmupExecutor} (which warms ONE patient on chart open, ad-hoc, LRU-capped):
+ * this sweep pins every entry ({@code warmup(patient, true)}) so the durable corpus is exempt from
+ * {@code kvCacheMaxEntries}. On hosts with disk for every patient that keeps them all warm; the
+ * optional {@link ChartSearchAiConstants#GP_LLM_KV_CACHE_MAX_PINNED_ENTRIES} valve bounds the size of
+ * the pinned corpus when a host wants a ceiling on it.
+ *
+ * <p>Concurrency: at most one sweep runs at a time (guarded by {@link #running}); each
+ * {@code warmup} serializes on {@link LocalLlmEngine}'s monitor against live traffic, and
+ * {@code throttleMs} widens the gap so clinician queries interleave. The patient enumeration is a
+ * lightweight, batched, id-only SQL cursor ({@code select patient_id ... where patient_id > ?}) so
+ * it scales to large facilities without loading every {@link Patient} into memory at once.
+ */
+@Component("chartSearchAi.prewarmBootstrapService")
+public class PrewarmBootstrapService {
+
+	private static final Logger log = LoggerFactory.getLogger(PrewarmBootstrapService.class);
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private static final int ENUMERATION_BATCH = 500;
+
+	static final String PROGRESS_FILENAME = "prewarm-progress.json";
+
+	public static final String STATUS_IDLE = "IDLE";
+
+	public static final String STATUS_RUNNING = "RUNNING";
+
+	public static final String STATUS_COMPLETED = "COMPLETED";
+
+	public static final String STATUS_STOPPED = "STOPPED";
+
+	public static final String SCOPE_ALL = "all";
+
+	@Autowired
+	@Qualifier("chartSearchAi.chartSearchServiceRouter")
+	private ChartSearchService chartSearchService;
+
+	private volatile DaemonToken daemonToken;
+
+	private final AtomicBoolean running = new AtomicBoolean(false);
+
+	private volatile boolean cancelRequested = false;
+
+	/** Live progress; also mirrored to disk after each patient for crash/restart resume. */
+	private volatile PrewarmProgress progress = PrewarmProgress.idle();
+
+	public void setDaemonToken(DaemonToken token) {
+		this.daemonToken = token;
+	}
+
+	/** Test/wiring seam: inject the chart-search router (production autowires it). */
+	void setChartSearchService(ChartSearchService chartSearchService) {
+		this.chartSearchService = chartSearchService;
+	}
+
+	/**
+	 * Trigger or steer the sweep. {@code action}:
+	 * <ul>
+	 *   <li>{@code start} (default) — resume from the persisted cursor, or begin if none.</li>
+	 *   <li>{@code restart} — clear the cursor and sweep from the beginning.</li>
+	 *   <li>{@code stop} — request cancellation of a running sweep.</li>
+	 * </ul>
+	 * Returns the current status snapshot immediately (the sweep itself runs on a daemon thread);
+	 * starting an already-running sweep is a no-op that just returns the live status.
+	 */
+	public synchronized PrewarmStatus trigger(String scope, String action) {
+		String act = action == null || action.trim().isEmpty() ? "start" : action.trim().toLowerCase();
+		if ("stop".equals(act)) {
+			cancelRequested = true;
+			return getStatus();
+		}
+		if (running.get()) {
+			return getStatus();
+		}
+		if (!isPrewarmEnabled()) {
+			return getStatus();
+		}
+		PrewarmProgress resumeFrom = "restart".equals(act) ? null : loadProgress();
+		final long startCursor = resumeFrom == null ? 0L : resumeFrom.cursorPatientId;
+		final long carriedDone = resumeFrom == null ? 0L : resumeFrom.done;
+		final long carriedFailed = resumeFrom == null ? 0L : resumeFrom.failed;
+		final String useScope = scope == null || scope.trim().isEmpty() ? SCOPE_ALL : scope.trim();
+
+		DaemonToken token = daemonToken;
+		if (token == null) {
+			log.warn("DaemonToken not yet available; cannot start prewarm sweep");
+			return getStatus();
+		}
+		cancelRequested = false;
+		running.set(true);
+		progress = PrewarmProgress.running(useScope, startCursor, carriedDone, carriedFailed);
+		persistProgress(progress);
+
+		Daemon.runInDaemonThread(() -> {
+			try {
+				runSweep(useScope, startCursor, carriedDone, carriedFailed);
+			}
+			catch (Exception e) {
+				log.warn("Prewarm sweep aborted: {}", e.getMessage(), e);
+			}
+			finally {
+				running.set(false);
+			}
+		}, token);
+		return getStatus();
+	}
+
+	void runSweep(String scope, long startCursor, long carriedDone, long carriedFailed) {
+		long cursor = startCursor;
+		long done = carriedDone;
+		long failed = carriedFailed;
+		long total = countPatients();
+		long throttleMs = getThrottleMs();
+		int maxPinned = getMaxPinnedEntries();
+
+		List<Long> batch;
+		while (!cancelRequested && !(batch = enumeratePatientIdsAfter(cursor, ENUMERATION_BATCH)).isEmpty()) {
+			for (Long id : batch) {
+				if (cancelRequested) {
+					break;
+				}
+				if (maxPinned > 0 && countPinnedEntries() >= maxPinned) {
+					log.warn("Prewarm reached maxPinnedEntries={}; stopping (no further pinning)", maxPinned);
+					cancelRequested = true;
+					break;
+				}
+				progress = progress.withCurrent(id, total, done, failed);
+				try {
+					Patient patient = getPatient(id);
+					if (patient != null) {
+						chartSearchService.warmup(patient, true);
+					}
+					done++;
+				}
+				catch (Exception e) {
+					failed++;
+					log.warn("Prewarm failed for patient [id={}]: {}", id, e.getMessage());
+				}
+				cursor = id;
+				progress = progress.advanced(cursor, total, done, failed);
+				persistProgress(progress);
+				sleep(throttleMs);
+			}
+		}
+		progress = progress.finished(cancelRequested ? STATUS_STOPPED : STATUS_COMPLETED, total, done, failed);
+		persistProgress(progress);
+		log.warn("Prewarm sweep {}: done={} failed={} cursor={}",
+				progress.status, done, failed, cursor);
+	}
+
+	public PrewarmStatus getStatus() {
+		PrewarmProgress p = progress;
+		// On a fresh process before any trigger, surface the persisted cursor so a caller sees prior
+		// progress (and autostart resume potential) rather than a bare IDLE.
+		if (p.status.equals(STATUS_IDLE)) {
+			PrewarmProgress saved = loadProgress();
+			if (saved != null) {
+				p = saved;
+			}
+		}
+		return new PrewarmStatus(p, running.get(), countPinnedEntries());
+	}
+
+	// ---- seams (overridable in tests) ----------------------------------------------------------
+
+	/** Patient ids ordered ascending, strictly greater than {@code afterId}, at most {@code limit}. */
+	protected List<Long> enumeratePatientIdsAfter(long afterId, int limit) {
+		String sql = "select patient_id from patient where voided = 0 and patient_id > " + afterId
+				+ " order by patient_id limit " + limit;
+		List<List<Object>> rows = Context.getAdministrationService().executeSQL(sql, true);
+		List<Long> ids = new ArrayList<>(rows.size());
+		for (List<Object> row : rows) {
+			ids.add(((Number) row.get(0)).longValue());
+		}
+		return ids;
+	}
+
+	protected long countPatients() {
+		List<List<Object>> rows = Context.getAdministrationService()
+				.executeSQL("select count(*) from patient where voided = 0", true);
+		return rows.isEmpty() ? 0L : ((Number) rows.get(0).get(0)).longValue();
+	}
+
+	protected Patient getPatient(long id) {
+		return Context.getPatientService().getPatient((int) id);
+	}
+
+	protected boolean isPrewarmEnabled() {
+		return ChartSearchAiUtils.getBooleanGlobalProperty(
+				ChartSearchAiConstants.GP_PREWARM_ENABLED, ChartSearchAiConstants.DEFAULT_PREWARM_ENABLED);
+	}
+
+	protected long getThrottleMs() {
+		return parseLong(ChartSearchAiUtils.getStringGlobalProperty(
+				ChartSearchAiConstants.GP_PREWARM_THROTTLE_MS, null),
+				ChartSearchAiConstants.DEFAULT_PREWARM_THROTTLE_MS);
+	}
+
+	protected int getMaxPinnedEntries() {
+		return (int) parseLong(ChartSearchAiUtils.getStringGlobalProperty(
+				ChartSearchAiConstants.GP_LLM_KV_CACHE_MAX_PINNED_ENTRIES, null),
+				ChartSearchAiConstants.DEFAULT_LLM_KV_CACHE_MAX_PINNED_ENTRIES);
+	}
+
+	/** Count of pinned KV entries (.bin files with a .pin sidecar) currently on disk. */
+	protected int countPinnedEntries() {
+		File dir = pinnedDir();
+		if (dir == null || !dir.isDirectory()) {
+			return 0;
+		}
+		File[] pins = dir.listFiles((d, name) -> name.endsWith(LocalLlmEngine.PIN_SUFFIX));
+		return pins == null ? 0 : pins.length;
+	}
+
+	/** The effective KV-cache directory, or null when disk KV persistence is disabled. */
+	protected File pinnedDir() {
+		String configured = ChartSearchAiUtils.getStringGlobalProperty(
+				ChartSearchAiConstants.GP_LLM_KV_CACHE_DIR, null);
+		String resolved = LocalLlmEngine.resolveKvCacheDir(configured,
+				OpenmrsUtil.getApplicationDataDirectory());
+		return resolved == null ? null : new File(resolved);
+	}
+
+	protected File progressFile() {
+		File dir = new File(OpenmrsUtil.getApplicationDataDirectory(), "chartsearchai");
+		return new File(dir, PROGRESS_FILENAME);
+	}
+
+	protected void sleep(long ms) {
+		if (ms <= 0) {
+			return;
+		}
+		try {
+			Thread.sleep(ms);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			cancelRequested = true;
+		}
+	}
+
+	// ---- progress persistence ------------------------------------------------------------------
+
+	void persistProgress(PrewarmProgress p) {
+		File f = progressFile();
+		try {
+			File parent = f.getParentFile();
+			if (parent != null && !parent.isDirectory()) {
+				parent.mkdirs();
+			}
+			MAPPER.writeValue(f, p);
+		}
+		catch (IOException e) {
+			log.warn("Could not persist prewarm progress to {}: {}", f, e.getMessage());
+		}
+	}
+
+	PrewarmProgress loadProgress() {
+		File f = progressFile();
+		if (!f.isFile()) {
+			return null;
+		}
+		try {
+			return MAPPER.readValue(f, PrewarmProgress.class);
+		}
+		catch (IOException e) {
+			log.warn("Could not read prewarm progress from {}: {}", f, e.getMessage());
+			return null;
+		}
+	}
+
+	private static long parseLong(String v, long fallback) {
+		if (v == null || v.trim().isEmpty()) {
+			return fallback;
+		}
+		try {
+			return Long.parseLong(v.trim());
+		}
+		catch (NumberFormatException e) {
+			return fallback;
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PrewarmProgress.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PrewarmProgress.java
@@ -1,0 +1,108 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+/**
+ * Serializable cursor state of the prewarm sweep, persisted to
+ * {@code <appdata>/chartsearchai/prewarm-progress.json} after each patient so a crash or restart
+ * resumes from {@link #cursorPatientId} rather than re-prefilling from scratch. Public fields +
+ * a no-arg constructor keep it trivially Jackson-(de)serializable. The transform methods return
+ * fresh instances so the owning service can publish it via a single {@code volatile} reference.
+ */
+public class PrewarmProgress {
+
+	public String status = PrewarmBootstrapService.STATUS_IDLE;
+
+	public String scope = PrewarmBootstrapService.SCOPE_ALL;
+
+	public long total;
+
+	public long done;
+
+	public long failed;
+
+	/** Highest patient id already processed; the sweep resumes at {@code patient_id > cursorPatientId}. */
+	public long cursorPatientId;
+
+	/** Patient currently being prefilled (0 when idle/finished). */
+	public long currentPatientId;
+
+	public long startedAt;
+
+	public long updatedAt;
+
+	public PrewarmProgress() {
+	}
+
+	static PrewarmProgress idle() {
+		PrewarmProgress p = new PrewarmProgress();
+		p.status = PrewarmBootstrapService.STATUS_IDLE;
+		return p;
+	}
+
+	static PrewarmProgress running(String scope, long cursor, long done, long failed) {
+		PrewarmProgress p = new PrewarmProgress();
+		p.status = PrewarmBootstrapService.STATUS_RUNNING;
+		p.scope = scope;
+		p.cursorPatientId = cursor;
+		p.done = done;
+		p.failed = failed;
+		p.startedAt = System.currentTimeMillis();
+		p.updatedAt = p.startedAt;
+		return p;
+	}
+
+	PrewarmProgress withCurrent(long currentId, long total, long done, long failed) {
+		PrewarmProgress p = copy();
+		p.currentPatientId = currentId;
+		p.total = total;
+		p.done = done;
+		p.failed = failed;
+		p.updatedAt = System.currentTimeMillis();
+		return p;
+	}
+
+	PrewarmProgress advanced(long cursor, long total, long done, long failed) {
+		PrewarmProgress p = copy();
+		p.cursorPatientId = cursor;
+		p.total = total;
+		p.done = done;
+		p.failed = failed;
+		p.updatedAt = System.currentTimeMillis();
+		return p;
+	}
+
+	PrewarmProgress finished(String finalStatus, long total, long done, long failed) {
+		PrewarmProgress p = copy();
+		p.status = finalStatus;
+		p.currentPatientId = 0L;
+		p.total = total;
+		p.done = done;
+		p.failed = failed;
+		p.updatedAt = System.currentTimeMillis();
+		return p;
+	}
+
+	// NOTE: copies every field. When adding a field above, add it here too — a field left out would
+	// silently reset to its default on every progress update (the transform methods all go through copy()).
+	private PrewarmProgress copy() {
+		PrewarmProgress p = new PrewarmProgress();
+		p.status = status;
+		p.scope = scope;
+		p.total = total;
+		p.done = done;
+		p.failed = failed;
+		p.cursorPatientId = cursorPatientId;
+		p.currentPatientId = currentPatientId;
+		p.startedAt = startedAt;
+		p.updatedAt = updatedAt;
+		return p;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PrewarmStatus.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/PrewarmStatus.java
@@ -1,0 +1,57 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Immutable status snapshot the {@code /prewarmstatus} endpoint returns: the persisted
+ * {@link PrewarmProgress} plus the live {@code running} flag and the on-disk pinned-entry count
+ * (the durable warm corpus). {@link #toMap()} yields the REST response body.
+ */
+public class PrewarmStatus {
+
+	private final PrewarmProgress progress;
+
+	private final boolean running;
+
+	private final int pinnedOnDisk;
+
+	public PrewarmStatus(PrewarmProgress progress, boolean running, int pinnedOnDisk) {
+		this.progress = progress;
+		this.running = running;
+		this.pinnedOnDisk = pinnedOnDisk;
+	}
+
+	public boolean isRunning() {
+		return running;
+	}
+
+	public String getStatus() {
+		return progress.status;
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> m = new LinkedHashMap<String, Object>();
+		m.put("status", progress.status);
+		m.put("running", running);
+		m.put("scope", progress.scope);
+		m.put("total", progress.total);
+		m.put("done", progress.done);
+		m.put("failed", progress.failed);
+		m.put("cursorPatientId", progress.cursorPatientId);
+		m.put("currentPatientId", progress.currentPatientId);
+		m.put("pinnedOnDisk", pinnedOnDisk);
+		m.put("startedAt", progress.startedAt);
+		m.put("updatedAt", progress.updatedAt);
+		return m;
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceWarmupIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceWarmupIntegrationTest.java
@@ -232,6 +232,14 @@ public class LlmInferenceServiceWarmupIntegrationTest {
 			warmupCalled = true;
 		}
 
+		// The prewarm bootstrap warms via the pinning overload (pin=true exempts the entry from the
+		// LRU cap). Production's warmup(Patient, pin) routes here, so the fake must cover it too —
+		// otherwise it falls through to the real LlmProvider, which reads GPs off a missing context.
+		@Override
+		public void warmup(String numberedRecords, String cacheScope, boolean pin) {
+			warmupCalled = true;
+		}
+
 		@Override
 		public boolean supportsWarmup() {
 			supportsWarmupCalls++;

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
@@ -413,6 +413,91 @@ public class LocalLlmEngineTest {
 		}
 	}
 
+	@Test
+	public void evictOldestKvEntries_shouldNeverEvictPinnedEntries() throws Exception {
+		// A pinned entry (a <name>.pin sidecar exists) is the prewarm bootstrap's durable corpus:
+		// it must be exempt from the LRU cap entirely — neither counted toward the limit nor deleted —
+		// so a deployment with disk for every patient keeps them all warm regardless of how small the
+		// cap is. The cap continues to govern only the ad-hoc (chart-open warmup + query-save) pool.
+		java.io.File dir = java.nio.file.Files.createTempDirectory("kvcache-pin").toFile();
+		try {
+			java.io.File pinned = newFile(dir, "pinA.bin", 1_000L);
+			newFile(dir, "pinA.bin.pin", 1_000L);
+			java.io.File pinnedOldest = newFile(dir, "pinB.bin", 500L);
+			newFile(dir, "pinB.bin.pin", 500L);
+			java.io.File adhocOld = newFile(dir, "x.bin", 2_000L);
+			java.io.File adhocMid = newFile(dir, "y.bin", 3_000L);
+			java.io.File adhocNew = newFile(dir, "z.bin", 4_000L);
+
+			// Cap of 1 applied to the UNPINNED pool only: the two oldest unpinned go, the newest stays.
+			LocalLlmEngine.evictOldestKvEntries(dir, 1);
+
+			assertTrue(pinned.exists(), "a pinned entry must never be evicted");
+			assertTrue(pinnedOldest.exists(),
+					"a pinned entry must never be evicted, even when it is the oldest file overall");
+			assertFalse(adhocOld.exists(), "the oldest unpinned entry over the cap must be evicted");
+			assertFalse(adhocMid.exists(), "unpinned entries over the cap must be evicted");
+			assertTrue(adhocNew.exists(), "the newest unpinned entry must be kept under the cap");
+		}
+		finally {
+			for (java.io.File f : dir.listFiles()) {
+				f.delete();
+			}
+			dir.delete();
+		}
+	}
+
+	@Test
+	public void purgeKvScopeEntries_shouldAlsoDeleteThePinSidecarOfSupersededEntries() throws Exception {
+		// When a pinned patient's chart changes, the new prefill hashes to a new filename and the old
+		// .bin is purged; its orphaned .pin sidecar must go with it, or it would pin a file that no
+		// longer exists and skew the pinned-corpus accounting.
+		java.io.File dir = java.nio.file.Files.createTempDirectory("kvscope-pin").toFile();
+		try {
+			java.io.File keep = newFile(dir, "pA-newhash.bin", 3_000L);
+			java.io.File keepPin = newFile(dir, "pA-newhash.bin.pin", 3_000L);
+			java.io.File stale = newFile(dir, "pA-oldhash.bin", 1_000L);
+			java.io.File stalePin = newFile(dir, "pA-oldhash.bin.pin", 1_000L);
+
+			LocalLlmEngine.purgeKvScopeEntries(dir, "pA", "pA-newhash.bin");
+
+			assertTrue(keep.exists(), "the patient's current entry must be kept");
+			assertTrue(keepPin.exists(), "the current entry's pin marker must be kept");
+			assertFalse(stale.exists(), "the patient's superseded entry must be deleted");
+			assertFalse(stalePin.exists(),
+					"the superseded entry's orphaned pin marker must also be deleted");
+		}
+		finally {
+			for (java.io.File f : dir.listFiles()) {
+				f.delete();
+			}
+			dir.delete();
+		}
+	}
+
+	@Test
+	public void writePinMarker_shouldCreateTheSidecarAndBeIdempotent() throws Exception {
+		java.io.File dir = java.nio.file.Files.createTempDirectory("kvpin-write").toFile();
+		try {
+			java.io.File bin = newFile(dir, "pX-hash.bin", 1_000L);
+			java.io.File pin = new java.io.File(dir, "pX-hash.bin" + LocalLlmEngine.PIN_SUFFIX);
+			assertFalse(pin.exists(), "precondition: no marker yet");
+
+			LocalLlmEngine.writePinMarker(dir, "pX-hash.bin");
+			assertTrue(pin.exists(), "the pin sidecar must be created for the given key");
+
+			// Idempotent: a second call on an already-pinned entry is a no-op and must not throw.
+			LocalLlmEngine.writePinMarker(dir, "pX-hash.bin");
+			assertTrue(pin.exists() && bin.exists(), "re-pinning leaves both the marker and the .bin intact");
+		}
+		finally {
+			for (java.io.File f : dir.listFiles()) {
+				f.delete();
+			}
+			dir.delete();
+		}
+	}
+
 	private static java.io.File newFile(java.io.File dir, String name, long lastModified) throws IOException {
 		java.io.File f = new java.io.File(dir, name);
 		java.nio.file.Files.write(f.toPath(), new byte[] { 1 });

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/PrewarmBootstrapServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/PrewarmBootstrapServiceTest.java
@@ -1,0 +1,218 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.ChartSearchService;
+
+/**
+ * Exercises the real {@link PrewarmBootstrapService#runSweep} and on-disk progress persistence,
+ * with the OpenMRS-Context seams (patient enumeration, patient lookup, GP reads, KV dir) overridden
+ * to in-memory fakes — the same seam pattern {@code LlmInferenceServiceWarmupIntegrationTest} uses.
+ * The sweep orchestration itself is the production code under test, not a reimplementation.
+ */
+public class PrewarmBootstrapServiceTest {
+
+	private File tempDir;
+
+	private RecordingChartSearchService recorder;
+
+	private TestablePrewarmBootstrapService service;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		tempDir = java.nio.file.Files.createTempDirectory("prewarm-test").toFile();
+		recorder = new RecordingChartSearchService();
+		service = new TestablePrewarmBootstrapService(tempDir);
+		service.setChartSearchService(recorder);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		File[] files = tempDir.listFiles();
+		if (files != null) {
+			for (File f : files) {
+				f.delete();
+			}
+		}
+		tempDir.delete();
+	}
+
+	@Test
+	public void runSweep_shouldPinEveryPatientInCursorOrderAndCompleteAtTotal() {
+		service.patientIds = new ArrayList<>(java.util.Arrays.asList(1L, 2L, 3L, 4L, 5L));
+
+		service.runSweep(PrewarmBootstrapService.SCOPE_ALL, 0L, 0L, 0L);
+
+		assertEquals(java.util.Arrays.asList(1, 2, 3, 4, 5), recorder.warmedPatientIds,
+				"every patient must be warmed exactly once, in ascending cursor order");
+		assertTrue(recorder.allPinned, "the bootstrap must warm with pin=true so entries join the durable corpus");
+		PrewarmStatus status = service.getStatus();
+		assertEquals(PrewarmBootstrapService.STATUS_COMPLETED, status.getStatus());
+		assertEquals(5L, service.loadProgress().done, "done must reach the patient total");
+		assertEquals(5L, service.loadProgress().cursorPatientId, "the cursor must end at the last patient");
+	}
+
+	@Test
+	public void runSweep_shouldResumeFromCursor_skippingAlreadyProcessedPatients() {
+		// Simulates a restart mid-sweep: the cursor is at patient 3, so only ids > 3 are processed,
+		// and the carried done count continues rather than resetting.
+		service.patientIds = new ArrayList<>(java.util.Arrays.asList(1L, 2L, 3L, 4L, 5L));
+
+		service.runSweep(PrewarmBootstrapService.SCOPE_ALL, 3L, 3L, 0L);
+
+		assertEquals(java.util.Arrays.asList(4, 5), recorder.warmedPatientIds,
+				"resuming at cursor 3 must process only patients beyond it");
+		assertEquals(5L, service.loadProgress().done, "carried done (3) plus the 2 new must total 5");
+	}
+
+	@Test
+	public void runSweep_shouldStopPinningWhenMaxPinnedEntriesReached() {
+		service.patientIds = new ArrayList<>(java.util.Arrays.asList(1L, 2L, 3L, 4L, 5L));
+		service.maxPinned = 2;
+		service.pinnedOnDisk = 2; // already at the cap before the first patient
+
+		service.runSweep(PrewarmBootstrapService.SCOPE_ALL, 0L, 0L, 0L);
+
+		assertTrue(recorder.warmedPatientIds.isEmpty(),
+				"at the pinned cap the sweep must stop without pinning any further entry");
+		assertEquals(PrewarmBootstrapService.STATUS_STOPPED, service.getStatus().getStatus(),
+				"hitting the cap is a stop, not a completion");
+	}
+
+	@Test
+	public void persistProgress_then_loadProgress_shouldRoundTrip() {
+		PrewarmProgress p = PrewarmProgress.running("all", 7L, 7L, 1L);
+		service.persistProgress(p);
+
+		PrewarmProgress loaded = service.loadProgress();
+		assertEquals(PrewarmBootstrapService.STATUS_RUNNING, loaded.status);
+		assertEquals(7L, loaded.cursorPatientId);
+		assertEquals(7L, loaded.done);
+		assertEquals(1L, loaded.failed);
+	}
+
+	@Test
+	public void getStatus_shouldSurfacePersistedCursorOnAFreshProcess() {
+		// A brand-new service instance (in-memory state IDLE) must reflect a cursor left on disk by a
+		// prior run, so a status check after restart shows real progress, not a bare IDLE.
+		service.persistProgress(PrewarmProgress.running("all", 42L, 42L, 0L));
+
+		TestablePrewarmBootstrapService fresh = new TestablePrewarmBootstrapService(tempDir);
+		assertEquals(42L, fresh.getStatus().toMap().get("cursorPatientId"),
+				"a fresh process must read the persisted cursor for its status");
+		assertFalse(fresh.getStatus().isRunning());
+	}
+
+	// ---- test doubles --------------------------------------------------------------------------
+
+	private static final class TestablePrewarmBootstrapService extends PrewarmBootstrapService {
+
+		private final File dir;
+
+		List<Long> patientIds = new ArrayList<>();
+
+		int maxPinned = 0;
+
+		int pinnedOnDisk = 0;
+
+		TestablePrewarmBootstrapService(File dir) {
+			this.dir = dir;
+		}
+
+		@Override
+		protected List<Long> enumeratePatientIdsAfter(long afterId, int limit) {
+			List<Long> out = new ArrayList<>();
+			for (Long id : patientIds) {
+				if (id > afterId && out.size() < limit) {
+					out.add(id);
+				}
+			}
+			return out;
+		}
+
+		@Override
+		protected long countPatients() {
+			return patientIds.size();
+		}
+
+		@Override
+		protected Patient getPatient(long id) {
+			Patient p = new Patient();
+			p.setPatientId((int) id);
+			p.setUuid("uuid-" + id);
+			return p;
+		}
+
+		@Override
+		protected long getThrottleMs() {
+			return 0L; // no real sleeping in tests
+		}
+
+		@Override
+		protected int getMaxPinnedEntries() {
+			return maxPinned;
+		}
+
+		@Override
+		protected int countPinnedEntries() {
+			return pinnedOnDisk;
+		}
+
+		@Override
+		protected File progressFile() {
+			return new File(dir, PROGRESS_FILENAME);
+		}
+	}
+
+	private static final class RecordingChartSearchService implements ChartSearchService {
+
+		final List<Integer> warmedPatientIds = new ArrayList<>();
+
+		boolean allPinned = true;
+
+		@Override
+		public void warmup(Patient patient, boolean pin) {
+			warmedPatientIds.add(patient.getPatientId());
+			if (!pin) {
+				allPinned = false;
+			}
+		}
+
+		@Override
+		public ChartAnswer search(Patient patient, String question) {
+			throw new UnsupportedOperationException("prewarm sweep must never call search");
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer) {
+			throw new UnsupportedOperationException("prewarm sweep must never call searchStreaming");
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer,
+				Consumer<String> reasoningConsumer, Consumer<List<RecordReference>> citationsConsumer,
+				Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+			throw new UnsupportedOperationException("prewarm sweep must never call searchStreaming");
+		}
+	}
+}

--- a/eval/latency/kv_prefill_gate.py
+++ b/eval/latency/kv_prefill_gate.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""KV-prefill measurement gate: how much first-query latency would a KV prewarm remove?
+
+For each patient, on a fresh llama-server process (empty RAM prompt-cache pool):
+  1. reindex (warm the querystore index WITHOUT touching the LLM, so the cold reading
+     isolates LLM prefill, not the ~42s lazy index)
+  2. delete the patient's on-disk KV .bin -> the next query is a GENUINE cold full prefill
+  3. cold  /search/stream  -> record the `prefill` phase (t0 -> first output)
+  4. warm  /search/stream  (different question, same patient: KV prefix now RAM-resident)
+                           -> record the `prefill` phase again
+  delta = prefill_cold - prefill_warm  == exactly what ANY prewarm (reactive or bootstrap)
+  could remove from a first query. This is the number the prewarm-bootstrap decision hinges on.
+
+Run against the live standalone on :8081. Prints a per-patient table + median delta.
+"""
+import base64
+import glob
+import json
+import os
+import statistics
+import time
+import urllib.request
+
+BASE = "http://localhost:8081/openmrs/ws/rest/v1"
+AUTH = base64.b64encode(b"admin:Admin123").decode()
+KVDIR = ("/Users/danielkayiwa/Projects/openmrs/test/"
+         "referenceapplication-standalone-3.7.0-SNAPSHOT/appdata/chartsearchai/kvcache")
+
+PATIENTS = {
+    # Large-chart patients (KV .bin 78-142MB) -- the case a prewarm is meant to help.
+    "sarah-taylor":   "165497e8-13e0-4fa4-8190-8e6fa067c4b7",
+    "richard-jones":  "2c384236-7c4f-4971-9c57-05d0069d3bbd",
+    "karen-sanchez":  "60369905-12b3-4c57-99c4-817aa7d3ae4c",
+    "kevin-brown":    "636ac9f1-bcc7-452a-b51e-32a2c0399939",
+    "steven-white":   "f9e185d5-ef1e-43de-87d0-aba47aae4957",
+    "susan-young":    "0178f06f-c6e6-4fe0-b1ae-1c2d8490ed5f",
+}
+# Two DISTINCT questions so the warm query is a real second query (same question would also
+# hit the answer cache). The records prefix is question-independent, so KV reuse holds.
+Q_COLD = "What medications is the patient taking?"
+Q_WARM = "Does the patient have any allergies?"
+
+
+def req(path, data=None, method="GET", timeout=180):
+    r = urllib.request.Request(BASE + path,
+                               data=(json.dumps(data).encode() if data is not None else None),
+                               method=method)
+    r.add_header("Authorization", "Basic " + AUTH)
+    if data is not None:
+        r.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(r, timeout=timeout) as resp:
+        b = resp.read()
+        return json.loads(b) if b else {}
+
+
+def set_gp(name, value):
+    rows = req("/systemsetting?q=%s&v=full" % name).get("results", [])
+    if rows:
+        req("/systemsetting/" + rows[0]["uuid"], {"value": str(value)}, "POST")
+
+
+def delete_kv(uuid):
+    n = 0
+    for f in glob.glob(os.path.join(KVDIR, uuid + "-*.bin")):
+        os.remove(f)
+        n += 1
+    return n
+
+
+def stream_prefill(uuid, q):
+    """Return (total, prefill, reasoning, answer, cites). prefill = t0 -> first SSE output."""
+    r = urllib.request.Request(BASE + "/chartsearchai/search/stream",
+                               data=json.dumps({"patient": uuid, "question": q}).encode(),
+                               method="POST")
+    r.add_header("Authorization", "Basic " + AUTH)
+    r.add_header("Content-Type", "application/json")
+    r.add_header("Accept", "text/event-stream")
+    t0 = time.time()
+    mark, cur, cites = {}, None, 0
+    with urllib.request.urlopen(r, timeout=300) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "replace").rstrip("\n")
+            if line.startswith("event:"):
+                cur = line[6:].strip()
+            elif line.startswith("data:"):
+                now = time.time() - t0
+                f, _ = mark.get(cur, (now, now))
+                mark[cur] = (f, now)
+                if cur == "done":
+                    try:
+                        cites = len(json.loads(line[5:].strip()).get("references") or [])
+                    except Exception:
+                        pass
+    total = time.time() - t0
+    # Full-chart prefill boundary = t0 -> first 'thinking' (full-chart reasoning start).
+    # With progressiveReasoning OFF this is the first event, so it's pure prompt prefill +
+    # TTFT, exactly what a KV prewarm removes. Fall back to first 'token' if no thinking.
+    if "thinking" in mark:
+        prefill = mark["thinking"][0]
+    elif "token" in mark:
+        prefill = mark["token"][0]
+    else:
+        prefill = min((v[0] for v in mark.values()), default=0.0)
+    tk0, tk1 = mark.get("token", (0, 0))
+    return total, prefill, 0.0, tk1 - tk0, cites
+
+
+# --- config: disable rate limit so the run isn't throttled; record + restore -------------
+rl = req("/systemsetting?q=chartsearchai.rateLimitPerMinute&v=full").get("results", [])
+orig_rl = rl[0].get("value") if rl else None
+set_gp("chartsearchai.rateLimitPerMinute", "0")
+# Turn progressiveReasoning OFF so the first 'thinking' event is the full-chart prefill
+# boundary with no preview pass in front of it. Restored in finally.
+pr = req("/systemsetting?q=chartsearchai.progressiveReasoning.enabled&v=full").get("results", [])
+orig_pr = pr[0].get("value") if pr else None
+set_gp("chartsearchai.progressiveReasoning.enabled", "false")
+print("KV-prefill gate | model=E2B | box=M1 Max (GPU/Metal) | progressiveReasoning OFF for clean prefill\n")
+print("%-15s %6s | %8s %8s | %7s | %6s" %
+      ("patient", "cites", "cold_pf", "warm_pf", "DELTA", "cold_tot"))
+
+deltas = []
+try:
+    for name, uuid in PATIENTS.items():
+        req("/querystore/reindex", {"patient": uuid}, "POST")     # warm index, no LLM
+        delete_kv(uuid)                                            # force genuine cold prefill
+        time.sleep(1)
+        c_tot, c_pf, _, _, c_ct = stream_prefill(uuid, Q_COLD)     # COLD: full prefill
+        time.sleep(2)
+        _, w_pf, _, _, _ = stream_prefill(uuid, Q_WARM)            # WARM: KV reused
+        d = c_pf - w_pf
+        deltas.append(d)
+        print("%-15s %6d | %7.2fs %7.2fs | %6.2fs | %6.1fs" %
+              (name, c_ct, c_pf, w_pf, d, c_tot))
+        time.sleep(2)
+finally:
+    set_gp("chartsearchai.rateLimitPerMinute", orig_rl if orig_rl else "10")
+    set_gp("chartsearchai.progressiveReasoning.enabled", orig_pr if orig_pr else "true")
+
+print("\n----- KV-prefill delta (cold - warm), n=%d -----" % len(deltas))
+print("  median=%.2fs  min=%.2fs  max=%.2fs  mean=%.2fs" %
+      (statistics.median(deltas), min(deltas), max(deltas), statistics.mean(deltas)))
+print("  >>> a prewarm removes ~%.1fs (median) from a first query on THIS box <<<"
+      % statistics.median(deltas))

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -12,6 +12,7 @@ package org.openmrs.module.chartsearchai.web.rest;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -42,6 +43,8 @@ import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 import org.openmrs.module.chartsearchai.api.AuditLogService;
 import org.openmrs.module.chartsearchai.api.PatientAccessCheck;
+import org.openmrs.module.chartsearchai.api.impl.PrewarmBootstrapService;
+import org.openmrs.module.chartsearchai.api.impl.PrewarmStatus;
 import org.openmrs.module.chartsearchai.api.impl.WarmupExecutor;
 import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
 import org.openmrs.module.chartsearchai.reference.SafetyWarning;
@@ -116,6 +119,10 @@ public class ChartSearchAiRestController {
 	@Autowired
 	@Qualifier("chartSearchAi.warmupExecutor")
 	private WarmupExecutor warmupExecutor;
+
+	@Autowired
+	@Qualifier("chartSearchAi.prewarmBootstrapService")
+	private PrewarmBootstrapService prewarmBootstrapService;
 
 	@RequestMapping(value = "/search", method = RequestMethod.POST)
 	@ResponseBody
@@ -256,6 +263,44 @@ public class ChartSearchAiRestController {
 
 		warmupExecutor.submit(resolved.patient);
 		return new ResponseEntity<Object>(HttpStatus.ACCEPTED);
+	}
+
+	/**
+	 * Trigger (or steer) the background prewarm bootstrap: a resumable sweep that pre-fills and pins
+	 * every patient's chart KV cache, so a first query on a patient never opened this process is still
+	 * warm. Body (all optional): {@code {"scope":"all","action":"start|restart|stop"}}. Returns
+	 * 202 Accepted with the current status snapshot; the sweep runs on a background daemon thread.
+	 * Requires the {@code Manage AI Prewarm} privilege (a system operation, not a clinical one), and
+	 * is gated by {@code chartsearchai.prewarm.enabled}.
+	 */
+	@RequestMapping(value = "/prewarm", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Object> prewarm(@RequestBody(required = false) Map<String, String> body) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_MANAGE_PREWARM);
+		Map<String, String> b = body == null ? Collections.<String, String> emptyMap() : body;
+		String scope = b.get("scope");
+		// Only the full-database sweep is implemented. Reject any other scope explicitly rather than
+		// silently running an "all" sweep — passing e.g. scope=queue must not surprise the caller with
+		// a full-DB prefill. ("all" and blank both mean all.)
+		if (scope != null && !scope.trim().isEmpty()
+				&& !PrewarmBootstrapService.SCOPE_ALL.equalsIgnoreCase(scope.trim())) {
+			return new ResponseEntity<Object>(
+					errorResponse("Unsupported scope '" + scope + "'. Only 'all' is supported."),
+					HttpStatus.BAD_REQUEST);
+		}
+		PrewarmStatus status = prewarmBootstrapService.trigger(scope, b.get("action"));
+		return new ResponseEntity<Object>(status.toMap(), HttpStatus.ACCEPTED);
+	}
+
+	/**
+	 * Current prewarm-bootstrap status: run state, scope, totals, the resume cursor, and the on-disk
+	 * pinned-entry count. Requires the {@code Manage AI Prewarm} privilege.
+	 */
+	@RequestMapping(value = "/prewarmstatus", method = RequestMethod.GET)
+	@ResponseBody
+	public ResponseEntity<Object> prewarmStatus() {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_MANAGE_PREWARM);
+		return new ResponseEntity<Object>(prewarmBootstrapService.getStatus().toMap(), HttpStatus.OK);
 	}
 
 	/**

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -36,6 +36,11 @@
 		<description>Allows viewing the audit log of AI chart search queries</description>
 	</privilege>
 
+	<privilege>
+		<name>Manage AI Prewarm</name>
+		<description>Allows triggering and monitoring the bulk KV-prewarm bootstrap (a system operation that pre-fills every patient's chart KV cache)</description>
+	</privilege>
+
 	<!-- Global Properties -->
 	<globalProperty>
 		<property>chartsearchai.llm.engine</property>
@@ -112,7 +117,31 @@
 	<globalProperty>
 		<property>chartsearchai.llm.kvCacheMaxEntries</property>
 		<defaultValue>16</defaultValue>
-		<description>Maximum number of persisted KV-cache files to keep in chartsearchai.llm.kvCacheDir. The oldest (by last-modified time) are evicted once this many exist, bounding disk use. Only consulted when the cache directory is configured.</description>
+		<description>Maximum number of persisted KV-cache files to keep in chartsearchai.llm.kvCacheDir. The oldest (by last-modified time) are evicted once this many exist, bounding disk use. Only consulted when the cache directory is configured. Note: entries pinned by the prewarm bootstrap (chartsearchai.prewarm.enabled) are EXEMPT from this cap — see chartsearchai.llm.kvCache.maxPinnedEntries.</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.llm.kvCache.maxPinnedEntries</property>
+		<defaultValue>0</defaultValue>
+		<description>Upper bound on the number of PINNED KV entries the prewarm bootstrap may create. Pinned entries are exempt from chartsearchai.llm.kvCacheMaxEntries (the LRU cap), so a deployment with disk for every patient keeps them all warm. 0 (default) = unlimited. When set greater than 0 and reached, the sweep logs once and stops pinning further entries; it never silently evicts already-pinned ones. Each file is large (tens to a few hundred MB), so bound this on hosts without disk for the whole patient population.</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.prewarm.enabled</property>
+		<defaultValue>false</defaultValue>
+		<description>Master switch for the bulk KV-prewarm bootstrap: the POST /chartsearchai/prewarm and GET /chartsearchai/prewarmstatus endpoints and the background sweep that pre-fills and pins every patient's chart KV cache so a first query on a never-opened patient is still warm. Default false (opt-in): a full-database sweep prefills every patient (tens of seconds each) on the single inference slot and grows the on-disk pinned corpus (bound it with chartsearchai.llm.kvCache.maxPinnedEntries). The per-patient chart-open warmup (chartsearchai.warmupEnabled) is independent of this flag. Only meaningful when chartsearchai.llm.engine is "local". Note: a pinned entry becomes stale when that patient's chart changes; the next query for them re-prefills and re-saves it as an ordinary (unpinned, LRU-capped) entry, so the pinned corpus erodes as charts change — re-run the sweep periodically to refresh it.</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.prewarm.autostart</property>
+		<defaultValue>false</defaultValue>
+		<description>When true (and chartsearchai.prewarm.enabled is on), the prewarm sweep resumes/starts on module startup from its persisted cursor — the analog of querystore.bootstrap.autostart. Default false.</description>
+	</globalProperty>
+
+	<globalProperty>
+		<property>chartsearchai.prewarm.throttleMs</property>
+		<defaultValue>500</defaultValue>
+		<description>Milliseconds the prewarm sweep pauses between patients so the single inference slot is not monopolised and live clinician warmup/query traffic can interleave. Default 500.</description>
 	</globalProperty>
 
 	<globalProperty>

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestControllerTest.java
@@ -269,6 +269,29 @@ public class ChartSearchAiRestControllerTest {
 		assertEquals("Insufficient privileges", errorOf(response));
 	}
 
+	/**
+	 * The prewarm endpoint implements only the full-database ("all") sweep. A request for any other
+	 * scope must be rejected with 400 rather than silently running an "all" sweep (which would surprise
+	 * the caller with an expensive full-DB prefill). Driven as a POJO: the privilege check is satisfied
+	 * via a UserContext that grants the privilege, and the bad-scope branch returns before touching the
+	 * (unset) autowired service. The happy path is verified end-to-end against a live server.
+	 */
+	@Test
+	public void prewarm_shouldReturn400ForUnsupportedScope() {
+		Context.setUserContext(new UserContext(null) {
+
+			@Override
+			public boolean hasPrivilege(String privilege) {
+				return true;
+			}
+		});
+		Map<String, String> body = new HashMap<String, String>();
+		body.put("scope", "queue");
+		ResponseEntity<Object> response = new ChartSearchAiRestController().prewarm(body);
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+		assertEquals("Unsupported scope 'queue'. Only 'all' is supported.", errorOf(response));
+	}
+
 	@Test
 	public void handleBadRequest_shouldReturn400() {
 		ResponseEntity<Object> response = new ChartSearchAiRestController()


### PR DESCRIPTION
## What & why

Cold full-chart prefill is the dominant first-query latency cost — measured **10–20s even on GPU**, ~**15.75s median** saved by a warm KV (harness: `eval/latency/kv_prefill_gate.py`). The reactive chart-open warmup already absorbs this for patients a clinician opens, but a first query on a **never-opened** patient still pays it. This adds an **opt-in** background bootstrap that pre-fills and **pins** every patient's chart KV so even that first query lands warm.

## How it works

**Eviction-exempt pinning.** A pinned `.bin` carries a zero-byte `<name>.bin.pin` sidecar. `evictOldestKvEntries` excludes pinned files from both the count and the delete list, so the LRU cap (`kvCacheMaxEntries`) governs only the ad-hoc warmup/query pool while the prewarm corpus stays durable and unbounded — the right behaviour for hosts with disk for every patient. `purgeKvScopeEntries` deletes the sidecar with its superseded `.bin`. The `pin` flag threads `ChartSearchService.warmup(patient, true)` → router → `LlmInferenceService` → `LlmProvider` → `LlmEngine.warmup(…pin)` → `LocalLlmEngine` as additive overloads (default `pin=false`, so existing callers are untouched), pinning on both the cold-prefill and disk-restore paths.

**Resumable sweep.** `PrewarmBootstrapService` warms patients one by one on a daemon thread, persisting a cursor to `<appdata>/chartsearchai/prewarm-progress.json` so a crash/restart resumes rather than re-prefilling from scratch. Patient enumeration is a batched, id-only SQL cursor (no `Patient` load). `throttleMs` paces the single inference slot so live traffic interleaves; optional `kvCache.maxPinnedEntries` bounds the pinned corpus.

**REST.** `POST /chartsearchai/prewarm` `{scope, action: start|restart|stop}` and `GET /chartsearchai/prewarmstatus`, both behind a new **Manage AI Prewarm** privilege. Only `scope=all` is implemented; other scopes are rejected with 400. The activator resumes the sweep on startup when `prewarm.autostart` is set (best-effort, in a broad catch so it can never break module startup). **All GPs default off.**

## Testing

- Unit: pin/eviction/sidecar tests; 5 sweep/cursor/resume tests; endpoint scope-validation test. **498 api + 42 omod, all green.**
- Live (standalone): gating, trigger, progress, stop, resume-from-cursor, completion 50/50, **eviction exemption (50 pins ≫ cap 16)**, autostart, and the bounded-cap reader path.

## Known follow-up

With a large pinned corpus, `evictOldestKvEntries` scans the whole KV dir on every ad-hoc save (an `.exists()` stat per `.bin`). A directory-layout split (pinned subdir) is the fix **if** anyone runs the corpus at scale — deferred because it changes the on-disk layout already verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)