### PR TITLE
fix(citations): drop the structured array when an answer cites nothing inline

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -465,11 +465,27 @@ public class LlmInferenceService implements ChartSearchService {
 	 * sources of citation indices that can disagree: the LLM's structured
 	 * {@code citations} array and the {@code [N]} markers it writes inline in the
 	 * prose. We take the UNION of both (restricted to indices that map to a real
-	 * retrieved record), so a record the model cited inline but forgot to add to
-	 * the array — or listed in the array but only referenced inline — still
-	 * resolves to a reference. Indices with no matching record are dropped and
+	 * retrieved record), so a record the model cited inline but omitted from the
+	 * array — or one it listed in the array while citing at least one record
+	 * inline — still resolves to a reference. The one exception is the
+	 * abstention-dump carve-out below: an answer whose prose cites nothing inline
+	 * discards the array entirely. Indices with no matching record are dropped and
 	 * logged, exactly as the array path already drops unmapped indices; the
 	 * prose itself is never rewritten.
+	 *
+	 * <p>An inline {@code [N]} marker in the answer is the authoritative record of
+	 * what the model cited: the system prompt instructs it to "Cite EVERY record
+	 * you reference by its number in brackets", and its own few-shot demonstrates
+	 * that an abstention answer carries {@code "citations": []}. A small local
+	 * model breaks that contract by writing an abstention ("no cancer found") with
+	 * no inline markers yet dumping its whole reviewed record set into the
+	 * structured array. So when the answer is real prose that anchors NO citation
+	 * inline, the structured array is treated as unanchored and no references are
+	 * surfaced — a "not found" answer must not arrive with the entire chart
+	 * attached. This is scoped to non-blank prose: an empty/blank answer is the
+	 * absence of an answer (a distinct degenerate output), not an answer that
+	 * failed to anchor its citations, so the array still resolves there — as does
+	 * the legacy {@code answer == null} entry point.
 	 */
 	static List<RecordReference> extractCitedReferences(String answer, List<Integer> citations,
 			List<RecordMapping> mappings) {
@@ -485,10 +501,19 @@ public class LlmInferenceService implements ChartSearchService {
 			}
 		}
 		if (answer != null) {
+			Set<Integer> inline = new LinkedHashSet<Integer>();
 			Matcher marker = ChartSearchAiUtils.INLINE_CITATION.matcher(answer);
 			while (marker.find()) {
-				seen.add(Integer.valueOf(marker.group(1)));
+				inline.add(Integer.valueOf(marker.group(1)));
 			}
+			// Real answer prose that anchors NO citation inline: the structured
+			// array is unanchored (the abstention-dump failure mode), so surface
+			// nothing rather than the records the model merely reviewed. The
+			// !isBlank guard exempts a blank answer — see the method javadoc.
+			if (inline.isEmpty() && !ChartSearchAiUtils.isBlank(answer)) {
+				return new ArrayList<RecordReference>();
+			}
+			seen.addAll(inline);
 		}
 
 		List<RecordReference> references = new ArrayList<RecordReference>();

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceAbstentionCitationTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceAbstentionCitationTest.java
@@ -1,0 +1,194 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.impl.LlmProvider.LlmResponse;
+import org.openmrs.module.chartsearchai.reference.DrugReferenceInjector;
+import org.openmrs.module.chartsearchai.reference.DrugSafetyValidator;
+import org.openmrs.module.chartsearchai.reference.SafetyWarning;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * Reproduces the exact demo failure behind "Does he have cancer?": a small local
+ * model returns an abstention answer that cites NOTHING inline (no {@code [N]}
+ * markers in the prose) yet dumps its whole reviewed record set into the
+ * structured {@code citations} array. The pipeline used to surface all of those
+ * as clickable references, so a "no cancer found" answer arrived with 30
+ * unrelated conditions attached.
+ *
+ * <p>The contract is set by the system prompt's own few-shot: an abstention
+ * answer ("There are no records of banana deliveries.") carries
+ * {@code "citations": []}, and every real citation is written inline in brackets.
+ * References must therefore be anchored by an inline {@code [N]} marker; a
+ * structured array with no inline anchor in the answer is spurious.</p>
+ *
+ * <p>Drives the real {@link LlmInferenceService#search}/{@code searchStreaming}
+ * orchestration (buildChart -&gt; generate -&gt; extract citations -&gt; ground)
+ * with the chart/LLM collaborators stubbed, mirroring
+ * {@link LlmInferenceServiceCitationWiringTest}.</p>
+ */
+public class LlmInferenceServiceAbstentionCitationTest {
+
+	private TestableService service;
+
+	@BeforeEach
+	public void setUp() {
+		service = new TestableService();
+		service.setChartBuildingStrategy(new StubStrategy());
+		service.setLlmProvider(new StubProvider());
+		service.setDrugReferenceInjector(new DrugReferenceInjector() {
+
+			@Override
+			public PatientChart inject(PatientChart chart, Patient patient, String question) {
+				return chart;
+			}
+		});
+		service.setDrugSafetyValidator(new DrugSafetyValidator() {
+
+			@Override
+			public List<SafetyWarning> validate(String answer, String question, Patient patient) {
+				return Collections.emptyList();
+			}
+		});
+	}
+
+	private static Patient patient() {
+		Patient p = new Patient();
+		p.setPatientId(1);
+		p.setUuid("uuid-1");
+		return p;
+	}
+
+	@Test
+	public void search_shouldReturnNoReferencesForAnAnswerThatCitesNothingInline() {
+		ChartAnswer answer = service.search(patient(), "Does he have cancer?");
+		assertNoReferences(answer);
+	}
+
+	@Test
+	public void searchStreaming_shouldReturnNoReferencesForAnAnswerThatCitesNothingInline() {
+		ChartAnswer answer = service.searchStreaming(patient(), "Does he have cancer?",
+				token -> { });
+		assertNoReferences(answer);
+	}
+
+	/**
+	 * Guards the {@code .trim()} in the drop condition. The abstention-dump drop
+	 * fires only on real prose that anchors no citation; a BLANK answer is a
+	 * distinct degenerate output (the model returned no text) where the structured
+	 * array is still allowed to resolve — the same contract the citation eval
+	 * dataset locks for an empty answer. Without {@code .trim()}, a whitespace-only
+	 * answer would be treated as prose and silently drop its array, diverging from
+	 * that spec with no other test to catch it.
+	 */
+	@Test
+	public void search_shouldStillResolveTheArrayForABlankAnswer() {
+		service.setLlmProvider(new BlankAnswerProvider());
+		ChartAnswer answer = service.search(patient(), "What conditions does he have?");
+		assertFalse(answer.getReferences().isEmpty(),
+				"A blank (whitespace-only) answer is degenerate, not an abstention: its structured "
+						+ "citations array must still resolve; got " + answer.getReferences());
+	}
+
+	private static void assertNoReferences(ChartAnswer answer) {
+		assertTrue(answer.getReferences().isEmpty(),
+				"An abstention answer with no inline [N] markers must carry no references; got "
+						+ answer.getReferences());
+	}
+
+	/** Subclass that no-ops the Context-backed resolvers so no OpenMRS runtime is needed. */
+	private static final class TestableService extends LlmInferenceService {
+
+		@Override
+		protected boolean resolveWarmupEnabled() {
+			return false;
+		}
+	}
+
+	private static final class StubStrategy extends ChartBuildingStrategy {
+
+		@Override
+		PatientChart buildChart(Patient patient, String question) {
+			List<RecordMapping> mappings = Arrays.asList(
+					new RecordMapping(8, "condition", "00000000-0000-0000-0000-000000000008", null),
+					new RecordMapping(9, "diagnosis", "00000000-0000-0000-0000-000000000009", null));
+			return new PatientChart("8. Tuberculosis\n9. Persistent vomiting", mappings,
+					Collections.<Integer>emptyList());
+		}
+
+		@Override
+		boolean usePreFilter() {
+			return false;
+		}
+	}
+
+	/**
+	 * The abstention shape: prose names no citation in brackets, but the structured
+	 * array dumps every reviewed record.
+	 */
+	private static final class StubProvider extends LlmProvider {
+
+		private static LlmResponse canned() {
+			return new LlmResponse(
+					"There is no explicit diagnosis of cancer in the patient records.",
+					Arrays.asList(8, 9));
+		}
+
+		@Override
+		public LlmResponse search(String numberedRecords, List<Integer> focusIndices,
+				String question) {
+			return canned();
+		}
+
+		@Override
+		public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices,
+				String question, Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+				String cacheScope) {
+			return canned();
+		}
+	}
+
+	/**
+	 * Returns a whitespace-only answer with a non-empty citations array — the blank
+	 * degenerate case, distinct from a real abstention sentence.
+	 */
+	private static final class BlankAnswerProvider extends LlmProvider {
+
+		private static LlmResponse canned() {
+			return new LlmResponse("   ", Arrays.asList(8, 9));
+		}
+
+		@Override
+		public LlmResponse search(String numberedRecords, List<Integer> focusIndices,
+				String question) {
+			return canned();
+		}
+
+		@Override
+		public LlmResponse searchStreaming(String numberedRecords, List<Integer> focusIndices,
+				String question, Consumer<String> tokenConsumer, Consumer<String> reasoningConsumer,
+				String cacheScope) {
+			return canned();
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceTest.java
@@ -185,6 +185,33 @@ public class LlmInferenceServiceTest {
 	}
 
 	@Test
+	public void extractCitedReferences_shouldKeepTheArrayWhenTheOnlyInlineMarkerIsUnmapped() {
+		List<RecordMapping> mappings = Arrays.asList(
+				new RecordMapping(8, "condition", uuid(8), null),
+				new RecordMapping(9, "obs", uuid(9), null));
+
+		// A positive answer whose ONLY inline marker is a typo ([99] does not exist)
+		// while its structured array lists real records. The abstention-dump drop
+		// must NOT fire: the model DID attempt an inline citation, so this is a
+		// mistyped positive answer, not an abstention. Any inline marker — mapped or
+		// not — bypasses the drop by design; a map-aware drop that tried to also
+		// catch a stray-bracket abstention would lose these legitimate array
+		// citations, and the two cases are otherwise indistinguishable without
+		// semantic abstention detection. This locks that decision.
+		String answer = "Yes, the patient has cancer [99].";
+
+		List<RecordReference> result = LlmInferenceService.extractCitedReferences(
+				answer, Arrays.asList(8, 9), mappings);
+
+		List<Integer> indices = new ArrayList<Integer>();
+		for (RecordReference ref : result) {
+			indices.add(ref.getIndex());
+		}
+		Collections.sort(indices);
+		assertEquals(Arrays.asList(8, 9), indices);
+	}
+
+	@Test
 	public void stripQueryStopwords_shouldNormalizeDifferentPhrasingsToSameResult() {
 		// Both queries have only 1 content word ("medications"), so both
 		// preserve the full sentence. The embedding model handles both


### PR DESCRIPTION
## Problem

For patient `b51254aa-…` on the demo, **"Does he have cancer?"** returned the correct answer —

> There is no explicit diagnosis of cancer in the patient records.

— but with **30 references** attached: the patient's entire condition/diagnosis history (Tuberculosis, Fracture of scapula, Alopecia areata…), none of them cancer. It makes no sense to attach references to a "not found" answer, and it actively misleads: a clinician clicking through them would assume they're cancer-related.

## Root cause

`LlmInferenceService.extractCitedReferences(...)` takes the **union** of the LLM's structured `citations` array and the inline `[N]` markers in the prose. A small local model, on an abstention answer, writes **zero** inline markers yet dumps its whole reviewed record set into the structured array — and the pipeline faithfully surfaced all of it.

This violates the model's own contract: the system prompt instructs *"Cite EVERY record you reference by its number in brackets"*, and its few-shot demonstrates that an abstention carries `"citations": []`. Inline `[N]` markers are the authoritative record of what was actually cited.

## Fix

At the single reconciliation chokepoint (feeds both `search` and `searchStreaming`): when the answer is **real prose that anchors no `[N]` marker**, treat the structured array as unanchored and return no references.

Deliberately preserved:
- **Blank/empty answer** (`""`, whitespace) — a distinct degenerate output, not an answer that failed to anchor citations; the array still resolves (matches the existing `citation-empty-answer-with-citations` eval case).
- **`answer == null`** legacy entry point — array resolves alone (existing unit tests).
- **The union whenever any inline marker is present** — even an unmapped typo (`[99]`) still merges the array, so a mistyped *positive* answer keeps its citations. The union's ordering is byte-identical to before.

## Tests

All exercise the real code path — no assertions weakened, no existing test modified.

- `LlmInferenceServiceAbstentionCitationTest` (new) — drives `search()` **and** `searchStreaming()` through the full pipeline with a stub reproducing the exact demo shape (abstention prose + dumped `[8,9]`): asserts **zero** references. A third test guards the `isBlank` distinction (a blank answer still resolves its array).
- `LlmInferenceServiceTest` (added guard) — an answer whose only inline marker is unmapped still keeps its array, locking the design decision against a naive map-aware "fix".

`api` suite: **584 tests, 0 failures.**

## Verified live

Rebuilt and redeployed to the `:8081` standalone:

| Query | Answer | References (before → after) |
|-------|--------|------------------------------|
| Does he have cancer? | *no explicit diagnosis of cancer…* | **30 → 0** |
| Does he have tuberculosis? (positive control) | *Yes, he has Tuberculosis. The condition is ACTIVE [2] and the diagnosis is PROVISIONAL [6].* | 2 (unchanged) |

## Notes / follow-ups (not in this PR)

- **Eval A/B flip gates** (`eval/latency/quality_panel.py`, `prod_reasoning_ab.py`) count any abstention citation flip and gate `flips == 0`. This change *intentionally* flips dumped-abstention cells from non-empty to empty, so a run across this change reports FAIL — re-baseline the `pre_dir` capture rather than treat it as a regression.
- **Known tail:** an abstention answer containing a stray bracketed number that isn't a real citation (e.g. `[2024]`) would bypass the drop. No clean fix without semantic abstention detection (which the design forbids); the added guard test documents why a map-aware "fix" is off the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)