### PR TITLE
Fix hasActiveDrug to match whole words, not substrings (closes #86)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -228,20 +228,38 @@ public class DrugReference {
 			return false;
 		}
 		for (String alias : aliases) {
-			if (alias == null || alias.isEmpty()) {
-				continue;
+			if (containsWord(lowerText, alias)) {
+				return true;
 			}
-			String a = alias.toLowerCase(Locale.ROOT);
-			int idx = lowerText.indexOf(a);
-			while (idx >= 0) {
-				boolean leftOk = idx == 0 || !Character.isLetterOrDigit(lowerText.charAt(idx - 1));
-				int end = idx + a.length();
-				boolean rightOk = end >= lowerText.length() || !Character.isLetterOrDigit(lowerText.charAt(end));
-				if (leftOk && rightOk) {
-					return true;
-				}
-				idx = lowerText.indexOf(a, idx + 1);
+		}
+		return false;
+	}
+
+	/**
+	 * @return true when {@code word} occurs in {@code text} as a <em>whole word</em> — bounded on
+	 *         each side by a non-alphanumeric character or the string edge. Whole-word, not
+	 *         substring, so a drug name nested inside a longer one does not spuriously match
+	 *         ("chlorothiazide" is not a whole word in "hydrochlorothiazide"), while a real token
+	 *         still matches ("aspirin" in "Aspirin 81 mg"). Case-insensitive; a null/blank word
+	 *         never matches. This is the one matcher shared by {@link #matchesText}
+	 *         (alias-in-question) and {@link PatientClinicalContext#hasActiveDrug}
+	 *         (token-in-order-name), so the two cannot drift.
+	 */
+	static boolean containsWord(String text, String word) {
+		if (text == null || word == null || word.isEmpty()) {
+			return false;
+		}
+		String t = text.toLowerCase(Locale.ROOT);
+		String w = word.toLowerCase(Locale.ROOT);
+		int idx = t.indexOf(w);
+		while (idx >= 0) {
+			boolean leftOk = idx == 0 || !Character.isLetterOrDigit(t.charAt(idx - 1));
+			int end = idx + w.length();
+			boolean rightOk = end >= t.length() || !Character.isLetterOrDigit(t.charAt(end));
+			if (leftOk && rightOk) {
+				return true;
 			}
+			idx = t.indexOf(w, idx + 1);
 		}
 		return false;
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
@@ -114,9 +114,11 @@ public class PatientClinicalContext {
 	/** @return true when any active-order name or ATC code matches the given interaction rule. */
 	boolean hasActiveDrug(String nameToken, String atcCode) {
 		if (nameToken != null && !nameToken.trim().isEmpty()) {
-			String n = nameToken.trim().toLowerCase(Locale.ROOT);
+			String n = nameToken.trim();
 			for (String drug : activeDrugNames) {
-				if (drug.contains(n)) {
+				// Whole-word, not substring: an interaction token that is a sub-token of a longer
+				// order name (e.g. "chlorothiazide" inside "hydrochlorothiazide") must not match.
+				if (DrugReference.containsWord(drug, n)) {
 					return true;
 				}
 			}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
@@ -1,0 +1,70 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link PatientClinicalContext#hasActiveDrug} through the real
+ * {@link DrugSafetyValidator} over a fixture whose drug names are substring-nested
+ * ("chlorothiazide" ⊂ "hydrochlorothiazide"). The matcher must fire on whole-word
+ * matches only: an interaction token that is merely a sub-token of a longer active-order
+ * name must not raise a warning naming a drug the patient is not on.
+ */
+public class HasActiveDrugWholeWordTest {
+
+	private static final String FIXTURE = "chartsearchai-test/drug-reference-substring-nested.json";
+
+	private DrugSafetyValidator validatorOverFixture() throws Exception {
+		return DrugReferenceTestSupport.validator(
+				DrugReferenceTestSupport.serviceWith(DrugReferenceTestSupport.fixtureEntries(FIXTURE)));
+	}
+
+	private long interactionCount(List<SafetyWarning> warnings, String drug) {
+		return warnings.stream()
+				.filter(w -> SafetyWarning.TYPE_INTERACTION.equals(w.getType())
+						&& drug.equalsIgnoreCase(w.getDrug()))
+				.count();
+	}
+
+	@Test
+	public void subtokenOfLongerOrderNameDoesNotFire() throws Exception {
+		// Patient is on hydrochlorothiazide; ibuprofen interacts with BOTH hydrochlorothiazide and
+		// chlorothiazide. Only the hydrochlorothiazide rule should fire — the chlorothiazide rule
+		// must not, even though "chlorothiazide" is a substring of "hydrochlorothiazide".
+		List<SafetyWarning> warnings = validatorOverFixture().validate(
+				"Ibuprofen is a reasonable analgesic choice.",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("hydrochlorothiazide"),
+						null, null, null));
+
+		assertEquals(1, interactionCount(warnings, "Ibuprofen"),
+				"exactly one interaction should fire (hydrochlorothiazide), not the nested chlorothiazide");
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Ibuprofen", "hydrochlorothiazide"),
+				"the fired interaction should name the drug actually on the chart");
+	}
+
+	@Test
+	public void wholeWordInAMultiWordOrderNameStillFires() throws Exception {
+		// Real order display names carry dose/form suffixes; a whole-word token must still match.
+		List<SafetyWarning> warnings = validatorOverFixture().validate(
+				"Ibuprofen is a reasonable analgesic choice.",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("hydrochlorothiazide 25 mg tablet"), null, null, null));
+
+		assertEquals(1, interactionCount(warnings, "Ibuprofen"),
+				"the whole-word token should match within a dose/form-qualified order name");
+	}
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-substring-nested.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-substring-nested.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "source": "test fixture — substring-nested drug names",
+  "entries": [
+    {
+      "id": "ibuprofen",
+      "name": "Ibuprofen",
+      "aliases": ["ibuprofen"],
+      "atcCodes": ["M01AE01"],
+      "interactions": [
+        { "token": "hydrochlorothiazide", "atc": "C03AA03", "note": "NSAIDs may blunt the diuretic/antihypertensive effect" },
+        { "token": "chlorothiazide", "atc": "C03AA04", "note": "NSAIDs may blunt the diuretic/antihypertensive effect" }
+      ],
+      "source": "test fixture"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #86.

`PatientClinicalContext.hasActiveDrug` matched an interaction/contraindication token as a raw substring of an active-order name (`drug.contains(token)`), so a token nested inside a longer drug name over-fired. Reproduced through the real validator: a patient on **hydrochlorothiazide** asking about **ibuprofen** got a second interaction chip naming **chlorothiazide** — not on their chart — because `"hydrochlorothiazide".contains("chlorothiazide")`.

### Fix

The cause is shared matching infrastructure, so the fix is a single shared matcher rather than a per-call-site patch. `DrugReference.matchesText` already did whole-word matching; that logic is extracted to `DrugReference.containsWord(text, word)` and now backs **both** `matchesText` (alias-in-question, behaviour-preserving) and `hasActiveDrug` (token-in-order-name, the fix), so the two cannot drift.

Whole-word matching rejects `chlorothiazide` inside `hydrochlorothiazide` (it is a sub-token of one word, not a whole word) while still matching `aspirin` in `Aspirin 81 mg`.

### Scope

Affects all drug-reference sources (`json`, `atc`, and the proposed `ddinter` in #85) since `hasActiveDrug` is shared. Surfaced during the #85 review; kept as its own change per the module's "fix shared infra, not the call site" rule.

### Tests

`HasActiveDrugWholeWordTest` drives the real `DrugSafetyValidator` over a substring-nested fixture (ibuprofen interacting with both hydrochlorothiazide and chlorothiazide):
- the nested sub-token (`chlorothiazide`) does **not** fire against a `hydrochlorothiazide` order;
- the real order still fires;
- a dose/form-qualified order name (`hydrochlorothiazide 25 mg tablet`) still matches.

Full `reference` suite green locally on JDK 11: **109 tests, 0 failures** (matchesText-dependent injector/service/validator tests unaffected).