### PR TITLE
Fold same-class explicit interactions into one chip (closes #88)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -10,9 +10,11 @@
 package org.openmrs.module.chartsearchai.reference;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -182,8 +184,7 @@ public class DrugSafetyValidator {
 				addClassContraindications(warnings, ref, context);
 			}
 			if (warnInteractions) {
-				addInteractions(warnings, ref, context);
-				addClassInteractions(warnings, ref, context);
+				addInteractionWarnings(warnings, ref, context);
 			}
 			if (warnDose) {
 				addOverdose(warnings, ref, context, lower, all);
@@ -218,22 +219,98 @@ public class DrugSafetyValidator {
 		}
 	}
 
-	private void addInteractions(List<SafetyWarning> warnings, DrugReference ref,
+	/**
+	 * Interaction reasoning with both arms coordinated so a co-medication that is BOTH an explicit
+	 * interaction partner AND same-class yields ONE chip, not two (issue #88). Two arms feed it:
+	 * <ul>
+	 *   <li><b>rule</b> — an explicit interaction row matched against an active order (by ATC code or
+	 *       name token);</li>
+	 *   <li><b>class</b> — the drug shares an ATC level-4 subgroup with an active order (duplicate
+	 *       therapy), else a curated {@link CrossReactivityGroup}.</li>
+	 * </ul>
+	 * Correlated by the order's ATC code — the key both arms already share. When both apply to the
+	 * same order the chip <em>folds</em> the class/duplicate-therapy relationship together with the
+	 * rule's mechanism note, so nothing is lost and an Unknown-severity row (whose rule note is
+	 * empty) still surfaces the informative class relationship rather than a bare, contentless rule
+	 * chip. When only one arm applies, its single chip is emitted unchanged. A rule matched only by
+	 * name (no ATC to correlate on) is emitted standalone.
+	 */
+	private void addInteractionWarnings(List<SafetyWarning> warnings, DrugReference ref,
 			PatientClinicalContext context) {
 		if (context == null) {
 			return;
 		}
+		Set<String> activeCodes = context.getActiveDrugAtcCodes();
+
+		// Explicit-interaction rules: those correlated to an active order by ATC code (which may also
+		// hit the class arm, so they are resolved in the loop below) vs name-only matches (standalone).
+		Map<String, DrugReference.Interaction> ruleByOrderCode = new LinkedHashMap<String, DrugReference.Interaction>();
 		for (DrugReference.Interaction i : ref.getInteractions()) {
-			if (context.hasActiveDrug(i.getToken(), i.getAtc())) {
-				// A matched rule has a non-blank token or ATC, so the coalesce never yields null.
-				String detail = "interacts with active order "
-						+ ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc());
-				if (i.getNote() != null && !i.getNote().isEmpty()) {
-					detail += " — " + i.getNote();
+			String code = DrugReference.normalizeAtcToken(i.getAtc());
+			if (code != null && activeCodes.contains(code)) {
+				if (!ruleByOrderCode.containsKey(code)) {
+					ruleByOrderCode.put(code, i);
 				}
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.getName(), detail));
+			} else if (context.hasActiveDrug(i.getToken(), null)) {
+				warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.getName(), ruleDetail(i)));
 			}
 		}
+
+		Set<String> refClasses = ref.atcSubgroups();
+		List<CrossReactivityGroup> refGroups = CrossReactivityGroup.groupsOf(ref,
+				drugReferenceService.getCrossReactivityGroups());
+		Set<String> refCodes = ref.normalizedAtcCodes();
+
+		for (String orderCode : activeCodes) {
+			if (refCodes.contains(orderCode)) {
+				// The active order is the same drug — restating existing therapy is not a duplicate,
+				// and a drug does not interact with itself, so neither arm should fire.
+				continue;
+			}
+			DrugReference.Interaction rule = ruleByOrderCode.remove(orderCode);
+			String classNote = classRelationship(orderCode, refClasses, refGroups);
+			if (classNote != null) {
+				String detail = classNote;
+				if (rule != null && rule.getNote() != null && !rule.getNote().isEmpty()) {
+					detail += "; explicit interaction: " + rule.getNote();
+				}
+				warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.getName(), detail));
+			} else if (rule != null) {
+				warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.getName(), ruleDetail(rule)));
+			}
+		}
+	}
+
+	/** The rule-arm chip detail: "interacts with active order X", plus the mechanism note when present. */
+	private static String ruleDetail(DrugReference.Interaction i) {
+		String detail = "interacts with active order " + ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc());
+		if (i.getNote() != null && !i.getNote().isEmpty()) {
+			detail += " — " + i.getNote();
+		}
+		return detail;
+	}
+
+	/**
+	 * @return the class-arm relationship phrasing for an active order code — a shared ATC level-4
+	 *         subgroup (duplicate therapy), else a curated cross-reactivity group — or {@code null}
+	 *         when neither applies.
+	 */
+	private String classRelationship(String orderCode, Set<String> refClasses,
+			List<CrossReactivityGroup> refGroups) {
+		if (refClasses.isEmpty() && refGroups.isEmpty()) {
+			return null;
+		}
+		if (orderCode.length() >= DrugReference.ATC_SUBGROUP_PREFIX_LENGTH && refClasses
+				.contains(orderCode.substring(0, DrugReference.ATC_SUBGROUP_PREFIX_LENGTH))) {
+			return "same ATC class (" + orderCode.substring(0, DrugReference.ATC_SUBGROUP_PREFIX_LENGTH)
+					+ ") as active order " + displayNameForAtcCode(orderCode) + " — possible duplicate therapy";
+		}
+		CrossReactivityGroup group = CrossReactivityGroup.sharedGroupForCode(refGroups, orderCode);
+		if (group != null) {
+			return "same cross-reactivity group (" + group.getName() + ") as active order "
+					+ displayNameForAtcCode(orderCode) + " — possible additive or duplicate-class therapy";
+		}
+		return null;
 	}
 
 	/**
@@ -295,40 +372,6 @@ public class DrugSafetyValidator {
 	 * matches on codes directly and names the order from the dataset; the most specific match wins,
 	 * so a subgroup + group double-match warns once.
 	 */
-	private void addClassInteractions(List<SafetyWarning> warnings, DrugReference ref,
-			PatientClinicalContext context) {
-		if (context == null) {
-			return;
-		}
-		Set<String> refClasses = ref.atcSubgroups();
-		List<CrossReactivityGroup> refGroups = CrossReactivityGroup.groupsOf(ref,
-				drugReferenceService.getCrossReactivityGroups());
-		if (refClasses.isEmpty() && refGroups.isEmpty()) {
-			return;
-		}
-		Set<String> refCodes = ref.normalizedAtcCodes();
-		for (String orderCode : context.getActiveDrugAtcCodes()) {
-			if (refCodes.contains(orderCode)) {
-				// Restating existing therapy is not a duplicate.
-				continue;
-			}
-			if (orderCode.length() >= DrugReference.ATC_SUBGROUP_PREFIX_LENGTH && refClasses
-					.contains(orderCode.substring(0, DrugReference.ATC_SUBGROUP_PREFIX_LENGTH))) {
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.getName(),
-						"same ATC class (" + orderCode.substring(0, DrugReference.ATC_SUBGROUP_PREFIX_LENGTH)
-								+ ") as active order " + displayNameForAtcCode(orderCode)
-								+ " — possible duplicate therapy"));
-				continue;
-			}
-			CrossReactivityGroup group = CrossReactivityGroup.sharedGroupForCode(refGroups, orderCode);
-			if (group != null) {
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.getName(),
-						"same cross-reactivity group (" + group.getName() + ") as active order "
-								+ displayNameForAtcCode(orderCode) + " — possible additive or duplicate-class therapy"));
-			}
-		}
-	}
-
 	/** @return the ATC level-4 subgroup {@code other} shares with {@code refClasses}, or null when none. */
 	private static String sharedClass(Set<String> refClasses, DrugReference other) {
 		for (String cls : other.atcSubgroups()) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DuplicateInteractionChipTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DuplicateInteractionChipTest.java
@@ -1,0 +1,73 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A co-medication that is BOTH an explicit interaction partner AND in the same ATC subgroup used to
+ * raise two {@link SafetyWarning#TYPE_INTERACTION} chips (rule arm + class arm). The two arms are now
+ * folded into one chip per pair. Driven through the real {@link DrugSafetyValidator} over a fixture
+ * where lisinopril/enalapril each interact with ramipril and all three share subgroup C09AA.
+ */
+public class DuplicateInteractionChipTest {
+
+	private static final String FIXTURE = "chartsearchai-test/drug-reference-sameclass.json";
+
+	private DrugSafetyValidator validator() throws Exception {
+		return DrugReferenceTestSupport.validator(
+				DrugReferenceTestSupport.serviceWith(DrugReferenceTestSupport.fixtureEntries(FIXTURE)));
+	}
+
+	/** Active order: ramipril (ATC C09AA05). */
+	private PatientClinicalContext ramiprilActive() {
+		return DrugReferenceTestSupport.ctx(60, null, null, DrugReferenceTestSupport.set("C09AA05"), null, null);
+	}
+
+	private long interactionCount(List<SafetyWarning> warnings, String drug) {
+		return warnings.stream()
+				.filter(w -> SafetyWarning.TYPE_INTERACTION.equals(w.getType())
+						&& drug.equalsIgnoreCase(w.getDrug()))
+				.count();
+	}
+
+	@Test
+	public void sameClassPairWithMechanismFoldsToOneContentfulChip() throws Exception {
+		// Lisinopril asked about, ramipril active: explicit interaction (with a mechanism) AND same
+		// ATC subgroup C09AA. One chip, carrying both the duplicate-therapy relationship and the note.
+		List<SafetyWarning> warnings = validator().validate(
+				"Lisinopril is a reasonable choice.", ramiprilActive());
+
+		assertEquals(1, interactionCount(warnings, "Lisinopril"),
+				"the rule arm and the class arm must fold into a single interaction chip, not two");
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Lisinopril", "duplicate therapy", "additive hyperkalemia"),
+				"the single chip should carry both the class/duplicate-therapy relationship and the mechanism");
+	}
+
+	@Test
+	public void sameClassPairWithoutMechanismStillYieldsTheInformativeClassChip() throws Exception {
+		// Enalapril's ramipril interaction carries no mechanism note. Naively preferring the rule arm
+		// would drop to a contentless chip; folding keeps the informative class relationship.
+		List<SafetyWarning> warnings = validator().validate(
+				"Enalapril is a reasonable choice.", ramiprilActive());
+
+		assertEquals(1, interactionCount(warnings, "Enalapril"),
+				"still exactly one chip for the pair");
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Enalapril", "duplicate therapy", "C09AA"),
+				"with no mechanism note, the surviving chip must still carry the class/duplicate-therapy info");
+	}
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-sameclass.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-sameclass.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "source": "test fixture — same-class explicit-interaction pairs",
+  "entries": [
+    {
+      "id": "lisinopril",
+      "name": "Lisinopril",
+      "aliases": ["lisinopril"],
+      "atcCodes": ["C09AA03"],
+      "interactions": [
+        { "token": "ramipril", "atc": "C09AA05", "note": "additive hyperkalemia and renal impairment risk" }
+      ],
+      "source": "test fixture"
+    },
+    {
+      "id": "enalapril",
+      "name": "Enalapril",
+      "aliases": ["enalapril"],
+      "atcCodes": ["C09AA02"],
+      "interactions": [
+        { "token": "ramipril", "atc": "C09AA05" }
+      ],
+      "source": "test fixture"
+    },
+    {
+      "id": "ramipril",
+      "name": "Ramipril",
+      "aliases": ["ramipril"],
+      "atcCodes": ["C09AA05"],
+      "source": "test fixture"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #88.

A co-medication that is BOTH an explicit interaction partner AND in the same ATC level-4 subgroup raised **two** `TYPE_INTERACTION` chips — the rule arm (`addInteractions`) and the class arm (`addClassInteractions`) both fired for the one pair. Reproduced through the real validator: lisinopril asked about with ramipril active → both `interacts with active order ramipril …` and `same ATC class (C09AA) as active order Ramipril — possible duplicate therapy`.

### Fix

The two arms are merged into one coordinated `addInteractionWarnings`, correlating them by the **order's ATC code** (the key both already share). When both apply to the same order, the chip **folds** the class/duplicate-therapy relationship together with the rule's mechanism note.

Folding — rather than "class arm yields to rule arm" — is deliberate, and addresses the wrinkle raised in the review: ~42k of the full KB's rows are Unknown severity with **no** mechanism text, so a naive rule-wins dedup would collapse those pairs to a contentless chip. Folding keeps the informative class relationship in that case, and the mechanism when there is one. Single-arm cases (class-only duplicate therapy, or a different-class explicit interaction) are emitted **unchanged**. A rule matched only by name (no ATC to correlate on) is emitted standalone.

`ruleDetail()` and `classRelationship()` are extracted so the fold and the single-arm paths share one definition.

### Scope

Shared validator infrastructure — it predates the DDInter source (the seed's ibuprofen against an active aspirin order double-chips on `main` today via the cross-reactivity-group path); #85 just made it systematic. Fixed here rather than in the source. Surfaced during the #85 review.

### Tests

`DuplicateInteractionChipTest` drives the real `DrugSafetyValidator` over a same-class fixture:
- a same-class pair **with** a mechanism folds to one chip carrying both the duplicate-therapy relationship and the mechanism;
- a same-class pair **without** a mechanism still yields the informative class chip (not a contentless one);
- neither yields two chips.

Full `reference` suite green locally on JDK 11: **109 tests, 0 failures** (the existing rule-only and class-only interaction tests unaffected, confirming single-arm behaviour is preserved).