### PR TITLE
Dual-provider rebuild: provider boundary + shared querystore context slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ An OpenMRS module that lets clinicians ask natural language questions about a pa
 
 For project background, community discussion, and roadmap, see the [wiki project page](https://openmrs.atlassian.net/wiki/spaces/projects/pages/373325839/Chart+Search+aka+ChartSearchAI).
 
+## Provider architecture (current development)
+
+ChartSearchAI authorizes the patient request and supports two explicit providers behind one OpenMRS
+conversation, audit, evidence, and cancellation contract:
+
+- The **bundled provider** preserves the module's local and configured remote inference engines,
+  streaming, QueryStore-backed context, safety, grounding, and cache behavior.
+- The **med-agent-hub provider** relays one staged hub profile request and persists its returned
+  answer-validation, temporal-gate, grounding, safety, and In-Depth states without reinterpreting
+  them in Java.
+
+Deployments may enable one or both providers. When both are available, the user chooses a provider
+before starting a conversation; switching provider starts a new conversation. **No automatic fallback**
+occurs between providers. QueryStore remains the OpenMRS clinical-context surface; it is
+required for the bundled path and an optional source for a separately configured hub deployment.
+
+The standalone instructions below describe the supported bundled-provider installation. Hub
+integration configuration and the dual-provider acceptance record live in the validation harness's
+`openmrs-dual-provider-parity-roadmap.md`.
+
 The standalone download above includes the backend module, frontend ESM, and the following AI models — ready to run:
 
 - **LLM**: [Gemma 4 E4B Instruct (Q4_K_M)](https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF) — ~5 GB, the module's default model, for answering clinical questions. (A larger Gemma 4 26B MoE bundle can be built via the workflow's `gguf_model_url` input.)

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -472,6 +472,18 @@ public class ChartSearchAiConstants {
 	/** Reference data, not patient data — injected by {@link org.openmrs.module.chartsearchai.reference.DrugReferenceInjector}. */
 	public static final String RESOURCE_TYPE_DRUG_REFERENCE = "drug_reference";
 
+	/**
+	 * Fixed med-agent-hub chat-completions endpoint used by {@code HubClinicalAnswerProvider}.
+	 * Must end with {@code /v1/chat/completions}. Empty/unset means the hub provider is not ready.
+	 */
+	public static final String GP_HUB_ENDPOINT_URL = "chartsearchai.hub.endpointUrl";
+
+	/**
+	 * Optional runtime-property Bearer token for the hub endpoint
+	 * ({@code chartsearchai.hub.apikey} in OpenMRS runtime properties — never a global property).
+	 */
+	public static final String RP_HUB_API_KEY = "chartsearchai.hub.apikey";
+
 	private ChartSearchAiConstants() {
 	}
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/ChartSearchService.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.reference.DrugSafetyValidator;
 import org.openmrs.module.chartsearchai.reference.SafetyWarning;
 
 /**
@@ -211,6 +212,8 @@ public interface ChartSearchService {
 
 		private final List<SafetyWarning> safetyWarnings;
 
+		private final String safetyStatus;
+
 		public ChartAnswer(String answer, List<RecordReference> references) {
 			this(answer, references, 0, 0, 0);
 		}
@@ -229,6 +232,13 @@ public interface ChartSearchService {
 		public ChartAnswer(String answer, List<RecordReference> references,
 				int inputTokens, int outputTokens, int cachedTokens,
 				List<SafetyWarning> safetyWarnings) {
+			this(answer, references, inputTokens, outputTokens, cachedTokens, safetyWarnings,
+					DrugSafetyValidator.STATUS_UNAVAILABLE);
+		}
+
+		public ChartAnswer(String answer, List<RecordReference> references,
+				int inputTokens, int outputTokens, int cachedTokens,
+				List<SafetyWarning> safetyWarnings, String safetyStatus) {
 			this.answer = answer;
 			this.references = java.util.Collections.unmodifiableList(
 					new java.util.ArrayList<>(references));
@@ -238,6 +248,7 @@ public interface ChartSearchService {
 			this.safetyWarnings = java.util.Collections.unmodifiableList(
 					new java.util.ArrayList<>(safetyWarnings == null
 							? java.util.Collections.<SafetyWarning> emptyList() : safetyWarnings));
+			this.safetyStatus = safetyStatus;
 		}
 
 		/**
@@ -285,6 +296,15 @@ public interface ChartSearchService {
 		 */
 		public List<SafetyWarning> getSafetyWarnings() {
 			return safetyWarnings;
+		}
+
+		/**
+		 * One of {@link DrugSafetyValidator#STATUS_CHECKED}, {@link DrugSafetyValidator#STATUS_LIMITED},
+		 * {@link DrugSafetyValidator#STATUS_UNAVAILABLE} — an empty {@link #getSafetyWarnings()} must
+		 * never be read as "checked" on its own.
+		 */
+		public String getSafetyStatus() {
+			return safetyStatus;
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/InsufficientContextException.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/InsufficientContextException.java
@@ -1,0 +1,42 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Thrown when a patient's mandatory clinical evidence (demographics, allergies, active
+ * conditions) alone exceeds the LLM's available input budget, before any optional context is
+ * even considered. Distinct from {@link ChartTooLargeException}: that one is llama-server's own
+ * after-the-fact rejection of a prompt that turned out too big; this one is a proactive,
+ * specifically-diagnosed abstention — the same {@code insufficient_context} outcome the
+ * dual-provider conformance fixture's {@code context.mandatory-overflow-abstains} case and
+ * med-agent-hub's {@code InsufficientContextError} already use. Mandatory evidence is never
+ * droppable (ADR Decision 17), so there is nothing left to trim — the turn must abstain rather
+ * than silently omit safety-critical content.
+ */
+public class InsufficientContextException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final List<String> mandatoryRecordIds;
+
+	public InsufficientContextException(String message, List<String> mandatoryRecordIds) {
+		super(message);
+		this.mandatoryRecordIds = mandatoryRecordIds == null ? Collections.<String> emptyList()
+				: Collections.unmodifiableList(mandatoryRecordIds);
+	}
+
+	/** Stable resource uuids of the mandatory records that alone exceeded the budget. */
+	public List<String> getMandatoryRecordIds() {
+		return mandatoryRecordIds;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationDAO.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationDAO.java
@@ -1,0 +1,44 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.conversation;
+
+import java.util.Date;
+import java.util.List;
+
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+
+/** Persistence boundary for provider-neutral clinical conversations and turns. */
+public interface ConversationDAO {
+
+	ClinicalConversation saveConversation(ClinicalConversation conversation);
+
+	ClinicalConversation getConversation(Integer conversationId);
+
+	ClinicalConversation getConversationByUuid(String uuid);
+
+	ClinicalConversation getLatestActiveConversation(Patient patient, User user);
+
+	ClinicalConversationTurn saveTurn(ClinicalConversationTurn turn);
+
+	ClinicalConversationTurn getTurnByUuid(String uuid);
+
+	List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation);
+
+	int getLastOrdinal(ClinicalConversation conversation);
+
+	/**
+	 * Deletes turns completed before the retention horizon, then conversation headers with no
+	 * surviving turns whose last activity is also before the horizon.
+	 */
+	int purgeBefore(Date before);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
@@ -38,6 +38,13 @@ public interface ConversationService {
 
 	ClinicalConversation getByUuid(String uuid);
 
+	/**
+	 * The current authenticated user's active conversation for this patient, or {@code null} if
+	 * none exists. Lets chat history be recovered without a client-supplied session id — a fresh
+	 * page load (reload) has no session to send, only the patient it is looking at.
+	 */
+	ClinicalConversation getLatestActiveConversation(Patient patient);
+
 	List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation);
 
 	ClinicalConversationTurn startTurn(ClinicalConversation conversation, String requestId, String question);

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
@@ -12,6 +12,7 @@ package org.openmrs.module.chartsearchai.api.conversation;
 import java.util.List;
 
 import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope;
 import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
 import org.openmrs.module.chartsearchai.api.provider.TurnResult;
 import org.openmrs.module.chartsearchai.model.ClinicalConversation;
@@ -51,6 +52,15 @@ public interface ConversationService {
 
 	ClinicalConversationTurn finishTurn(ClinicalConversationTurn turn, TurnResult result, long responseTimeMs);
 
-	/** Completed successful turns projected to canonical prose for the provider's next request. */
+	/**
+	 * Persists an already reviewed safe answer while an optional later stage (such as In-Depth) is
+	 * still running. Returns {@code false} when the envelope is not a checked final answer.
+	 */
+	boolean recordCheckedAnswer(ClinicalConversationTurn turn, AnswerEnvelope answer);
+
+	/**
+	 * Completed successful turns, plus checked answers whose optional In-Depth tail is still
+	 * running, projected to canonical prose for the provider's next request.
+	 */
 	List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation);
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
@@ -1,0 +1,43 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.conversation;
+
+import java.util.List;
+
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
+import org.openmrs.module.chartsearchai.api.provider.TurnResult;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+
+/**
+ * Common OpenMRS ownership boundary for provider-neutral conversation lifecycle, persistence, and
+ * audit. Providers execute answers; this service records who asked, which provider/mode served the
+ * turn, and the provider's complete content-agnostic answer envelope.
+ */
+public interface ConversationService {
+
+	/**
+	 * Reuses the current user's active conversation only when patient, provider, and mode all match.
+	 * Selecting another provider or mode closes the old conversation and starts a new one.
+	 */
+	ClinicalConversation openOrCreate(Patient patient, String providerId, ProviderMode mode);
+
+	ClinicalConversation getByUuid(String uuid);
+
+	List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation);
+
+	ClinicalConversationTurn startTurn(ClinicalConversation conversation, String requestId, String question);
+
+	ClinicalConversationTurn finishTurn(ClinicalConversationTurn turn, TurnResult result, long responseTimeMs);
+
+	/** Completed successful turns projected to canonical prose for the provider's next request. */
+	List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/ConversationService.java
@@ -30,6 +30,12 @@ public interface ConversationService {
 	 */
 	ClinicalConversation openOrCreate(Patient patient, String providerId, ProviderMode mode);
 
+	/**
+	 * Always closes any active conversation for the current user/patient and opens a fresh empty
+	 * one for the given provider/mode. Used by {@code POST /chat/new}.
+	 */
+	ClinicalConversation startNew(Patient patient, String providerId, ProviderMode mode);
+
 	ClinicalConversation getByUuid(String uuid);
 
 	List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation);

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/PriorClinicalTurn.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/PriorClinicalTurn.java
@@ -1,0 +1,35 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.conversation;
+
+/**
+ * Canonical prose projection of one completed prior turn. Providers receive this projection rather
+ * than another provider's persisted JSON envelope, so conversation replay does not couple an
+ * engine to persistence format or provider-specific output fields.
+ */
+public final class PriorClinicalTurn {
+
+	private final String question;
+
+	private final String answer;
+
+	public PriorClinicalTurn(String question, String answer) {
+		this.question = question;
+		this.answer = answer;
+	}
+
+	public String getQuestion() {
+		return question;
+	}
+
+	public String getAnswer() {
+		return answer;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/hibernate/HibernateConversationDAO.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/hibernate/HibernateConversationDAO.java
@@ -1,0 +1,125 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.conversation.hibernate;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.module.chartsearchai.api.conversation.ConversationDAO;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+/** Hibernate persistence for provider-neutral conversations and turns. */
+@Repository("chartSearchAi.conversationDAO")
+public class HibernateConversationDAO implements ConversationDAO {
+
+	@Autowired
+	private SessionFactory sessionFactory;
+
+	@Override
+	public ClinicalConversation saveConversation(ClinicalConversation conversation) {
+		sessionFactory.getCurrentSession().saveOrUpdate(conversation);
+		return conversation;
+	}
+
+	@Override
+	public ClinicalConversation getConversation(Integer conversationId) {
+		return (ClinicalConversation) sessionFactory.getCurrentSession()
+				.get(ClinicalConversation.class, conversationId);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public ClinicalConversation getConversationByUuid(String uuid) {
+		List<ClinicalConversation> results = sessionFactory.getCurrentSession()
+				.createQuery("from ClinicalConversation where uuid = :uuid")
+				.setParameter("uuid", uuid)
+				.list();
+		return results.isEmpty() ? null : results.get(0);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public ClinicalConversation getLatestActiveConversation(Patient patient, User user) {
+		List<ClinicalConversation> results = sessionFactory.getCurrentSession()
+				.createQuery("from ClinicalConversation where patient = :patient and user = :user "
+						+ "and status = :status order by lastActivityAt desc")
+				.setParameter("patient", patient)
+				.setParameter("user", user)
+				.setParameter("status", ClinicalConversation.STATUS_ACTIVE)
+				.setMaxResults(1)
+				.list();
+		return results.isEmpty() ? null : results.get(0);
+	}
+
+	@Override
+	public ClinicalConversationTurn saveTurn(ClinicalConversationTurn turn) {
+		sessionFactory.getCurrentSession().saveOrUpdate(turn);
+		return turn;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public ClinicalConversationTurn getTurnByUuid(String uuid) {
+		List<ClinicalConversationTurn> results = sessionFactory.getCurrentSession()
+				.createQuery("from ClinicalConversationTurn where uuid = :uuid")
+				.setParameter("uuid", uuid)
+				.list();
+		return results.isEmpty() ? null : results.get(0);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation) {
+		if (conversation == null) {
+			return Collections.emptyList();
+		}
+		return sessionFactory.getCurrentSession()
+				.createQuery("from ClinicalConversationTurn where conversation = :conversation "
+						+ "order by ordinal asc")
+				.setParameter("conversation", conversation)
+				.list();
+	}
+
+	@Override
+	public int getLastOrdinal(ClinicalConversation conversation) {
+		if (conversation == null) {
+			return -1;
+		}
+		Integer max = (Integer) sessionFactory.getCurrentSession()
+				.createQuery("select max(ordinal) from ClinicalConversationTurn "
+						+ "where conversation = :conversation")
+				.setParameter("conversation", conversation)
+				.uniqueResult();
+		return max == null ? -1 : max;
+	}
+
+	@Override
+	public int purgeBefore(Date before) {
+		int turns = sessionFactory.getCurrentSession()
+				.createQuery("delete from ClinicalConversationTurn "
+						+ "where completedAt is not null and completedAt < :before")
+				.setParameter("before", before)
+				.executeUpdate();
+		int conversations = sessionFactory.getCurrentSession()
+				.createQuery("delete from ClinicalConversation c where c.lastActivityAt < :before "
+						+ "and not exists (select 1 from ClinicalConversationTurn t "
+						+ "where t.conversation = c)")
+				.setParameter("before", before)
+				.executeUpdate();
+		return turns + conversations;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
@@ -102,6 +102,14 @@ public class ConversationServiceImpl implements ConversationService {
 	}
 
 	@Override
+	public ClinicalConversation getLatestActiveConversation(Patient patient) {
+		require(patient != null, "patient is required");
+		User user = Context.getAuthenticatedUser();
+		require(user != null, "an authenticated user is required");
+		return conversationDAO.getLatestActiveConversation(patient, user);
+	}
+
+	@Override
 	public ClinicalConversation getByUuid(String uuid) {
 		if (uuid == null || uuid.trim().isEmpty()) {
 			return null;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
@@ -67,6 +67,22 @@ public class ConversationServiceImpl implements ConversationService {
 				&& Objects.equals(modeName, current.getProviderMode())) {
 			return current;
 		}
+		return closeAndCreate(patient, user, providerId, modeName, current);
+	}
+
+	@Override
+	public ClinicalConversation startNew(Patient patient, String providerId, ProviderMode mode) {
+		require(patient != null, "patient is required");
+		require(providerId != null && !providerId.trim().isEmpty(), "providerId is required");
+		User user = Context.getAuthenticatedUser();
+		require(user != null, "an authenticated user is required");
+		String modeName = mode == null ? null : mode.getWireName();
+		ClinicalConversation current = conversationDAO.getLatestActiveConversation(patient, user);
+		return closeAndCreate(patient, user, providerId, modeName, current);
+	}
+
+	private ClinicalConversation closeAndCreate(Patient patient, User user, String providerId,
+			String modeName, ClinicalConversation current) {
 		Date now = new Date();
 		if (current != null) {
 			current.setStatus(ClinicalConversation.STATUS_CLOSED);

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.openmrs.Patient;
@@ -185,11 +186,30 @@ public class ConversationServiceImpl implements ConversationService {
 	}
 
 	@Override
+	public boolean recordCheckedAnswer(ClinicalConversationTurn turn, AnswerEnvelope answer) {
+		require(turn != null && turn.getConversation() != null, "turn and conversation are required");
+		require(answer != null, "answer is required");
+		if (turn.getTerminalState() != null || !isChecked(answer)) {
+			return false;
+		}
+
+		turn.setAnswerText(answer.getText());
+		turn.setProviderPayload(serialize(answer.getPayload()));
+		turn.setPayloadMediaType(ClinicalConversationTurn.MEDIA_TYPE_JSON);
+		Date now = new Date();
+		turn.getConversation().setLastActivityAt(now);
+		conversationDAO.saveConversation(turn.getConversation());
+		conversationDAO.saveTurn(turn);
+		return true;
+	}
+
+	@Override
 	public List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation) {
 		List<PriorClinicalTurn> prior = new ArrayList<>();
 		for (ClinicalConversationTurn turn : conversationDAO.getTurns(conversation)) {
-			if (TurnEventType.TURN_DONE.getWireName().equals(turn.getTerminalState())
-					&& turn.getAnswerText() != null) {
+			boolean completedAnswer = TurnEventType.TURN_DONE.getWireName().equals(turn.getTerminalState());
+			boolean checkedAnswerStillRunning = turn.getTerminalState() == null && isStoredChecked(turn);
+			if ((completedAnswer || checkedAnswerStillRunning) && turn.getAnswerText() != null) {
 				prior.add(new PriorClinicalTurn(turn.getQuestion(), turn.getAnswerText()));
 			}
 		}
@@ -232,6 +252,29 @@ public class ConversationServiceImpl implements ConversationService {
 		}
 		Object value = answer.getPayload().get(field);
 		return value instanceof Number ? ((Number) value).intValue() : null;
+	}
+
+	private static boolean isChecked(AnswerEnvelope answer) {
+		Object validation = answer.getPayload().get("answerValidation");
+		if (!(validation instanceof Map)) {
+			return false;
+		}
+		Object status = ((Map<?, ?>) validation).get("status");
+		return "checked".equals(status) || "edited".equals(status);
+	}
+
+	private static boolean isStoredChecked(ClinicalConversationTurn turn) {
+		if (turn.getProviderPayload() == null) {
+			return false;
+		}
+		try {
+			JsonNode status = MAPPER.readTree(turn.getProviderPayload()).path("answerValidation")
+					.path("status");
+			return "checked".equals(status.asText()) || "edited".equals(status.asText());
+		}
+		catch (IOException ignored) {
+			return false;
+		}
 	}
 
 	private static String serialize(Map<String, Object> payload) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/conversation/impl/ConversationServiceImpl.java
@@ -1,0 +1,227 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.conversation.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.openmrs.Patient;
+import org.openmrs.User;
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.api.conversation.ConversationDAO;
+import org.openmrs.module.chartsearchai.api.conversation.ConversationService;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+import org.openmrs.module.chartsearchai.api.db.ChartSearchAiDAO;
+import org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope;
+import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
+import org.openmrs.module.chartsearchai.api.provider.TurnEventType;
+import org.openmrs.module.chartsearchai.api.provider.TurnResult;
+import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Transactional owner of provider-neutral conversation history and audit attribution. Provider
+ * payloads are serialized as complete opaque envelopes; only canonical answer text, references
+ * count, and token accounting are read for shared display/audit fields.
+ */
+@Service("chartSearchAi.conversationService")
+@Transactional
+public class ConversationServiceImpl implements ConversationService {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@Autowired
+	private ConversationDAO conversationDAO;
+
+	@Autowired
+	private ChartSearchAiDAO auditDAO;
+
+	@Override
+	public ClinicalConversation openOrCreate(Patient patient, String providerId, ProviderMode mode) {
+		require(patient != null, "patient is required");
+		require(providerId != null && !providerId.trim().isEmpty(), "providerId is required");
+		User user = Context.getAuthenticatedUser();
+		require(user != null, "an authenticated user is required");
+
+		String modeName = mode == null ? null : mode.getWireName();
+		ClinicalConversation current = conversationDAO.getLatestActiveConversation(patient, user);
+		if (current != null && providerId.equals(current.getProviderId())
+				&& Objects.equals(modeName, current.getProviderMode())) {
+			return current;
+		}
+		Date now = new Date();
+		if (current != null) {
+			current.setStatus(ClinicalConversation.STATUS_CLOSED);
+			current.setEndedAt(now);
+			conversationDAO.saveConversation(current);
+		}
+
+		ClinicalConversation conversation = new ClinicalConversation();
+		conversation.setPatient(patient);
+		conversation.setUser(user);
+		conversation.setProviderId(providerId);
+		conversation.setProviderMode(modeName);
+		conversation.setStartedAt(now);
+		conversation.setLastActivityAt(now);
+		conversation.setStatus(ClinicalConversation.STATUS_ACTIVE);
+		return conversationDAO.saveConversation(conversation);
+	}
+
+	@Override
+	public ClinicalConversation getByUuid(String uuid) {
+		if (uuid == null || uuid.trim().isEmpty()) {
+			return null;
+		}
+		ClinicalConversation conversation = conversationDAO.getConversationByUuid(uuid.trim());
+		User user = Context.getAuthenticatedUser();
+		return conversation != null && user != null && user.equals(conversation.getUser())
+				? conversation : null;
+	}
+
+	@Override
+	public List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation) {
+		return conversationDAO.getTurns(conversation);
+	}
+
+	@Override
+	public ClinicalConversationTurn startTurn(ClinicalConversation conversation, String requestId,
+			String question) {
+		require(conversation != null, "conversation is required");
+		require(ClinicalConversation.STATUS_ACTIVE.equals(conversation.getStatus()),
+				"conversation is not active");
+		require(requestId != null && !requestId.trim().isEmpty(), "requestId is required");
+		require(question != null && !question.trim().isEmpty(), "question is required");
+
+		Date now = new Date();
+		ClinicalConversationTurn turn = new ClinicalConversationTurn();
+		turn.setConversation(conversation);
+		turn.setOrdinal(conversationDAO.getLastOrdinal(conversation) + 1);
+		turn.setRequestId(requestId);
+		turn.setQuestion(question);
+		turn.setStartedAt(now);
+		conversation.setLastActivityAt(now);
+		conversationDAO.saveConversation(conversation);
+		return conversationDAO.saveTurn(turn);
+	}
+
+	@Override
+	public ClinicalConversationTurn finishTurn(ClinicalConversationTurn turn, TurnResult result,
+			long responseTimeMs) {
+		require(turn != null && turn.getConversation() != null, "turn and conversation are required");
+		require(result != null, "turn result is required");
+		ClinicalConversation conversation = turn.getConversation();
+		require(conversation.getProviderId().equals(result.getProviderId()),
+				"turn provider does not match its conversation");
+		String resultMode = result.getMode() == null ? null : result.getMode().getWireName();
+		require(Objects.equals(conversation.getProviderMode(), resultMode),
+				"turn mode does not match its conversation");
+		require(result.getTerminalState() == TurnEventType.TURN_DONE
+				|| result.getTerminalState() == TurnEventType.TURN_ERROR,
+				"turn result must be terminal");
+
+		Date now = new Date();
+		turn.setTerminalState(result.getTerminalState().getWireName());
+		turn.setProblemCode(result.getProblemCode());
+		turn.setCompletedAt(now);
+
+		AnswerEnvelope answer = result.getAnswer();
+		if (result.getTerminalState() == TurnEventType.TURN_DONE) {
+			require(answer != null, "turn_done requires an answer");
+			turn.setAnswerText(answer.getText());
+			turn.setProviderPayload(serialize(answer.getPayload()));
+			turn.setPayloadMediaType(ClinicalConversationTurn.MEDIA_TYPE_JSON);
+		} else {
+			require(answer == null, "turn_error cannot carry a final answer");
+		}
+
+		ChartSearchAuditLog audit = buildAudit(turn, result, responseTimeMs, now);
+		auditDAO.saveAuditLog(audit);
+		turn.setAuditLog(audit);
+		conversation.setLastActivityAt(now);
+		conversationDAO.saveConversation(conversation);
+		return conversationDAO.saveTurn(turn);
+	}
+
+	@Override
+	public List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation) {
+		List<PriorClinicalTurn> prior = new ArrayList<>();
+		for (ClinicalConversationTurn turn : conversationDAO.getTurns(conversation)) {
+			if (TurnEventType.TURN_DONE.getWireName().equals(turn.getTerminalState())
+					&& turn.getAnswerText() != null) {
+				prior.add(new PriorClinicalTurn(turn.getQuestion(), turn.getAnswerText()));
+			}
+		}
+		return prior;
+	}
+
+	private ChartSearchAuditLog buildAudit(ClinicalConversationTurn turn, TurnResult result,
+			long responseTimeMs, Date now) {
+		ClinicalConversation conversation = turn.getConversation();
+		ChartSearchAuditLog audit = new ChartSearchAuditLog();
+		audit.setUser(conversation.getUser());
+		audit.setPatient(conversation.getPatient());
+		audit.setQuestion(turn.getQuestion());
+		audit.setAnswer(result.getAnswer() == null ? "" : result.getAnswer().getText());
+		audit.setReferenceCount(referenceCount(result.getAnswer()));
+		audit.setSearchMode(conversation.getProviderMode() == null
+				? conversation.getProviderId() : conversation.getProviderMode());
+		audit.setResponseTimeMs(responseTimeMs);
+		audit.setInputTokens(number(result.getAnswer(), "inputTokens"));
+		audit.setOutputTokens(number(result.getAnswer(), "outputTokens"));
+		audit.setProviderId(conversation.getProviderId());
+		audit.setProviderMode(conversation.getProviderMode());
+		audit.setConversationUuid(conversation.getUuid());
+		audit.setRequestId(turn.getRequestId());
+		audit.setDateCreated(now);
+		return audit;
+	}
+
+	private static int referenceCount(AnswerEnvelope answer) {
+		if (answer == null) {
+			return 0;
+		}
+		Object references = answer.getPayload().get("references");
+		return references instanceof List ? ((List<?>) references).size() : 0;
+	}
+
+	private static Integer number(AnswerEnvelope answer, String field) {
+		if (answer == null) {
+			return null;
+		}
+		Object value = answer.getPayload().get(field);
+		return value instanceof Number ? ((Number) value).intValue() : null;
+	}
+
+	private static String serialize(Map<String, Object> payload) {
+		try {
+			return MAPPER.writeValueAsString(payload);
+		}
+		catch (IOException e) {
+			throw new APIException("Could not serialize provider answer payload", e);
+		}
+	}
+
+	private static void require(boolean condition, String message) {
+		if (!condition) {
+			throw new IllegalArgumentException(message);
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/db/hibernate/HibernateChartSearchAiDAO.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/db/hibernate/HibernateChartSearchAiDAO.java
@@ -68,6 +68,21 @@ public class HibernateChartSearchAiDAO implements ChartSearchAiDAO {
 
 	@Override
 	public int deleteAuditLogsBefore(Date before) {
+		// Conversation turns may outlive their audit rows. Null the FK by id first so purge works
+		// even when the database FK was created without ON DELETE SET NULL (e.g. Hibernate-managed
+		// test schemas). Liquibase still declares ON DELETE SET NULL for production DDL.
+		@SuppressWarnings("unchecked")
+		List<Integer> expiredAuditIds = sessionFactory.getCurrentSession()
+				.createQuery("select auditLogId from ChartSearchAuditLog where dateCreated < :before")
+				.setParameter("before", before)
+				.list();
+		if (!expiredAuditIds.isEmpty()) {
+			sessionFactory.getCurrentSession()
+					.createQuery("update ClinicalConversationTurn set auditLog = null "
+							+ "where auditLog.auditLogId in (:ids)")
+					.setParameterList("ids", expiredAuditIds)
+					.executeUpdate();
+		}
 		return sessionFactory.getCurrentSession()
 				.createQuery("delete from ChartSearchAuditLog where dateCreated < :before")
 				.setParameter("before", before)

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/HubProfileService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/HubProfileService.java
@@ -1,0 +1,93 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.openmrs.api.APIException;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.springframework.stereotype.Component;
+
+/** Relays med-agent-hub's authoritative product-profile metadata without reshaping it. */
+@Component("chartSearchAi.hubProfileService")
+public class HubProfileService {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private final HttpClient httpClient = HttpClient.newBuilder()
+			.connectTimeout(Duration.ofSeconds(5))
+			.version(HttpClient.Version.HTTP_1_1)
+			.build();
+
+	public Map<String, Object> listProfiles() {
+		String endpoint = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_HUB_ENDPOINT_URL);
+		if (endpoint == null || endpoint.trim().isEmpty()) {
+			throw new APIException("Cannot list profiles: "
+					+ ChartSearchAiConstants.GP_HUB_ENDPOINT_URL + " is not set.");
+		}
+		HttpRequest.Builder request = HttpRequest.newBuilder()
+				.uri(modelsUri(endpoint))
+				.timeout(Duration.ofSeconds(10))
+				.GET();
+		String apiKey = runtimeApiKey();
+		if (apiKey != null && !apiKey.trim().isEmpty()) {
+			request.header("Authorization", "Bearer " + apiKey.trim());
+		}
+		try {
+			HttpResponse<String> response = httpClient.send(
+					request.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+			if (response.statusCode() < 200 || response.statusCode() >= 300) {
+				throw new APIException("Hub profile discovery failed: HTTP " + response.statusCode());
+			}
+			Map<String, Object> payload = MAPPER.readValue(
+					response.body(), new TypeReference<Map<String, Object>>() {});
+			if (!(payload.get("data") instanceof List)) {
+				throw new APIException("Hub profile discovery returned no data list.");
+			}
+			return payload;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new APIException("Hub profile discovery was interrupted.", e);
+		}
+		catch (IOException | IllegalArgumentException e) {
+			throw new APIException("Hub profile discovery failed: " + e.getMessage(), e);
+		}
+	}
+
+	static URI modelsUri(String chatEndpoint) {
+		String normalized = chatEndpoint == null ? "" : chatEndpoint.trim();
+		if (!normalized.endsWith("/v1/chat/completions")) {
+			throw new IllegalArgumentException(
+					"Hub endpoint must end with /v1/chat/completions.");
+		}
+		return URI.create(normalized.substring(
+				0, normalized.length() - "/v1/chat/completions".length()) + "/v1/models");
+	}
+
+	private String runtimeApiKey() {
+		Properties properties = Context.getRuntimeProperties();
+		return properties == null ? null : properties.getProperty(ChartSearchAiConstants.RP_HUB_API_KEY);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -27,7 +27,6 @@ import org.openmrs.module.chartsearchai.api.ChartSearchService;
 import org.openmrs.module.chartsearchai.api.impl.LlmProvider.LlmResponse;
 import org.openmrs.module.chartsearchai.reference.DrugReferenceInjector;
 import org.openmrs.module.chartsearchai.reference.DrugSafetyValidator;
-import org.openmrs.module.chartsearchai.reference.SafetyWarning;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
 import org.slf4j.Logger;
@@ -131,10 +130,11 @@ public class LlmInferenceService implements ChartSearchService {
 					extractCitedReferences(response.getAnswer(), response.getCitations(),
 							chart.getMappings()),
 					chart.getMappings());
-			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(response.getAnswer(), question, patient);
+			DrugSafetyValidator.SafetyCheckResult safetyResult =
+					drugSafetyValidator.validateWithStatus(response.getAnswer(), question, patient);
 			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
 					response.getInputTokens(), response.getOutputTokens(),
-					response.getCachedTokens(), safetyWarnings);
+					response.getCachedTokens(), safetyResult.getWarnings(), safetyResult.getStatus());
 			outcome = "ok";
 			return answer;
 		}
@@ -410,10 +410,11 @@ public class LlmInferenceService implements ChartSearchService {
 					chart.getMappings());
 			groundMs = System.currentTimeMillis() - groundStart;
 
-			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(response.getAnswer(), question, patient);
+			DrugSafetyValidator.SafetyCheckResult safetyResult =
+					drugSafetyValidator.validateWithStatus(response.getAnswer(), question, patient);
 			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
 					response.getInputTokens(), response.getOutputTokens(),
-					response.getCachedTokens(), safetyWarnings);
+					response.getCachedTokens(), safetyResult.getWarnings(), safetyResult.getStatus());
 			outcome = "ok";
 			return answer;
 		}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmResponseParser.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmResponseParser.java
@@ -55,6 +55,29 @@ final class LlmResponseParser {
 		return responseBody != null && responseBody.contains("exceed_context_size_error");
 	}
 
+	/**
+	 * Parses llama-server's {@code /tokenize} response ({@code {"tokens": [...]}} by default, or
+	 * {@code {"tokens": N}} / {@code {"n_tokens": N}} when a caller requests the summary form)
+	 * into a token count.
+	 *
+	 * @throws IOException when the body is not valid JSON or carries neither shape
+	 */
+	static int parseTokenizeResponse(String responseBody) throws IOException {
+		JsonNode root = MAPPER.readTree(responseBody);
+		JsonNode tokens = root.get("tokens");
+		if (tokens != null && tokens.isArray()) {
+			return tokens.size();
+		}
+		if (tokens != null && tokens.isInt()) {
+			return tokens.asInt();
+		}
+		JsonNode nTokens = root.get("n_tokens");
+		if (nTokens != null && nTokens.isInt()) {
+			return nTokens.asInt();
+		}
+		throw new IOException("Tokenize response had no 'tokens' array or count: " + responseBody);
+	}
+
 	static InferenceResult parseResponse(String responseBody, Logger callerLog) throws IOException {
 		JsonNode root = MAPPER.readTree(responseBody);
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlamaTokenCounter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlamaTokenCounter.java
@@ -1,0 +1,53 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link TokenCounter} for {@link LocalLlmEngine}, available exactly when
+ * {@code chartsearchai.llm.engine} resolves to local (the same default {@link LlmProvider} uses).
+ * A remote engine has no assumed {@code /tokenize} route — an arbitrary OpenAI-compatible
+ * endpoint (vLLM, Ollama, a cloud provider) is not guaranteed to expose one — so
+ * {@link #isAvailable()} is false in that case and callers must skip proactive budget
+ * enforcement rather than approximate.
+ */
+@Component("chartSearchAi.localLlamaTokenCounter")
+public class LocalLlamaTokenCounter implements TokenCounter {
+
+	@Autowired
+	private LocalLlmEngine localLlmEngine;
+
+	/** Test seam: production wires {@link LocalLlmEngine} via {@link Autowired}. */
+	void setLocalLlmEngine(LocalLlmEngine localLlmEngine) {
+		this.localLlmEngine = localLlmEngine;
+	}
+
+	@Override
+	public boolean isAvailable() {
+		String engineType = Context.getAdministrationService()
+				.getGlobalProperty(ChartSearchAiConstants.GP_LLM_ENGINE);
+		return engineType == null
+				|| !ChartSearchAiConstants.LLM_ENGINE_REMOTE.equalsIgnoreCase(engineType.trim());
+	}
+
+	@Override
+	public int count(String text) {
+		return localLlmEngine.countTokens(text);
+	}
+
+	@Override
+	public int inputBudget() {
+		return localLlmEngine.getContextSize() - ChartSearchAiConstants.DEFAULT_LLM_MAX_OUTPUT_TOKENS;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngine.java
@@ -195,6 +195,44 @@ public class LocalLlmEngine implements LlmEngine {
 		}
 	}
 
+	/**
+	 * Exact token count for {@code text} from this engine's own llama-server, via its
+	 * {@code /tokenize} endpoint (llama.cpp server API) — mirrors med-agent-hub's
+	 * {@code RouterTokenCounter.count()}, which likewise delegates counting to the real engine
+	 * rather than approximating in the application layer. Starts the server first if it is not
+	 * already running: a token-budget check only ever precedes a generation call that would need
+	 * the server running anyway, so this adds no new cold-start cost.
+	 */
+	synchronized int countTokens(String text) {
+		ensureServerRunning();
+		ObjectNode body = MAPPER.createObjectNode();
+		body.put("content", text == null ? "" : text);
+		body.put("add_special", false);
+		try {
+			HttpRequest request = HttpRequest.newBuilder()
+					.uri(URI.create("http://127.0.0.1:" + serverPort + "/tokenize"))
+					.timeout(Duration.ofSeconds(30))
+					.header("Content-Type", "application/json")
+					.POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body),
+							StandardCharsets.UTF_8))
+					.build();
+			HttpResponse<String> response = getHttpClient().send(request,
+					HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+			if (response.statusCode() < 200 || response.statusCode() >= 300) {
+				throw new APIException(
+						"Local llama-server /tokenize returned HTTP " + response.statusCode());
+			}
+			return LlmResponseParser.parseTokenizeResponse(response.body());
+		}
+		catch (IOException e) {
+			throw new APIException("Failed to call local llama-server /tokenize: " + e.getMessage(), e);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new APIException("Local llama-server /tokenize call was interrupted", e);
+		}
+	}
+
 	@Override
 	public synchronized InferenceResult inferStreaming(String systemPrompt, String userMessage,
 			int timeoutSeconds, Consumer<String> tokenConsumer) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
@@ -200,49 +200,38 @@ class QueryStoreChartBuilder {
 	PatientChart buildScoped(Patient patient, String question) {
 		long buildStart = System.currentTimeMillis();
 		if (patient == null || patient.getUuid() == null) {
-			log.info("[timing] querystoreScopedBuild patient={} intent=unknown chartDocs=0 simHits=0 slice=0 rpcMs=0 serializeMs=0 totalMs={} outcome=skipped",
+			log.info("[timing] querystoreScopedBuild patient={} types=unresolved chartDocs=0 simHits=0 slice=0 rpcMs=0 serializeMs=0 totalMs={} outcome=skipped",
 					patient == null ? null : patient.getPatientId(), System.currentTimeMillis() - buildStart);
 			return markScoped(emptyChart(patient));
 		}
 
-		// Every matched intent contributes its types (union): completeness must hold for
-		// whichever intent a multi-cue question ("any drug allergies?") actually meant.
-		Set<QueryScopeRouter.Intent> intents = QueryScopeRouter.matchedIntents(question);
-		// The built-in typed scope, additionally UNIONed with any module-contributed scopes
-		// (billing, appointments, …). typedSlice(...) is unmodifiable, so wrap it before adding.
-		// The union is additive: with zero contributors this is exactly the built-in behaviour, and
-		// a contributor can only add its own domain's records — never perturb another domain's
-		// routing. See QueryScopeContributor.
-		Set<String> typedScope = new HashSet<String>(QueryScopeRouter.typedSlice(intents));
-		typedScope.addAll(contributedResourceTypes(question));
-		String intentLabel = intentLabel(intents);
-
 		QueryStoreService queryStore = resolveQueryStoreOrNull();
 		if (queryStore == null) {
 			log.warn(QUERYSTORE_UNAVAILABLE_MSG);
-			log.info("[timing] querystoreScopedBuild patient={} intent={} chartDocs=0 simHits=0 slice=0 rpcMs=0 serializeMs=0 totalMs={} outcome=unavailable",
-					patient.getPatientId(), intentLabel, System.currentTimeMillis() - buildStart);
+			log.info("[timing] querystoreScopedBuild patient={} types=unresolved chartDocs=0 simHits=0 slice=0 rpcMs=0 serializeMs=0 totalMs={} outcome=unavailable",
+					patient.getPatientId(), System.currentTimeMillis() - buildStart);
 			return markScoped(emptyChart(patient));
 		}
 
-		// The caller's question interpretation rides the request; selection is querystore's.
-		// Lab-panel abbreviations are expanded before the similarity leg ("BMP" → "+ basic
-		// metabolic panel") so the retrieval text carries the full concept name querystore indexed.
-		ContextSliceRequest request = new ContextSliceRequest(typedScope, QueryScopeRouter.isTemporal(question));
+		// Question interpretation and retrieval preprocessing are querystore's now (its ADR
+		// Decision 18): the RAW question goes over with interpretQuestion set, so the typed
+		// scope, the temporal gate, panel expansion, and stopword stripping run once, at the
+		// data owner, identically for every consumer. This builder contributes only what is
+		// genuinely its own: module-contributed scopes (QueryScopeContributor SPI, unioned
+		// server-side with the derived types) and its recency-anchor deployment knob.
+		ContextSliceRequest request = new ContextSliceRequest(contributedResourceTypes(question), false);
+		request.setInterpretQuestion(true);
 		request.setRecencyAnchorSize(resolveScopedRecencyAnchor());
-		request.setSimilarityLimit(resolveQueryStoreTopK());
-		String preprocessed = question == null ? null
-				: QueryPreprocessor.stripQueryStopwords(QueryPreprocessor.expandLabPanelAbbreviations(question));
 
 		long rpcStart = System.currentTimeMillis();
 		ContextSlice slice;
 		try {
-			slice = queryStore.getContextSlice(patient.getUuid(), preprocessed, request);
+			slice = queryStore.getContextSlice(patient.getUuid(), question, request);
 		}
 		catch (RuntimeException e) {
 			log.error("QueryStore.getContextSlice failed for patient [uuid={}]", patient.getUuid(), e);
-			log.info("[timing] querystoreScopedBuild patient={} intent={} chartDocs=0 simHits=0 slice=0 rpcMs={} serializeMs=0 totalMs={} outcome=error errorClass={}",
-					patient.getPatientId(), intentLabel, System.currentTimeMillis() - rpcStart,
+			log.info("[timing] querystoreScopedBuild patient={} types=unresolved chartDocs=0 simHits=0 slice=0 rpcMs={} serializeMs=0 totalMs={} outcome=error errorClass={}",
+					patient.getPatientId(), System.currentTimeMillis() - rpcStart,
 					System.currentTimeMillis() - buildStart, e.getClass().getSimpleName());
 			return markScoped(emptyChart(patient));
 		}
@@ -270,8 +259,9 @@ class QueryStoreChartBuilder {
 		PatientChart chart = chartSerializer.serialize(patient, records,
 				Collections.<String>emptySet(), false, false);
 		long serializeMs = System.currentTimeMillis() - serializeStart;
-		log.info("[timing] querystoreScopedBuild patient={} intent={} chartDocs={} simHits={} slice={} rpcMs={} serializeMs={} totalMs={} outcome=ok",
-				patient.getPatientId(), intentLabel, slice.getChartSize(), simHits, records.size(),
+		log.info("[timing] querystoreScopedBuild patient={} types={} temporal={} chartDocs={} simHits={} slice={} rpcMs={} serializeMs={} totalMs={} outcome=ok",
+				patient.getPatientId(), typesLabel(slice.getEffectiveTypes()), slice.isTemporalApplied(),
+				slice.getChartSize(), simHits, records.size(),
 				rpcMs, serializeMs, System.currentTimeMillis() - buildStart);
 		return markScoped(chart);
 	}
@@ -285,21 +275,16 @@ class QueryStoreChartBuilder {
 	}
 
 
-	/** The [timing] log label for the slice's matched intents: {@code TOPICAL} when none matched,
-	 *  else the names joined with {@code +} in declaration order (e.g.
-	 *  {@code MEDICATIONS+ALLERGIES}) — one greppable token per line either way. */
-	private static String intentLabel(Set<QueryScopeRouter.Intent> intents) {
-		if (intents.isEmpty()) {
-			return QueryScopeRouter.Intent.TOPICAL.name();
+	/** The [timing] log label for the slice's effective typed scope (querystore's derived
+	 *  interpretation unioned with contributed types): {@code TOPICAL} when empty, else the
+	 *  sorted types joined with {@code +} — one greppable token per line either way. */
+	private static String typesLabel(Set<String> effectiveTypes) {
+		if (effectiveTypes == null || effectiveTypes.isEmpty()) {
+			return "TOPICAL";
 		}
-		StringBuilder label = new StringBuilder();
-		for (QueryScopeRouter.Intent intent : intents) {
-			if (label.length() > 0) {
-				label.append('+');
-			}
-			label.append(intent.name());
-		}
-		return label.toString();
+		List<String> sorted = new ArrayList<String>(effectiveTypes);
+		Collections.sort(sorted);
+		return String.join("+", sorted);
 	}
 
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
@@ -27,6 +27,9 @@ import org.openmrs.module.chartsearchai.serializer.SerializedRecord;
 import org.openmrs.module.chartsearchai.util.DateFormatUtil;
 import org.openmrs.module.querystore.QueryStoreConstants;
 import org.openmrs.module.querystore.api.QueryStoreService;
+import org.openmrs.module.querystore.model.ContextSlice;
+import org.openmrs.module.querystore.model.ContextSliceRecord;
+import org.openmrs.module.querystore.model.ContextSliceRequest;
 import org.openmrs.module.querystore.model.QueryDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,24 +177,25 @@ class QueryStoreChartBuilder {
 	}
 
 	/**
-	 * Builds the query-scoped slice chart for {@code chartsearchai.chartMode=queryScoped}: every
-	 * record of the question's typed scope (complete by construction — see {@link QueryScopeRouter}),
-	 * unioned with the querystore similarity top-K (the semantic catch-all), the mandatory clinical
-	 * core (allergies + active conditions — see {@link #isMandatoryClinicalCore}), plus the
-	 * demographics {@code patient} record — all in the CHART's most-recent-first order, never the
-	 * similarity ranking's, because the system prompt asserts "sorted most recent first". The slice
-	 * renders no focus hint: the slice IS the scope. A similarity failure degrades to the typed
-	 * slice alone; a null patient degrades to an empty chart, exactly like {@link #build}.
+	 * Builds the query-scoped slice chart for {@code chartsearchai.chartMode=queryScoped} as a
+	 * THIN ADAPTER over querystore's shared context-selection contract (querystore ADR
+	 * Decision 17): this builder interprets the question — intent-typed scope (see
+	 * {@link QueryScopeRouter}), module-contributed types, temporal phrasing, stopword/lab-panel
+	 * preprocessing — and {@code QueryStoreService.getContextSlice} performs the selection
+	 * (mandatory clinical core, temporal recency anchor, typed-complete types, similarity union,
+	 * obs-group panel completion) exactly once for every consumer. Records come back in the
+	 * CHART's most-recent-first order, which the system prompt asserts. The slice renders no
+	 * focus hint: the slice IS the scope. A selection failure degrades to an empty chart; a null
+	 * patient degrades to an empty chart, exactly like {@link #build}.
 	 *
 	 * <p>The slice is question-dependent, so callers must not attach a KV-cache scope to it (see
 	 * {@code LlmInferenceService.kvCacheScopeFor}); its latency contract is the opposite of
 	 * {@link #build}'s — a small fresh prefill every query instead of a big amortized one.
 	 *
-	 * <p>Completeness caveat: querystore's Elasticsearch tier caps {@code getPatientChart} at its
-	 * 10&nbsp;000 most recent documents (silently dropping the older tail). fullChart mode fails
-	 * loud on such patients ({@code ChartTooLargeException} — the chart overflows the context
-	 * window long before 10&nbsp;000 docs); a scoped slice keeps working, so a typed enumeration
-	 * could silently omit pre-cutoff records. WARNed below when the fetch lands on the cap.
+	 * <p>Completeness caveat: querystore's Elasticsearch tier caps the underlying chart at its
+	 * 10&nbsp;000 most recent documents. fullChart mode fails loud on such patients
+	 * ({@code ChartTooLargeException}); a scoped slice keeps working, so the slice contract
+	 * surfaces the cap explicitly ({@code ContextSlice.isChartTruncated}) and it is WARNed below.
 	 */
 	PatientChart buildScoped(Patient patient, String question) {
 		long buildStart = System.currentTimeMillis();
@@ -221,70 +225,43 @@ class QueryStoreChartBuilder {
 			return markScoped(emptyChart(patient));
 		}
 
+		// The caller's question interpretation rides the request; selection is querystore's.
+		// Lab-panel abbreviations are expanded before the similarity leg ("BMP" → "+ basic
+		// metabolic panel") so the retrieval text carries the full concept name querystore indexed.
+		ContextSliceRequest request = new ContextSliceRequest(typedScope, QueryScopeRouter.isTemporal(question));
+		request.setRecencyAnchorSize(resolveScopedRecencyAnchor());
+		request.setSimilarityLimit(resolveQueryStoreTopK());
+		String preprocessed = question == null ? null
+				: QueryPreprocessor.stripQueryStopwords(QueryPreprocessor.expandLabPanelAbbreviations(question));
+
 		long rpcStart = System.currentTimeMillis();
-		List<QueryDocument> chartDocs;
+		ContextSlice slice;
 		try {
-			chartDocs = queryStore.getPatientChart(patient.getUuid());
+			slice = queryStore.getContextSlice(patient.getUuid(), preprocessed, request);
 		}
 		catch (RuntimeException e) {
-			log.error(GET_PATIENT_CHART_FAILED_MSG, patient.getUuid(), e);
+			log.error("QueryStore.getContextSlice failed for patient [uuid={}]", patient.getUuid(), e);
 			log.info("[timing] querystoreScopedBuild patient={} intent={} chartDocs=0 simHits=0 slice=0 rpcMs={} serializeMs=0 totalMs={} outcome=error errorClass={}",
 					patient.getPatientId(), intentLabel, System.currentTimeMillis() - rpcStart,
 					System.currentTimeMillis() - buildStart, e.getClass().getSimpleName());
 			return markScoped(emptyChart(patient));
 		}
-
-		// querystore's ES tier returns at most its 10 000 most recent docs (older tail silently
-		// dropped) — at the cap, "complete by construction" typed slices may be missing
-		// pre-cutoff records, and unlike fullChart (which fails loud on context overflow) the
-		// slice keeps working. Surface it for operators.
-		if (chartDocs.size() >= QUERYSTORE_ES_CHART_CAP) {
-			log.warn("getPatientChart returned {} docs for patient [uuid={}] — at querystore's ES "
-					+ "tier cap; typed slices may silently omit records older than the cutoff.",
-					chartDocs.size(), patient.getUuid());
-		}
-
-		// Similarity top-K uuids — the semantic catch-all beyond the typed scope. Lab-panel
-		// abbreviations are expanded first ("BMP" → "+ basic metabolic panel") so the retrieval
-		// text carries the full concept name querystore indexed. Failure degrades to the typed
-		// slice alone (never blocks the answer), mirroring build()'s focus-hint contract.
-		Set<String> similarityUuids = Collections.<String>emptySet();
-		if (question != null && !question.trim().isEmpty()) {
-			similarityUuids = searchSimilarityUuids(queryStore, patient,
-					QueryPreprocessor.stripQueryStopwords(
-							QueryPreprocessor.expandLabPanelAbbreviations(question)),
-					"QueryStore.searchByPatient failed for scoped build [uuid={}] — proceeding with the typed slice only");
-		}
 		long rpcMs = System.currentTimeMillis() - rpcStart;
 
-		// Filter the chart (already most-recent-first) down to the slice, preserving its order.
-		// TEMPORAL questions additionally carry the recency anchor — the first N chart records:
-		// similarity ranks by meaning, not date, so without it "most recent X" can lose the newest
-		// reading to older, better-matching records (measured: a stale systolic quoted). The anchor
-		// is gated purely on temporal phrasing (QueryScopeRouter.isTemporal), independent of typed
-		// scope; non-temporal questions get none, which is what keeps an absent-topic slice from
-		// baiting enumeration.
-		int recencyAnchor = QueryScopeRouter.isTemporal(question) ? resolveScopedRecencyAnchor() : 0;
-		List<QueryDocument> sliceDocs = new ArrayList<QueryDocument>();
-		Set<String> sliceUuids = new HashSet<String>();
-		for (int i = 0; i < chartDocs.size(); i++) {
-			QueryDocument doc = chartDocs.get(i);
-			if (doc == null) {
-				continue;
-			}
-			boolean isAnchor = i < recencyAnchor;
-			boolean isPatientRecord = PATIENT_RESOURCE_TYPE.equals(doc.getResourceType());
-			boolean isMandatoryCore = isMandatoryClinicalCore(doc);
-			boolean inTypedScope = doc.getResourceType() != null && typedScope.contains(doc.getResourceType());
-			boolean isSimilarityHit = doc.getResourceUuid() != null && similarityUuids.contains(doc.getResourceUuid());
-			if (isAnchor || isPatientRecord || isMandatoryCore || inTypedScope || isSimilarityHit) {
-				sliceDocs.add(doc);
-				if (doc.getResourceUuid() != null) {
-					sliceUuids.add(doc.getResourceUuid());
-				}
+		if (slice.isChartTruncated()) {
+			log.warn("Context slice for patient [uuid={}] was built on a chart at querystore's ES "
+					+ "tier cap ({} docs) — typed slices may silently omit records older than the cutoff.",
+					patient.getUuid(), slice.getChartSize());
+		}
+
+		List<QueryDocument> sliceDocs = new ArrayList<QueryDocument>(slice.getRecords().size());
+		int simHits = 0;
+		for (ContextSliceRecord record : slice.getRecords()) {
+			sliceDocs.add(record.getDocument());
+			if (QueryStoreConstants.TIER_SIMILARITY.equals(record.getTier())) {
+				simHits++;
 			}
 		}
-		sliceDocs = completeObsGroupFamilies(chartDocs, sliceDocs, sliceUuids);
 
 		List<SerializedRecord> records = toSerializedRecords(sliceDocs);
 		long serializeStart = System.currentTimeMillis();
@@ -294,7 +271,7 @@ class QueryStoreChartBuilder {
 				Collections.<String>emptySet(), false, false);
 		long serializeMs = System.currentTimeMillis() - serializeStart;
 		log.info("[timing] querystoreScopedBuild patient={} intent={} chartDocs={} simHits={} slice={} rpcMs={} serializeMs={} totalMs={} outcome=ok",
-				patient.getPatientId(), intentLabel, chartDocs.size(), similarityUuids.size(), records.size(),
+				patient.getPatientId(), intentLabel, slice.getChartSize(), simHits, records.size(),
 				rpcMs, serializeMs, System.currentTimeMillis() - buildStart);
 		return markScoped(chart);
 	}
@@ -307,26 +284,6 @@ class QueryStoreChartBuilder {
 		return chart;
 	}
 
-	/**
-	 * Mandatory clinical core: allergies and ACTIVE conditions ride EVERY scoped slice regardless
-	 * of matched intent (conformance fixture {@code context.enumerated-medications-are-complete}
-	 * pins the allergy record as mandatory for a medication question). A medication answer
-	 * composed without the patient's allergy list — measured on the live parity harness — is the
-	 * safety omission this guards against. Active status is read from the serialized text
-	 * ("Status: ACTIVE"), the same signal querystore's condition serializer emits and the hub's
-	 * context policy matches on; inactive/resolved problems stay subject to normal scoping.
-	 */
-	private static boolean isMandatoryClinicalCore(QueryDocument doc) {
-		String type = doc.getResourceType();
-		if ("allergy".equals(type)) {
-			return true;
-		}
-		if ("condition".equals(type) || "diagnosis".equals(type)) {
-			String text = doc.getText();
-			return text != null && text.toLowerCase(java.util.Locale.ROOT).contains("status: active");
-		}
-		return false;
-	}
 
 	/** The [timing] log label for the slice's matched intents: {@code TOPICAL} when none matched,
 	 *  else the names joined with {@code +} in declaration order (e.g.
@@ -345,53 +302,6 @@ class QueryStoreChartBuilder {
 		return label.toString();
 	}
 
-	/**
-	 * Obs-group family completion for the scoped slice: if a panel PARENT (e.g. "Basic metabolic
-	 * panel") or any MEMBER made the slice, the whole family joins it. The panel's VALUES live in
-	 * member obs whose indexed text carries no panel name ("Serum sodium: 146"), so similarity can
-	 * match the parent and miss every value — measured: "results of the last BMP" answered "no
-	 * records" while the panel existed. One level only (obs groups don't nest in this chart).
-	 *
-	 * <p>Returns a REBUILT list scanned from {@code chartDocs} rather than appending the missing
-	 * family members to {@code sliceDocs}: appending would place them after unrelated newer
-	 * records and violate the most-recent-first chart order {@link #buildScoped}'s contract (and
-	 * the system prompt) asserts. Returns {@code sliceDocs} unchanged when no family is touched.
-	 */
-	private List<QueryDocument> completeObsGroupFamilies(List<QueryDocument> chartDocs,
-			List<QueryDocument> sliceDocs, Set<String> sliceUuids) {
-		Set<String> familyGroups = new HashSet<String>();
-		for (QueryDocument doc : chartDocs) {
-			if (doc == null || doc.getResourceUuid() == null) {
-				continue;
-			}
-			String groupUuid = metadataString(doc, QueryStoreConstants.FIELD_OBS_GROUP_UUID);
-			if (groupUuid == null) {
-				continue;
-			}
-			// doc is a MEMBER of groupUuid: the family joins the slice when the member itself is
-			// in it, or when its parent (the group record) is.
-			if (sliceUuids.contains(doc.getResourceUuid()) || sliceUuids.contains(groupUuid)) {
-				familyGroups.add(groupUuid);
-			}
-		}
-		if (familyGroups.isEmpty()) {
-			return sliceDocs;
-		}
-		List<QueryDocument> completed = new ArrayList<QueryDocument>();
-		for (QueryDocument doc : chartDocs) {
-			if (doc == null) {
-				continue;
-			}
-			String uuid = doc.getResourceUuid();
-			String groupUuid = metadataString(doc, QueryStoreConstants.FIELD_OBS_GROUP_UUID);
-			boolean inFamily = (groupUuid != null && familyGroups.contains(groupUuid))
-					|| (uuid != null && familyGroups.contains(uuid));
-			if ((uuid != null && sliceUuids.contains(uuid)) || inFamily) {
-				completed.add(doc);
-			}
-		}
-		return completed;
-	}
 
 	/**
 	 * Builds a focused chart of only the top-K querystore records most relevant to {@code question},
@@ -477,12 +387,6 @@ class QueryStoreChartBuilder {
 	private static final String GET_PATIENT_CHART_FAILED_MSG =
 			"QueryStore.getPatientChart failed for patient [uuid={}]";
 
-	/** querystore's Elasticsearch tier caps {@code getPatientChart} at its most-recent N documents
-	 *  (older tail silently dropped) — mirrors {@code ElasticsearchBackendStore.FULL_CHART_MAX_HITS}
-	 *  in the querystore module. Kept in sync manually: querystore-api exposes no constant for it.
-	 *  A returned size at this value means a scoped typed slice may be missing pre-cutoff records
-	 *  (see {@link #buildScoped}). */
-	private static final int QUERYSTORE_ES_CHART_CAP = 10_000;
 
 	/**
 	 * Runs the similarity search and collects hit uuids, degrading to an empty set on failure with

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
@@ -176,11 +176,12 @@ class QueryStoreChartBuilder {
 	/**
 	 * Builds the query-scoped slice chart for {@code chartsearchai.chartMode=queryScoped}: every
 	 * record of the question's typed scope (complete by construction — see {@link QueryScopeRouter}),
-	 * unioned with the querystore similarity top-K (the semantic catch-all), plus the demographics
-	 * {@code patient} record — all in the CHART's most-recent-first order, never the similarity
-	 * ranking's, because the system prompt asserts "sorted most recent first". The slice renders no
-	 * focus hint: the slice IS the scope. A similarity failure degrades to the typed slice alone; a
-	 * null patient degrades to an empty chart, exactly like {@link #build}.
+	 * unioned with the querystore similarity top-K (the semantic catch-all), the mandatory clinical
+	 * core (allergies + active conditions — see {@link #isMandatoryClinicalCore}), plus the
+	 * demographics {@code patient} record — all in the CHART's most-recent-first order, never the
+	 * similarity ranking's, because the system prompt asserts "sorted most recent first". The slice
+	 * renders no focus hint: the slice IS the scope. A similarity failure degrades to the typed
+	 * slice alone; a null patient degrades to an empty chart, exactly like {@link #build}.
 	 *
 	 * <p>The slice is question-dependent, so callers must not attach a KV-cache scope to it (see
 	 * {@code LlmInferenceService.kvCacheScopeFor}); its latency contract is the opposite of
@@ -273,9 +274,10 @@ class QueryStoreChartBuilder {
 			}
 			boolean isAnchor = i < recencyAnchor;
 			boolean isPatientRecord = PATIENT_RESOURCE_TYPE.equals(doc.getResourceType());
+			boolean isMandatoryCore = isMandatoryClinicalCore(doc);
 			boolean inTypedScope = doc.getResourceType() != null && typedScope.contains(doc.getResourceType());
 			boolean isSimilarityHit = doc.getResourceUuid() != null && similarityUuids.contains(doc.getResourceUuid());
-			if (isAnchor || isPatientRecord || inTypedScope || isSimilarityHit) {
+			if (isAnchor || isPatientRecord || isMandatoryCore || inTypedScope || isSimilarityHit) {
 				sliceDocs.add(doc);
 				if (doc.getResourceUuid() != null) {
 					sliceUuids.add(doc.getResourceUuid());
@@ -303,6 +305,27 @@ class QueryStoreChartBuilder {
 	private static PatientChart markScoped(PatientChart chart) {
 		chart.markQueryScoped();
 		return chart;
+	}
+
+	/**
+	 * Mandatory clinical core: allergies and ACTIVE conditions ride EVERY scoped slice regardless
+	 * of matched intent (conformance fixture {@code context.enumerated-medications-are-complete}
+	 * pins the allergy record as mandatory for a medication question). A medication answer
+	 * composed without the patient's allergy list — measured on the live parity harness — is the
+	 * safety omission this guards against. Active status is read from the serialized text
+	 * ("Status: ACTIVE"), the same signal querystore's condition serializer emits and the hub's
+	 * context policy matches on; inactive/resolved problems stay subject to normal scoping.
+	 */
+	private static boolean isMandatoryClinicalCore(QueryDocument doc) {
+		String type = doc.getResourceType();
+		if ("allergy".equals(type)) {
+			return true;
+		}
+		if ("condition".equals(type) || "diagnosis".equals(type)) {
+			String text = doc.getText();
+			return text != null && text.toLowerCase(java.util.Locale.ROOT).contains("status: active");
+		}
+		return false;
 	}
 
 	/** The [timing] log label for the slice's matched intents: {@code TOPICAL} when none matched,

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilder.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.openmrs.Patient;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.api.InsufficientContextException;
 import org.openmrs.module.chartsearchai.api.scope.QueryScopeContributor;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
@@ -34,6 +35,7 @@ import org.openmrs.module.querystore.model.QueryDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -97,12 +99,21 @@ class QueryStoreChartBuilder {
 	@Autowired
 	private PatientChartSerializer chartSerializer;
 
+	@Autowired(required = false)
+	@Qualifier("chartSearchAi.localLlamaTokenCounter")
+	private TokenCounter tokenCounter;
+
 	/** Test seam: production wires {@link PatientChartSerializer} via {@link Autowired}.
 	 *  Package-private so {@code QueryStoreChartBuilderTest} can inject a real serializer
 	 *  without bringing up Spring; matches the {@code resolveX()} method-override seam
 	 *  pattern used for {@link QueryStoreService} and topK. */
 	void setChartSerializer(PatientChartSerializer chartSerializer) {
 		this.chartSerializer = chartSerializer;
+	}
+
+	/** Test seam: production wires {@link TokenCounter} via {@link Autowired}. */
+	void setTokenCounter(TokenCounter tokenCounter) {
+		this.tokenCounter = tokenCounter;
 	}
 
 	PatientChart build(Patient patient, String question) {
@@ -243,9 +254,11 @@ class QueryStoreChartBuilder {
 					patient.getUuid(), slice.getChartSize());
 		}
 
-		List<QueryDocument> sliceDocs = new ArrayList<QueryDocument>(slice.getRecords().size());
+		List<ContextSliceRecord> budgeted = applyContextBudget(patient, slice.getRecords());
+
+		List<QueryDocument> sliceDocs = new ArrayList<QueryDocument>(budgeted.size());
 		int simHits = 0;
-		for (ContextSliceRecord record : slice.getRecords()) {
+		for (ContextSliceRecord record : budgeted) {
 			sliceDocs.add(record.getDocument());
 			if (QueryStoreConstants.TIER_SIMILARITY.equals(record.getTier())) {
 				simHits++;
@@ -272,6 +285,66 @@ class QueryStoreChartBuilder {
 	private static PatientChart markScoped(PatientChart chart) {
 		chart.markQueryScoped();
 		return chart;
+	}
+
+	/**
+	 * {@code context.mandatory-overflow-abstains}: mandatory clinical evidence (demographics,
+	 * allergies, active conditions) is never droppable (ADR Decision 17), so it either fits the
+	 * model's input budget or the turn abstains — it is never silently trimmed. Mirrors
+	 * med-agent-hub's {@code select_context}: a fast accept when everything fits, otherwise a
+	 * greedy fill of non-mandatory records (kept in chart order, a ceiling never a target) up to
+	 * the budget. Returns {@code records} unchanged when no {@link TokenCounter} is configured or
+	 * available (e.g. a remote engine with no assumed tokenizer route) — this feature can only
+	 * ever tighten behavior, never introduce a new failure mode where none existed.
+	 */
+	private List<ContextSliceRecord> applyContextBudget(Patient patient, List<ContextSliceRecord> records) {
+		TokenCounter counter = tokenCounter;
+		if (counter == null || !counter.isAvailable()) {
+			return records;
+		}
+		int budget = counter.inputBudget();
+
+		List<ContextSliceRecord> mandatory = new ArrayList<ContextSliceRecord>();
+		for (ContextSliceRecord record : records) {
+			if (QueryStoreConstants.TIER_MANDATORY.equals(record.getTier())) {
+				mandatory.add(record);
+			}
+		}
+		int mandatoryTokens = counter.count(renderedTextOf(patient, mandatory));
+		if (mandatoryTokens > budget) {
+			List<String> mandatoryIds = new ArrayList<String>();
+			for (ContextSliceRecord record : mandatory) {
+				mandatoryIds.add(record.getDocument().getResourceUuid());
+			}
+			throw new InsufficientContextException(
+					"Mandatory clinical evidence (" + mandatoryTokens + " tokens) exceeds the "
+							+ budget + "-token model input budget for patient " + patient.getUuid() + ".",
+					mandatoryIds);
+		}
+
+		if (counter.count(renderedTextOf(patient, records)) <= budget) {
+			return records;
+		}
+
+		List<ContextSliceRecord> selected = new ArrayList<ContextSliceRecord>();
+		for (ContextSliceRecord record : records) {
+			List<ContextSliceRecord> candidate = new ArrayList<ContextSliceRecord>(selected);
+			candidate.add(record);
+			if (QueryStoreConstants.TIER_MANDATORY.equals(record.getTier())
+					|| counter.count(renderedTextOf(patient, candidate)) <= budget) {
+				selected = candidate;
+			}
+		}
+		return selected;
+	}
+
+	private String renderedTextOf(Patient patient, List<ContextSliceRecord> records) {
+		List<QueryDocument> docs = new ArrayList<QueryDocument>(records.size());
+		for (ContextSliceRecord record : records) {
+			docs.add(record.getDocument());
+		}
+		return chartSerializer.serialize(patient, toSerializedRecords(docs),
+				Collections.<String>emptySet(), false, false).getText();
 	}
 
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngine.java
@@ -77,10 +77,7 @@ public class RemoteLlmEngine implements LlmEngine {
 			if (response.statusCode() < 200 || response.statusCode() >= 300) {
 				log.error("Remote LLM API returned HTTP {}: {}", response.statusCode(),
 						truncateForLog(response.body()));
-				throw new APIException("Remote LLM API returned HTTP " + response.statusCode()
-						+ ". Check the endpoint URL and model name in the "
-						+ "chartsearchai.llm.remote.* global properties, and the API key "
-						+ "in openmrs-runtime.properties.");
+				throwForErrorResponse(response.statusCode(), response.body());
 			}
 
 			return parseResponse(response.body());
@@ -121,7 +118,7 @@ public class RemoteLlmEngine implements LlmEngine {
 				String body = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
 				log.error("Remote LLM API returned HTTP {}: {}", response.statusCode(),
 						truncateForLog(body));
-				throw new APIException("Remote LLM API returned HTTP " + response.statusCode());
+				throwForErrorResponse(response.statusCode(), body);
 			}
 
 			return parseStreamingResponse(response.body(), tokenConsumer);
@@ -133,6 +130,27 @@ public class RemoteLlmEngine implements LlmEngine {
 			Thread.currentThread().interrupt();
 			throw new APIException("Remote LLM API call was interrupted", e);
 		}
+	}
+
+	/**
+	 * Translates a non-2xx remote response into the honest exception: a llama-server
+	 * context-overflow 400 becomes {@link org.openmrs.module.chartsearchai.api.ChartTooLargeException}
+	 * (the provider maps it to {@code chart_too_large}) — explicit-overflow parity with
+	 * {@link LocalLlmEngine}, so an oversized chart or slice is never disguised as a generic
+	 * provider failure. Everything else stays an {@link APIException} with the operator
+	 * remediation for the remote GPs.
+	 */
+	static void throwForErrorResponse(int statusCode, String body) {
+		if (statusCode == 400 && LlmResponseParser.isContextOverflowError(body)) {
+			throw new org.openmrs.module.chartsearchai.api.ChartTooLargeException(
+					"Patient chart exceeds the remote model's context window. Reduce the chart "
+							+ "(query-scoped mode / embedding pre-filter) or serve the model with a "
+							+ "larger context.");
+		}
+		throw new APIException("Remote LLM API returned HTTP " + statusCode
+				+ ". Check the endpoint URL and model name in the "
+				+ "chartsearchai.llm.remote.* global properties, and the API key "
+				+ "in openmrs-runtime.properties.");
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/TokenCounter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/TokenCounter.java
@@ -1,0 +1,37 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+/**
+ * An exact token count from the LLM engine actually serving this deployment — mirrors
+ * med-agent-hub's {@code TokenCounter} protocol (server/context_sources.py), which likewise
+ * delegates counting to the configured engine's own tokenizer rather than approximating in the
+ * application layer. Deliberately narrow: the mandatory-first budget policy that consumes this
+ * (see {@code QueryStoreChartBuilder#applyContextBudget}) is application-owned and cannot be
+ * delegated, but WHAT a given piece of text costs in tokens is the engine's own fact, not a
+ * guess this module should make on its behalf.
+ */
+public interface TokenCounter {
+
+	/**
+	 * False when no engine currently configured for this deployment can answer a token-count
+	 * query (e.g. a remote OpenAI-compatible endpoint with no {@code /tokenize} route). Callers
+	 * must skip budget enforcement rather than fabricate an approximate count in that case —
+	 * matching the hub's "never guess" rule for token counting specifically.
+	 */
+	boolean isAvailable();
+
+	/** Exact token count for {@code text} from the real, currently-configured engine. */
+	int count(String text);
+
+	/** The current input budget: the engine's configured context window minus its output
+	 *  reservation — mirrors med-agent-hub's {@code ContextBudget.input_limit}. */
+	int inputBudget();
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/AnswerEnvelope.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/AnswerEnvelope.java
@@ -1,0 +1,63 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Provider-neutral answer content carried by {@link TurnEvent} and {@link TurnResult}.
+ *
+ * <p>The common OpenMRS layer understands only the required canonical {@code answer} text, which
+ * it needs for display, conversation replay, and audit. The complete provider payload is otherwise
+ * preserved without converting validation, evidence, safety, In-Depth, structured blocks, or
+ * provider extensions into Java-owned domain types. This keeps persistence content-agnostic while
+ * allowing bundled and hub answers to share one lifecycle.</p>
+ *
+ * <p>The top-level map is snapshotted and exposed read-only. Nested values remain the provider's
+ * original objects and are treated as immutable after envelope construction so unknown fields and
+ * exact nested structures survive relay and serialization.</p>
+ */
+public final class AnswerEnvelope {
+
+	private final String text;
+
+	private final Map<String, Object> payload;
+
+	private AnswerEnvelope(String text, Map<String, Object> payload) {
+		this.text = text;
+		this.payload = Collections.unmodifiableMap(new LinkedHashMap<>(payload));
+	}
+
+	/**
+	 * Creates an envelope from a canonical provider payload.
+	 *
+	 * @throws IllegalArgumentException when {@code payload.answer} is absent or is not text
+	 */
+	public static AnswerEnvelope fromPayload(Map<String, Object> payload) {
+		if (payload == null || !(payload.get("answer") instanceof String)) {
+			throw new IllegalArgumentException("Provider answer payload must contain textual 'answer'");
+		}
+		return new AnswerEnvelope((String) payload.get("answer"), payload);
+	}
+
+	/** Canonical final prose used for display, conversation replay, and audit. */
+	public String getText() {
+		return text;
+	}
+
+	/**
+	 * Complete provider payload, including unknown provider extensions, with a read-only top level.
+	 */
+	public Map<String, Object> getPayload() {
+		return payload;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
 import org.openmrs.module.chartsearchai.api.ChartSearchService;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
@@ -96,9 +97,108 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 				String.valueOf(ChartSearchAiConstants.DEFAULT_DRUG_REFERENCE_ENABLED)))) {
 			capabilities.add(ProviderCapability.DRUG_SAFETY);
 		}
-		return new ProviderDescriptor(PROVIDER_ID, "ChartSearchAI (bundled)", true, true, true,
-				Collections.singletonList(configuredMode()), capabilities, null);
+		String unavailableReason = engineUnavailableReason();
+		return new ProviderDescriptor(PROVIDER_ID, "ChartSearchAI (bundled)", true,
+				unavailableReason == null, true, Collections.singletonList(configuredMode()),
+				capabilities, unavailableReason);
 	}
+
+	/**
+	 * Why the configured LLM engine cannot serve right now, or {@code null} when it can.
+	 * Readiness must be truthful: an unusable engine (missing model file, unset or
+	 * unreachable remote endpoint) reports {@code ready:false} with the reason, so the
+	 * picker disables the provider and {@code registry.require} rejects with
+	 * {@code provider_not_ready} instead of every turn dying mid-stream with
+	 * {@code provider_failure}.
+	 */
+	private String engineUnavailableReason() {
+		String engine = gp(ChartSearchAiConstants.GP_LLM_ENGINE,
+				ChartSearchAiConstants.LLM_ENGINE_LOCAL);
+		if (ChartSearchAiConstants.LLM_ENGINE_REMOTE.equals(engine)) {
+			String endpoint = trimToNull(gp(ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL, null));
+			if (endpoint == null) {
+				return ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL + " is not set";
+			}
+			if (trimToNull(gp(ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME, null)) == null) {
+				return ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME + " is not set";
+			}
+			if (!engineReachable(endpoint)) {
+				return "remote engine unreachable: " + endpoint;
+			}
+			return null;
+		}
+		try {
+			requireLocalModel(gp(ChartSearchAiConstants.GP_LLM_MODEL_FILE_PATH, null));
+			return null;
+		}
+		catch (IllegalStateException e) {
+			return e.getMessage();
+		}
+	}
+
+	private static String trimToNull(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	/**
+	 * Resolve the local engine's model file, throwing {@link IllegalStateException} with the
+	 * reason when it is missing or misconfigured. Seam overridable in tests (same pattern as
+	 * {@link #gp}); production delegates to the canonical resolver.
+	 */
+	protected String requireLocalModel(String configuredPath) {
+		return ChartSearchAiUtils.resolveModelPath(configuredPath,
+				ChartSearchAiConstants.GP_LLM_MODEL_FILE_PATH);
+	}
+
+	/**
+	 * Whether the remote engine endpoint answers HTTP at all — any status code counts (a
+	 * chat-completions URL answers GET with 405), only connect/read failures do not. Probes
+	 * are cached briefly so per-turn readiness gates and the providers endpoint stay cheap.
+	 * Seam overridable in tests; the ready-path test exercises this real implementation
+	 * against a live local server.
+	 */
+	protected boolean engineReachable(String endpointUrl) {
+		long now = System.currentTimeMillis();
+		if (endpointUrl.equals(reachabilityEndpoint)
+				&& now - reachabilityProbedAtMs < REACHABILITY_TTL_MS) {
+			return reachabilityResult;
+		}
+		boolean reachable;
+		try {
+			java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+					.uri(java.net.URI.create(endpointUrl))
+					.timeout(java.time.Duration.ofSeconds(2)).GET().build();
+			REACHABILITY_CLIENT.send(request,
+					java.net.http.HttpResponse.BodyHandlers.discarding());
+			reachable = true;
+		}
+		catch (java.io.IOException | IllegalArgumentException e) {
+			reachable = false;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			reachable = false;
+		}
+		reachabilityEndpoint = endpointUrl;
+		reachabilityProbedAtMs = now;
+		reachabilityResult = reachable;
+		return reachable;
+	}
+
+	private static final long REACHABILITY_TTL_MS = 10_000L;
+
+	private static final java.net.http.HttpClient REACHABILITY_CLIENT = java.net.http.HttpClient
+			.newBuilder().connectTimeout(java.time.Duration.ofSeconds(2)).build();
+
+	private volatile String reachabilityEndpoint;
+
+	private volatile long reachabilityProbedAtMs;
+
+	private volatile boolean reachabilityResult;
 
 	@Override
 	public CompletionStage<TurnResult> execute(TurnRequest request, TurnEventSink events,

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
@@ -27,6 +27,7 @@ import org.openmrs.module.chartsearchai.api.ChartSearchService;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 import org.openmrs.module.chartsearchai.api.ChartTooLargeException;
+import org.openmrs.module.chartsearchai.api.InsufficientContextException;
 import org.openmrs.module.chartsearchai.reference.SafetyWarning;
 import org.openmrs.module.chartsearchai.util.DateFormatUtil;
 import org.slf4j.Logger;
@@ -61,6 +62,11 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 	public static final String PROBLEM_PROVIDER_FAILURE = "provider_failure";
 
 	public static final String PROBLEM_CHART_TOO_LARGE = "chart_too_large";
+
+	/** Same wire string as med-agent-hub's {@code InsufficientContextError} — mandatory evidence
+	 *  alone exceeded the budget, a proactively-diagnosed abstention rather than llama-server's
+	 *  after-the-fact rejection ({@link #PROBLEM_CHART_TOO_LARGE}). */
+	public static final String PROBLEM_INSUFFICIENT_CONTEXT = "insufficient_context";
 
 	public static final String PROBLEM_UNSUPPORTED_MODE = "unsupported_mode";
 
@@ -234,6 +240,9 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 								sequence.getAndIncrement(), PROVIDER_ID, toAnswerEnvelope(ungrounded)));
 					}, preliminary -> events.accept(TurnEvent.delta(TurnEventType.REASONING_DELTA,
 							sequence.getAndIncrement(), PROVIDER_ID, preliminary)));
+		}
+		catch (InsufficientContextException e) {
+			return failed(events, sequence, configuredMode, PROBLEM_INSUFFICIENT_CONTEXT);
 		}
 		catch (ChartTooLargeException e) {
 			return failed(events, sequence, configuredMode, PROBLEM_CHART_TOO_LARGE);

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
@@ -9,8 +9,12 @@
  */
 package org.openmrs.module.chartsearchai.api.provider;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -20,7 +24,10 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
 import org.openmrs.module.chartsearchai.api.ChartSearchService;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 import org.openmrs.module.chartsearchai.api.ChartTooLargeException;
+import org.openmrs.module.chartsearchai.reference.SafetyWarning;
+import org.openmrs.module.chartsearchai.util.DateFormatUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,7 +119,7 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 					}, ungrounded -> {
 						answerDoneEmitted[0] = true;
 						events.accept(TurnEvent.withAnswer(TurnEventType.ANSWER_DONE,
-								sequence.getAndIncrement(), PROVIDER_ID, ungrounded));
+								sequence.getAndIncrement(), PROVIDER_ID, toAnswerEnvelope(ungrounded)));
 					}, preliminary -> events.accept(TurnEvent.delta(TurnEventType.REASONING_DELTA,
 							sequence.getAndIncrement(), PROVIDER_ID, preliminary)));
 		}
@@ -124,19 +131,20 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 			return failed(events, sequence, configuredMode, PROBLEM_PROVIDER_FAILURE);
 		}
 
+		AnswerEnvelope finalEnvelope = toAnswerEnvelope(finalAnswer);
 		if (answerDoneEmitted[0]) {
 			if (groundingEnabled()) {
 				events.accept(TurnEvent.withAnswer(TurnEventType.EVIDENCE_UPDATED,
-						sequence.getAndIncrement(), PROVIDER_ID, finalAnswer));
+						sequence.getAndIncrement(), PROVIDER_ID, finalEnvelope));
 			}
 		} else {
 			// The ungrounded seam did not fire, so the returned answer was already final
 			// (e.g. cached with verdicts attached when first computed).
 			events.accept(TurnEvent.withAnswer(TurnEventType.ANSWER_DONE, sequence.getAndIncrement(),
-					PROVIDER_ID, finalAnswer));
+					PROVIDER_ID, finalEnvelope));
 		}
 		events.accept(TurnEvent.of(TurnEventType.TURN_DONE, sequence.getAndIncrement(), PROVIDER_ID));
-		return CompletableFuture.completedFuture(TurnResult.done(PROVIDER_ID, configuredMode, finalAnswer));
+		return CompletableFuture.completedFuture(TurnResult.done(PROVIDER_ID, configuredMode, finalEnvelope));
 	}
 
 	private CompletionStage<TurnResult> failed(TurnEventSink events, AtomicInteger sequence,
@@ -148,6 +156,39 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 	private boolean groundingEnabled() {
 		return Boolean.parseBoolean(gp(ChartSearchAiConstants.GP_GROUNDING_ENABLED,
 				String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_ENABLED)));
+	}
+
+	private static AnswerEnvelope toAnswerEnvelope(ChartAnswer answer) {
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", answer.getAnswer());
+
+		List<Map<String, Object>> references = new ArrayList<>();
+		for (RecordReference reference : answer.getReferences()) {
+			Map<String, Object> value = new LinkedHashMap<>();
+			value.put("index", reference.getIndex());
+			value.put("resourceType", reference.getResourceType());
+			value.put("resourceUuid", reference.getResourceUuid());
+			value.put("date", reference.getDate() == null ? null
+					: DateFormatUtil.formatDate(reference.getDate()));
+			value.put("grounded", reference.getGrounded());
+			references.add(value);
+		}
+		payload.put("references", references);
+
+		List<Map<String, Object>> warnings = new ArrayList<>();
+		for (SafetyWarning warning : answer.getSafetyWarnings()) {
+			Map<String, Object> value = new LinkedHashMap<>();
+			value.put("type", warning.getType());
+			value.put("drug", warning.getDrug());
+			value.put("detail", warning.getDetail());
+			warnings.add(value);
+		}
+		payload.put("safetyWarnings", warnings);
+		payload.put("blocks", Collections.emptyList());
+		payload.put("inputTokens", answer.getInputTokens());
+		payload.put("outputTokens", answer.getOutputTokens());
+		payload.put("cachedTokens", answer.getCachedTokens());
+		return AnswerEnvelope.fromPayload(payload);
 	}
 
 	private ProviderMode configuredMode() {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
@@ -155,11 +155,12 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 	}
 
 	/**
-	 * Whether the remote engine endpoint answers HTTP at all — any status code counts (a
-	 * chat-completions URL answers GET with 405), only connect/read failures do not. Probes
-	 * are cached briefly so per-turn readiness gates and the providers endpoint stay cheap.
-	 * Seam overridable in tests; the ready-path test exercises this real implementation
-	 * against a live local server.
+	 * Whether the remote engine endpoint can serve: it must answer HTTP with a non-5xx
+	 * status (a chat-completions URL answers GET with 405, which counts). Connect/read
+	 * failures AND 5xx both mean not-ready — a relay in front of a dead engine answers 502,
+	 * which must not hide the outage. Probes are cached briefly so per-turn readiness gates
+	 * and the providers endpoint stay cheap. Seam overridable in tests; the ready-path and
+	 * proxy-502 tests exercise this real implementation against live local servers.
 	 */
 	protected boolean engineReachable(String endpointUrl) {
 		long now = System.currentTimeMillis();
@@ -172,9 +173,9 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 			java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
 					.uri(java.net.URI.create(endpointUrl))
 					.timeout(java.time.Duration.ofSeconds(2)).GET().build();
-			REACHABILITY_CLIENT.send(request,
+			java.net.http.HttpResponse<Void> response = REACHABILITY_CLIENT.send(request,
 					java.net.http.HttpResponse.BodyHandlers.discarding());
-			reachable = true;
+			reachable = response.statusCode() < 500;
 		}
 		catch (java.io.IOException | IllegalArgumentException e) {
 			reachable = false;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
@@ -30,6 +30,9 @@ import org.openmrs.module.chartsearchai.reference.SafetyWarning;
 import org.openmrs.module.chartsearchai.util.DateFormatUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 
 /**
  * Adapts the bundled ChartSearchAI pipeline (the {@link ChartSearchService} caching router and
@@ -49,6 +52,7 @@ import org.slf4j.LoggerFactory;
  *
  * Failures are normalized to one problem code and never fall back to another provider.
  */
+@Service("chartSearchAi.bundledClinicalAnswerProvider")
 public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 
 	public static final String PROVIDER_ID = "bundled";
@@ -65,13 +69,20 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 
 	private final ChartSearchService chartSearchService;
 
-	public BundledClinicalAnswerProvider(ChartSearchService chartSearchService) {
+	@Autowired
+	public BundledClinicalAnswerProvider(
+			@Qualifier("chartSearchAi.chartSearchServiceRouter") ChartSearchService chartSearchService) {
 		this.chartSearchService = chartSearchService;
 	}
 
 	/** Global-property read seam, overridable in tests (same pattern as the caching router). */
 	protected String gp(String property, String defaultValue) {
 		return Context.getAdministrationService().getGlobalProperty(property, defaultValue);
+	}
+
+	@Override
+	public String id() {
+		return PROVIDER_ID;
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
@@ -296,6 +296,7 @@ public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
 			warnings.add(value);
 		}
 		payload.put("safetyWarnings", warnings);
+		payload.put("safetyStatus", answer.getSafetyStatus());
 		payload.put("blocks", Collections.emptyList());
 		payload.put("inputTokens", answer.getInputTokens());
 		payload.put("outputTokens", answer.getOutputTokens());

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProvider.java
@@ -1,0 +1,158 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.ChartSearchService;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.ChartTooLargeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adapts the bundled ChartSearchAI pipeline (the {@link ChartSearchService} caching router and
+ * everything behind it: local/remote engines, query-scoped or full-chart context, grounding,
+ * drug safety, warmup) onto the provider-neutral {@link ClinicalAnswerProvider} boundary. Bundled
+ * behavior is unchanged — this class only translates the pipeline's streaming seams into the
+ * canonical turn lifecycle:
+ *
+ * <ul>
+ *   <li>preliminary and committed reasoning fragments become {@code reasoning_delta};</li>
+ *   <li>answer tokens become {@code answer_delta};</li>
+ *   <li>the ungrounded-answer seam becomes {@code answer_done} (verdicts still {@code null});</li>
+ *   <li>the grounded return value becomes {@code evidence_updated} when grounding is enabled;</li>
+ *   <li>an answer that arrives already final (e.g. cached, verdicts attached when first computed)
+ *       becomes a single {@code answer_done} with no separate evidence event.</li>
+ * </ul>
+ *
+ * Failures are normalized to one problem code and never fall back to another provider.
+ */
+public class BundledClinicalAnswerProvider implements ClinicalAnswerProvider {
+
+	public static final String PROVIDER_ID = "bundled";
+
+	public static final String PROBLEM_PROVIDER_FAILURE = "provider_failure";
+
+	public static final String PROBLEM_CHART_TOO_LARGE = "chart_too_large";
+
+	public static final String PROBLEM_UNSUPPORTED_MODE = "unsupported_mode";
+
+	public static final String PROBLEM_CANCELLED = "cancelled";
+
+	private static final Logger log = LoggerFactory.getLogger(BundledClinicalAnswerProvider.class);
+
+	private final ChartSearchService chartSearchService;
+
+	public BundledClinicalAnswerProvider(ChartSearchService chartSearchService) {
+		this.chartSearchService = chartSearchService;
+	}
+
+	/** Global-property read seam, overridable in tests (same pattern as the caching router). */
+	protected String gp(String property, String defaultValue) {
+		return Context.getAdministrationService().getGlobalProperty(property, defaultValue);
+	}
+
+	@Override
+	public ProviderDescriptor descriptor() {
+		Set<ProviderCapability> capabilities = EnumSet.of(ProviderCapability.ANSWER,
+				ProviderCapability.TOKEN_STREAMING);
+		if (groundingEnabled()) {
+			capabilities.add(ProviderCapability.GROUNDING);
+		}
+		if (Boolean.parseBoolean(gp(ChartSearchAiConstants.GP_DRUG_REFERENCE_ENABLED,
+				String.valueOf(ChartSearchAiConstants.DEFAULT_DRUG_REFERENCE_ENABLED)))) {
+			capabilities.add(ProviderCapability.DRUG_SAFETY);
+		}
+		return new ProviderDescriptor(PROVIDER_ID, "ChartSearchAI (bundled)", true, true, true,
+				Collections.singletonList(configuredMode()), capabilities, null);
+	}
+
+	@Override
+	public CompletionStage<TurnResult> execute(TurnRequest request, TurnEventSink events,
+			CancellationSignal cancellation) {
+		// The bundled pipeline is synchronous; the turn runs on the caller's thread and the
+		// stage completes when the last event has been delivered.
+		AtomicInteger sequence = new AtomicInteger();
+		events.accept(TurnEvent.of(TurnEventType.TURN_STARTED, sequence.getAndIncrement(), PROVIDER_ID));
+
+		if (cancellation.isCancelled()) {
+			return failed(events, sequence, null, PROBLEM_CANCELLED);
+		}
+		ProviderMode configuredMode = configuredMode();
+		if (request.getMode() != null && request.getMode() != configuredMode) {
+			return failed(events, sequence, null, PROBLEM_UNSUPPORTED_MODE);
+		}
+
+		boolean[] answerDoneEmitted = { false };
+		ChartAnswer finalAnswer;
+		try {
+			finalAnswer = chartSearchService.searchStreaming(request.getPatient(), request.getQuestion(),
+					token -> events.accept(TurnEvent.delta(TurnEventType.ANSWER_DELTA,
+							sequence.getAndIncrement(), PROVIDER_ID, token)),
+					reasoning -> events.accept(TurnEvent.delta(TurnEventType.REASONING_DELTA,
+							sequence.getAndIncrement(), PROVIDER_ID, reasoning)),
+					// Citations arrive inside the ungrounded answer below; the pre-grounding
+					// citations channel needs no separate lifecycle event.
+					citations -> {
+					}, ungrounded -> {
+						answerDoneEmitted[0] = true;
+						events.accept(TurnEvent.withAnswer(TurnEventType.ANSWER_DONE,
+								sequence.getAndIncrement(), PROVIDER_ID, ungrounded));
+					}, preliminary -> events.accept(TurnEvent.delta(TurnEventType.REASONING_DELTA,
+							sequence.getAndIncrement(), PROVIDER_ID, preliminary)));
+		}
+		catch (ChartTooLargeException e) {
+			return failed(events, sequence, configuredMode, PROBLEM_CHART_TOO_LARGE);
+		}
+		catch (RuntimeException e) {
+			log.warn("Bundled provider turn failed for request {}", request.getRequestId(), e);
+			return failed(events, sequence, configuredMode, PROBLEM_PROVIDER_FAILURE);
+		}
+
+		if (answerDoneEmitted[0]) {
+			if (groundingEnabled()) {
+				events.accept(TurnEvent.withAnswer(TurnEventType.EVIDENCE_UPDATED,
+						sequence.getAndIncrement(), PROVIDER_ID, finalAnswer));
+			}
+		} else {
+			// The ungrounded seam did not fire, so the returned answer was already final
+			// (e.g. cached with verdicts attached when first computed).
+			events.accept(TurnEvent.withAnswer(TurnEventType.ANSWER_DONE, sequence.getAndIncrement(),
+					PROVIDER_ID, finalAnswer));
+		}
+		events.accept(TurnEvent.of(TurnEventType.TURN_DONE, sequence.getAndIncrement(), PROVIDER_ID));
+		return CompletableFuture.completedFuture(TurnResult.done(PROVIDER_ID, configuredMode, finalAnswer));
+	}
+
+	private CompletionStage<TurnResult> failed(TurnEventSink events, AtomicInteger sequence,
+			ProviderMode mode, String problemCode) {
+		events.accept(TurnEvent.error(sequence.getAndIncrement(), PROVIDER_ID, problemCode));
+		return CompletableFuture.completedFuture(TurnResult.error(PROVIDER_ID, mode, problemCode));
+	}
+
+	private boolean groundingEnabled() {
+		return Boolean.parseBoolean(gp(ChartSearchAiConstants.GP_GROUNDING_ENABLED,
+				String.valueOf(ChartSearchAiConstants.DEFAULT_GROUNDING_ENABLED)));
+	}
+
+	private ProviderMode configuredMode() {
+		String chartMode = gp(ChartSearchAiConstants.GP_CHART_MODE, ChartSearchAiConstants.CHART_MODE_DEFAULT);
+		return ChartSearchAiConstants.CHART_MODE_FULL_CHART.equals(chartMode)
+				? ProviderMode.FULL_CHART_STABLE : ProviderMode.QUERY_SCOPED;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/CancellationSignal.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/CancellationSignal.java
@@ -1,0 +1,24 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+/**
+ * Cooperative cancellation for a provider turn. Providers poll this at their natural
+ * checkpoints (before starting expensive work, between stages) and end the turn with a
+ * {@code cancelled} {@code turn_error} when it reports {@code true}.
+ */
+@FunctionalInterface
+public interface CancellationSignal {
+
+	/** A signal that never cancels. */
+	CancellationSignal NONE = () -> false;
+
+	boolean isCancelled();
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProvider.java
@@ -25,6 +25,12 @@ import java.util.concurrent.CompletionStage;
  */
 public interface ClinicalAnswerProvider {
 
+	/**
+	 * Stable provider identity used for registry keys and persistence. Must not read OpenMRS
+	 * configuration — Spring constructs the registry before the OpenMRS Context is available.
+	 */
+	String id();
+
 	/** The provider's truthful self-description: identity, readiness, modes, and capabilities. */
 	ProviderDescriptor descriptor();
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProvider.java
@@ -1,0 +1,48 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * The provider-neutral boundary between OpenMRS and a clinical answering implementation. The
+ * bundled ChartSearchAI pipeline and the med-agent-hub relay both implement this one contract, so
+ * the common layer (authorization, sessions, persistence, audit, REST/SSE) never branches on the
+ * provider.
+ *
+ * <p>A provider never silently falls back to another provider: it either completes the turn or
+ * ends it with one normalized problem code. Emitted events must satisfy
+ * {@link TurnLifecycleValidator} for the provider's advertised capabilities.</p>
+ */
+public interface ClinicalAnswerProvider {
+
+	/** The provider's truthful self-description: identity, readiness, modes, and capabilities. */
+	ProviderDescriptor descriptor();
+
+	default Set<ProviderCapability> capabilities() {
+		return descriptor().getCapabilities();
+	}
+
+	default List<ProviderMode> modes() {
+		return descriptor().getModes();
+	}
+
+	/**
+	 * Executes one turn, delivering lifecycle events to {@code events} as they occur and
+	 * completing with the turn's final outcome. Implementations honor {@code cancellation}
+	 * at their natural checkpoints. The returned stage completes normally even for failed
+	 * turns (with a {@code turn_error} result); it completes exceptionally only for
+	 * infrastructure-level faults outside the turn contract.
+	 */
+	CompletionStage<TurnResult> execute(TurnRequest request, TurnEventSink events,
+			CancellationSignal cancellation);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProviderRegistry.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProviderRegistry.java
@@ -98,13 +98,20 @@ public class ClinicalAnswerProviderRegistry {
 	}
 
 	/**
-	 * The provider preselected for new conversations. A configured default that is not an
-	 * enabled provider is ignored in favor of the fresh-install default rather than exposing a
-	 * dead default.
+	 * The provider preselected for new conversations. A configured default that is not enabled
+	 * falls back to the fresh-install default when it is enabled, otherwise to the first enabled
+	 * provider. Discovery never advertises a disabled provider as the default.
 	 */
 	public String getDefaultProviderId() {
+		List<String> enabled = enabledProviderIds();
 		String configured = gp(GP_DEFAULT_PROVIDER, FRESH_INSTALL_DEFAULT);
-		return enabledProviderIds().contains(configured) ? configured : FRESH_INSTALL_DEFAULT;
+		if (enabled.contains(configured)) {
+			return configured;
+		}
+		if (enabled.contains(FRESH_INSTALL_DEFAULT)) {
+			return FRESH_INSTALL_DEFAULT;
+		}
+		return enabled.isEmpty() ? FRESH_INSTALL_DEFAULT : enabled.get(0);
 	}
 
 	/** The picker only exists when there is an actual choice. */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProviderRegistry.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProviderRegistry.java
@@ -1,0 +1,136 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openmrs.api.context.Context;
+
+/**
+ * Resolves which {@link ClinicalAnswerProvider}s OpenMRS configuration enables and which one is
+ * the default. The configuration rules the dual-provider roadmap fixes:
+ *
+ * <ul>
+ *   <li>A fresh install enables only the bundled provider, which is the default.</li>
+ *   <li>The provider picker exists only when more than one provider is enabled.</li>
+ *   <li>An enabled provider that is unavailable (no implementation deployed, or not ready)
+ *       stays visible in descriptors — disabled with a reason — rather than disappearing.</li>
+ *   <li>{@link #require} fails with one normalized problem code; it never substitutes another
+ *       provider.</li>
+ *   <li>Switching provider starts a new conversation; existing conversations keep the provider
+ *       that produced them.</li>
+ * </ul>
+ */
+public class ClinicalAnswerProviderRegistry {
+
+	/** Comma-separated ordered provider ids configuration enables. Fresh-install default: bundled only. */
+	public static final String GP_PROVIDERS_ENABLED = "chartsearchai.providers.enabled";
+
+	/** The provider preselected for new conversations. Must be an enabled provider. */
+	public static final String GP_DEFAULT_PROVIDER = "chartsearchai.providers.default";
+
+	public static final String FRESH_INSTALL_DEFAULT = BundledClinicalAnswerProvider.PROVIDER_ID;
+
+	private final Map<String, ClinicalAnswerProvider> providersById = new LinkedHashMap<>();
+
+	public ClinicalAnswerProviderRegistry(List<ClinicalAnswerProvider> providers) {
+		for (ClinicalAnswerProvider provider : providers) {
+			providersById.put(provider.descriptor().getId(), provider);
+		}
+	}
+
+	/** Global-property read seam, overridable in tests (same pattern as the caching router). */
+	protected String gp(String property, String defaultValue) {
+		return Context.getAdministrationService().getGlobalProperty(property, defaultValue);
+	}
+
+	/** The configured enabled provider ids, in configuration order. */
+	public List<String> enabledProviderIds() {
+		List<String> ids = new ArrayList<>();
+		for (String id : gp(GP_PROVIDERS_ENABLED, FRESH_INSTALL_DEFAULT).split(",")) {
+			String trimmed = id.trim();
+			if (!trimmed.isEmpty() && !ids.contains(trimmed)) {
+				ids.add(trimmed);
+			}
+		}
+		return ids;
+	}
+
+	/**
+	 * One descriptor per enabled provider, in configuration order, with {@code isDefault}
+	 * recomputed from configuration. An enabled provider with no deployed implementation is
+	 * represented as visible-but-unavailable instead of being dropped.
+	 */
+	public List<ProviderDescriptor> descriptors() {
+		String defaultId = getDefaultProviderId();
+		List<ProviderDescriptor> descriptors = new ArrayList<>();
+		for (String id : enabledProviderIds()) {
+			ClinicalAnswerProvider provider = providersById.get(id);
+			if (provider == null) {
+				descriptors.add(new ProviderDescriptor(id, id, true, false, id.equals(defaultId),
+						java.util.Collections.emptyList(),
+						java.util.Collections.emptySet(),
+						"no implementation for provider '" + id + "' is deployed"));
+				continue;
+			}
+			ProviderDescriptor descriptor = provider.descriptor();
+			descriptors.add(new ProviderDescriptor(descriptor.getId(), descriptor.getLabel(), true,
+					descriptor.isReady(), id.equals(defaultId), descriptor.getModes(),
+					descriptor.getCapabilities(), descriptor.getUnavailableReason()));
+		}
+		return descriptors;
+	}
+
+	/**
+	 * The provider preselected for new conversations. A configured default that is not an
+	 * enabled provider is ignored in favor of the fresh-install default rather than exposing a
+	 * dead default.
+	 */
+	public String getDefaultProviderId() {
+		String configured = gp(GP_DEFAULT_PROVIDER, FRESH_INSTALL_DEFAULT);
+		return enabledProviderIds().contains(configured) ? configured : FRESH_INSTALL_DEFAULT;
+	}
+
+	/** The picker only exists when there is an actual choice. */
+	public boolean isPickerVisible() {
+		return enabledProviderIds().size() > 1;
+	}
+
+	/**
+	 * Resolves the provider that must serve a turn, or fails with one normalized problem code
+	 * ({@code unknown_provider}, {@code provider_not_enabled}, {@code provider_not_ready}).
+	 * Never substitutes a different provider.
+	 */
+	public ClinicalAnswerProvider require(String providerId) {
+		ClinicalAnswerProvider provider = providersById.get(providerId);
+		if (provider == null) {
+			throw new ProviderUnavailableException("unknown_provider",
+					"No provider with id '" + providerId + "' is deployed");
+		}
+		if (!enabledProviderIds().contains(providerId)) {
+			throw new ProviderUnavailableException("provider_not_enabled",
+					"Provider '" + providerId + "' is not enabled by configuration");
+		}
+		if (!provider.descriptor().isReady()) {
+			throw new ProviderUnavailableException("provider_not_ready",
+					"Provider '" + providerId + "' is not ready: "
+							+ provider.descriptor().getUnavailableReason());
+		}
+		return provider;
+	}
+
+	/** A provider change always starts a new conversation; the old one stays in history. */
+	public static boolean switchRequiresNewConversation(String fromProviderId, String toProviderId) {
+		return !fromProviderId.equals(toProviderId);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProviderRegistry.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ClinicalAnswerProviderRegistry.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.openmrs.api.context.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 /**
  * Resolves which {@link ClinicalAnswerProvider}s OpenMRS configuration enables and which one is
@@ -31,6 +33,7 @@ import org.openmrs.api.context.Context;
  *       that produced them.</li>
  * </ul>
  */
+@Service("chartSearchAi.clinicalAnswerProviderRegistry")
 public class ClinicalAnswerProviderRegistry {
 
 	/** Comma-separated ordered provider ids configuration enables. Fresh-install default: bundled only. */
@@ -43,9 +46,12 @@ public class ClinicalAnswerProviderRegistry {
 
 	private final Map<String, ClinicalAnswerProvider> providersById = new LinkedHashMap<>();
 
+	@Autowired
 	public ClinicalAnswerProviderRegistry(List<ClinicalAnswerProvider> providers) {
 		for (ClinicalAnswerProvider provider : providers) {
-			providersById.put(provider.descriptor().getId(), provider);
+			// Use id(), not descriptor(): descriptor() may read global properties, and Spring
+			// constructs this registry before the OpenMRS Context is available.
+			providersById.put(provider.id(), provider);
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransport.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransport.java
@@ -58,7 +58,7 @@ public class HttpHubStreamTransport implements HubStreamTransport {
 	}
 
 	@Override
-	public void stream(HubCallRequest request, Consumer<HubWireEvent> sink) {
+	public void stream(HubCallRequest request, Consumer<HubWireEvent> sink, CancellationSignal cancellation) {
 		try {
 			String body = requestJson(request);
 			HttpRequest.Builder builder = HttpRequest.newBuilder()
@@ -76,6 +76,12 @@ public class HttpHubStreamTransport implements HubStreamTransport {
 			if (response.statusCode() < 200 || response.statusCode() >= 300) {
 				String errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
 				requireSuccess(response.statusCode(), errorBody);
+			}
+			// Bind the open response body so a preempting turn can force it closed from another
+			// thread, unblocking parseSse's readLine() below with an IOException instead of letting
+			// the hub keep generating an abandoned turn to completion (see TurnCancellation).
+			if (cancellation instanceof TurnCancellation) {
+				((TurnCancellation) cancellation).bindCloseable(response.body());
 			}
 			parseSse(response.body(), sink);
 		}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransport.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransport.java
@@ -1,0 +1,169 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+import org.springframework.stereotype.Component;
+
+/**
+ * Production {@link HubStreamTransport}: one HTTP POST to the configured hub chat-completions
+ * endpoint with {@code Accept: text/event-stream}, parsed into {@link HubWireEvent}s. There is no
+ * whole-profile wall-clock timeout — product profiles may continue through review and In-Depth;
+ * browser disconnects cancel the hub connection.
+ */
+@Component("chartSearchAi.hubStreamTransport")
+public class HttpHubStreamTransport implements HubStreamTransport {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private final HttpClient httpClient = HttpClient.newBuilder()
+			.connectTimeout(Duration.ofSeconds(10))
+			.version(HttpClient.Version.HTTP_1_1)
+			.build();
+
+	/** Runtime-property API key seam, overridable in tests. */
+	protected String apiKey() {
+		Properties properties = Context.getRuntimeProperties();
+		return properties == null ? null
+				: properties.getProperty(ChartSearchAiConstants.RP_HUB_API_KEY);
+	}
+
+	@Override
+	public void stream(HubCallRequest request, Consumer<HubWireEvent> sink) {
+		try {
+			String body = requestJson(request);
+			HttpRequest.Builder builder = HttpRequest.newBuilder()
+					.uri(URI.create(request.getEndpointUrl()))
+					.version(HttpClient.Version.HTTP_1_1)
+					.header("Content-Type", "application/json")
+					.header("Accept", "text/event-stream")
+					.POST(HttpRequest.BodyPublishers.ofByteArray(body.getBytes(StandardCharsets.UTF_8)));
+			String key = apiKey();
+			if (key != null && !key.trim().isEmpty()) {
+				builder.header("Authorization", "Bearer " + key.trim());
+			}
+			HttpResponse<InputStream> response = httpClient.send(builder.build(),
+					HttpResponse.BodyHandlers.ofInputStream());
+			if (response.statusCode() < 200 || response.statusCode() >= 300) {
+				String errorBody = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
+				requireSuccess(response.statusCode(), errorBody);
+			}
+			parseSse(response.body(), sink);
+		}
+		catch (HubTransportException e) {
+			throw e;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException("Hub stream interrupted", e);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Hub stream failed: " + e.getMessage(), e);
+		}
+	}
+
+	static void requireSuccess(int statusCode, String body) {
+		if (statusCode < 200 || statusCode >= 300) {
+			throw new HubTransportException(statusCode, body);
+		}
+	}
+
+	/**
+	 * Builds the hub request envelope. Prior turns are prose-only user/assistant pairs; the hub
+	 * owns chart retrieval and the system prompt.
+	 */
+	static String requestJson(HubCallRequest request) throws IOException {
+		Map<String, Object> root = new LinkedHashMap<>();
+		root.put("model", request.getProfileId());
+		root.put("stream", Boolean.TRUE);
+		root.put("patient", request.getPatientUuid());
+		List<Map<String, Object>> messages = new ArrayList<>();
+		for (PriorClinicalTurn prior : request.getPriorTurns()) {
+			messages.add(message("user", prior.getQuestion()));
+			messages.add(message("assistant", prior.getAnswer()));
+		}
+		messages.add(message("user", request.getQuestion()));
+		root.put("messages", messages);
+		Map<String, Object> context = new LinkedHashMap<>();
+		context.put("require_product_profile", Boolean.TRUE);
+		context.put("session", request.getConversationId());
+		context.put("request_id", request.getRequestId());
+		root.put("context", context);
+		return MAPPER.writeValueAsString(root);
+	}
+
+	private static Map<String, Object> message(String role, String content) {
+		Map<String, Object> message = new LinkedHashMap<>();
+		message.put("role", role);
+		message.put("content", content);
+		return message;
+	}
+
+	static void parseSse(InputStream body, Consumer<HubWireEvent> sink) throws IOException {
+		try (BufferedReader reader = new BufferedReader(
+				new InputStreamReader(body, StandardCharsets.UTF_8))) {
+			String event = "";
+			StringBuilder data = new StringBuilder();
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (line.isEmpty()) {
+					emit(event, data.toString(), sink);
+					event = "";
+					data.setLength(0);
+				} else if (line.startsWith("event:")) {
+					event = line.substring("event:".length()).trim();
+				} else if (line.startsWith("data:")) {
+					if (data.length() > 0) {
+						data.append('\n');
+					}
+					String raw = line.substring("data:".length());
+					data.append(raw.startsWith(" ") ? raw.substring(1) : raw);
+				}
+				// Comment/heartbeat lines (": ...") are ignored; the REST layer may still write them
+				// downstream to detect client disconnect.
+			}
+			if (data.length() > 0) {
+				emit(event, data.toString(), sink);
+			}
+		}
+	}
+
+	private static void emit(String event, String data, Consumer<HubWireEvent> sink)
+			throws IOException {
+		if (event == null || event.isEmpty() || data == null || data.isEmpty()) {
+			return;
+		}
+		Map<String, Object> payload = MAPPER.readValue(data,
+				new TypeReference<Map<String, Object>>() {});
+		sink.accept(new HubWireEvent(event, payload));
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubCallRequest.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubCallRequest.java
@@ -1,0 +1,74 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+
+/** One outbound product-profile request from {@link HubClinicalAnswerProvider} to med-agent-hub. */
+public final class HubCallRequest {
+
+	private final String endpointUrl;
+
+	private final String profileId;
+
+	private final String patientUuid;
+
+	private final String conversationId;
+
+	private final String requestId;
+
+	private final String question;
+
+	private final List<PriorClinicalTurn> priorTurns;
+
+	public HubCallRequest(String endpointUrl, String profileId, String patientUuid,
+			String conversationId, String requestId, String question,
+			List<PriorClinicalTurn> priorTurns) {
+		this.endpointUrl = endpointUrl;
+		this.profileId = profileId;
+		this.patientUuid = patientUuid;
+		this.conversationId = conversationId;
+		this.requestId = requestId;
+		this.question = question;
+		this.priorTurns = priorTurns == null ? Collections.emptyList()
+				: Collections.unmodifiableList(priorTurns);
+	}
+
+	public String getEndpointUrl() {
+		return endpointUrl;
+	}
+
+	public String getProfileId() {
+		return profileId;
+	}
+
+	public String getPatientUuid() {
+		return patientUuid;
+	}
+
+	public String getConversationId() {
+		return conversationId;
+	}
+
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public String getQuestion() {
+		return question;
+	}
+
+	public List<PriorClinicalTurn> getPriorTurns() {
+		return priorTurns;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProvider.java
@@ -1,0 +1,254 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Relays one med-agent-hub product-profile request and maps the hub's staged SSE wire onto the
+ * canonical {@link TurnEventType} lifecycle. The hub owns answer schema, validation, evidence, and
+ * In-Depth content; this provider never reinterprets those fields — it only translates event names
+ * and preserves complete payloads in {@link AnswerEnvelope}.
+ *
+ * <p>There is never a silent fallback to the bundled provider. Failures end in one
+ * {@code turn_error} with a normalized problem code.</p>
+ */
+public class HubClinicalAnswerProvider implements ClinicalAnswerProvider {
+
+	public static final String PROVIDER_ID = "hub";
+
+	public static final String PROBLEM_PROFILE_REQUIRED = "profile_required";
+
+	public static final String PROBLEM_HUB_NOT_CONFIGURED = "hub_not_configured";
+
+	public static final String PROBLEM_HUB_STREAM_INCOMPLETE = "hub_stream_incomplete";
+
+	public static final String PROBLEM_CANCELLED = "cancelled";
+
+	public static final String PROBLEM_PROVIDER_FAILURE = "provider_failure";
+
+	private static final Logger log = LoggerFactory.getLogger(HubClinicalAnswerProvider.class);
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private final HubStreamTransport transport;
+
+	public HubClinicalAnswerProvider(HubStreamTransport transport) {
+		this.transport = transport;
+	}
+
+	/** Global-property read seam, overridable in tests. */
+	protected String gp(String property, String defaultValue) {
+		return Context.getAdministrationService().getGlobalProperty(property, defaultValue);
+	}
+
+	@Override
+	public ProviderDescriptor descriptor() {
+		String endpoint = configuredEndpoint();
+		boolean ready = endpoint != null;
+		Set<ProviderCapability> capabilities = EnumSet.of(ProviderCapability.ANSWER,
+				ProviderCapability.TOKEN_STREAMING, ProviderCapability.ANSWER_CHECK,
+				ProviderCapability.ANSWER_REVIEW, ProviderCapability.INDEPTH,
+				ProviderCapability.GROUNDING, ProviderCapability.DRUG_SAFETY,
+				ProviderCapability.STRUCTURED_BLOCKS, ProviderCapability.MULTI_TURN_CONTEXT);
+		return new ProviderDescriptor(PROVIDER_ID, "med-agent-hub", true, ready, false,
+				Collections.singletonList(ProviderMode.QUERY_SCOPED), capabilities,
+				ready ? null : ChartSearchAiConstants.GP_HUB_ENDPOINT_URL + " is not set");
+	}
+
+	@Override
+	public CompletionStage<TurnResult> execute(TurnRequest request, TurnEventSink events,
+			CancellationSignal cancellation) {
+		AtomicInteger sequence = new AtomicInteger();
+		events.accept(TurnEvent.of(TurnEventType.TURN_STARTED, sequence.getAndIncrement(), PROVIDER_ID));
+
+		if (cancellation.isCancelled()) {
+			return failed(events, sequence, request.getMode(), PROBLEM_CANCELLED);
+		}
+		String endpoint = configuredEndpoint();
+		if (endpoint == null) {
+			return failed(events, sequence, request.getMode(), PROBLEM_HUB_NOT_CONFIGURED);
+		}
+		String profileId = request.getProfileId();
+		if (profileId == null || profileId.trim().isEmpty()) {
+			return failed(events, sequence, request.getMode(), PROBLEM_PROFILE_REQUIRED);
+		}
+
+		HubCallRequest call = new HubCallRequest(endpoint, profileId.trim(),
+				request.getPatient().getUuid(), request.getConversationId(), request.getRequestId(),
+				request.getQuestion(), request.getPriorClinicalTurns());
+
+		AtomicReference<AnswerEnvelope> latestAnswer = new AtomicReference<>();
+		AtomicReference<String> streamError = new AtomicReference<>();
+		boolean[] doneSeen = { false };
+		try {
+			transport.stream(call,
+					wire -> handleWire(wire, events, sequence, latestAnswer, streamError, doneSeen));
+		}
+		catch (HubTransportException e) {
+			return failed(events, sequence, request.getMode(), problemCodeFromHubBody(e.getBody()));
+		}
+		catch (RuntimeException e) {
+			log.warn("Hub provider turn failed for request {}", request.getRequestId(), e);
+			return failed(events, sequence, request.getMode(), PROBLEM_PROVIDER_FAILURE);
+		}
+
+		if (streamError.get() != null) {
+			return CompletableFuture.completedFuture(
+					TurnResult.error(PROVIDER_ID, request.getMode(), streamError.get()));
+		}
+		if (!doneSeen[0]) {
+			return failed(events, sequence, request.getMode(), PROBLEM_HUB_STREAM_INCOMPLETE);
+		}
+		AnswerEnvelope answer = latestAnswer.get();
+		if (answer == null) {
+			return failed(events, sequence, request.getMode(), PROBLEM_HUB_STREAM_INCOMPLETE);
+		}
+		return CompletableFuture.completedFuture(
+				TurnResult.done(PROVIDER_ID, request.getMode(), answer));
+	}
+
+	private void handleWire(HubWireEvent wire, TurnEventSink events, AtomicInteger sequence,
+			AtomicReference<AnswerEnvelope> latestAnswer, AtomicReference<String> streamError,
+			boolean[] doneSeen) {
+		String event = wire.getEvent();
+		if (event == null || event.isEmpty()) {
+			return;
+		}
+		if ("error".equals(event)) {
+			String code = problemCodeFromHubPayload(wire.getPayload());
+			events.accept(TurnEvent.error(sequence.getAndIncrement(), PROVIDER_ID, code));
+			streamError.set(code);
+			doneSeen[0] = true;
+			return;
+		}
+		if ("done".equals(event)) {
+			AnswerEnvelope answer = envelopeOrNull(wire.getPayload());
+			if (answer != null) {
+				latestAnswer.set(answer);
+			}
+			events.accept(TurnEvent.of(TurnEventType.TURN_DONE, sequence.getAndIncrement(), PROVIDER_ID));
+			doneSeen[0] = true;
+			return;
+		}
+		TurnEventType type = mapEvent(event);
+		if (type == null) {
+			return;
+		}
+		AnswerEnvelope answer = envelopeOrNull(wire.getPayload());
+		if (answer != null) {
+			latestAnswer.set(answer);
+			events.accept(TurnEvent.withAnswer(type, sequence.getAndIncrement(), PROVIDER_ID, answer));
+		} else if (type == TurnEventType.REASONING_DELTA || type == TurnEventType.ANSWER_DELTA) {
+			Object delta = wire.getPayload().get("delta");
+			events.accept(TurnEvent.delta(type, sequence.getAndIncrement(), PROVIDER_ID,
+					delta == null ? "" : String.valueOf(delta)));
+		} else {
+			events.accept(TurnEvent.of(type, sequence.getAndIncrement(), PROVIDER_ID));
+		}
+	}
+
+	private static TurnEventType mapEvent(String hubEvent) {
+		switch (hubEvent) {
+			case "reasoning_delta":
+			case "thinking":
+				return TurnEventType.REASONING_DELTA;
+			case "answer_delta":
+			case "token":
+				return TurnEventType.ANSWER_DELTA;
+			case "answer_done":
+				return TurnEventType.ANSWER_DONE;
+			case "answer_validation":
+				return TurnEventType.ANSWER_VALIDATION;
+			case "evidence_updated":
+			case "grounded":
+				return TurnEventType.EVIDENCE_UPDATED;
+			case "indepth_pending":
+				return TurnEventType.INDEPTH_PENDING;
+			case "indepth_done":
+				return TurnEventType.INDEPTH_DONE;
+			case "indepth_error":
+				return TurnEventType.INDEPTH_ERROR;
+			default:
+				return null;
+		}
+	}
+
+	private static AnswerEnvelope envelopeOrNull(Map<String, Object> payload) {
+		if (payload == null || !(payload.get("answer") instanceof String)) {
+			return null;
+		}
+		return AnswerEnvelope.fromPayload(payload);
+	}
+
+	private CompletionStage<TurnResult> failed(TurnEventSink events, AtomicInteger sequence,
+			ProviderMode mode, String problemCode) {
+		events.accept(TurnEvent.error(sequence.getAndIncrement(), PROVIDER_ID, problemCode));
+		return CompletableFuture.completedFuture(TurnResult.error(PROVIDER_ID, mode, problemCode));
+	}
+
+	private String configuredEndpoint() {
+		String endpoint = gp(ChartSearchAiConstants.GP_HUB_ENDPOINT_URL, "");
+		if (endpoint == null) {
+			return null;
+		}
+		endpoint = endpoint.trim();
+		return endpoint.isEmpty() ? null : endpoint;
+	}
+
+	@SuppressWarnings("unchecked")
+	static String problemCodeFromHubBody(String body) {
+		if (body == null || body.trim().isEmpty()) {
+			return "hub_rejected_request";
+		}
+		try {
+			Map<String, Object> envelope = MAPPER.readValue(body,
+					new TypeReference<Map<String, Object>>() {});
+			return problemCodeFromHubPayload(envelope);
+		}
+		catch (Exception ignored) {
+			return "hub_rejected_request";
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	static String problemCodeFromHubPayload(Map<String, Object> payload) {
+		if (payload == null) {
+			return "hub_rejected_request";
+		}
+		Object detail = payload.get("detail");
+		if (detail instanceof Map) {
+			Object code = ((Map<String, Object>) detail).get("code");
+			if (code != null && !String.valueOf(code).trim().isEmpty()) {
+				return String.valueOf(code).trim();
+			}
+		}
+		Object code = payload.get("code");
+		if (code != null && !String.valueOf(code).trim().isEmpty()) {
+			return String.valueOf(code).trim();
+		}
+		return "hub_rejected_request";
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProvider.java
@@ -25,6 +25,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 /**
  * Relays one med-agent-hub product-profile request and maps the hub's staged SSE wire onto the
@@ -35,6 +37,7 @@ import org.slf4j.LoggerFactory;
  * <p>There is never a silent fallback to the bundled provider. Failures end in one
  * {@code turn_error} with a normalized problem code.</p>
  */
+@Service("chartSearchAi.hubClinicalAnswerProvider")
 public class HubClinicalAnswerProvider implements ClinicalAnswerProvider {
 
 	public static final String PROVIDER_ID = "hub";
@@ -55,6 +58,7 @@ public class HubClinicalAnswerProvider implements ClinicalAnswerProvider {
 
 	private final HubStreamTransport transport;
 
+	@Autowired
 	public HubClinicalAnswerProvider(HubStreamTransport transport) {
 		this.transport = transport;
 	}
@@ -62,6 +66,11 @@ public class HubClinicalAnswerProvider implements ClinicalAnswerProvider {
 	/** Global-property read seam, overridable in tests. */
 	protected String gp(String property, String defaultValue) {
 		return Context.getAdministrationService().getGlobalProperty(property, defaultValue);
+	}
+
+	@Override
+	public String id() {
+		return PROVIDER_ID;
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProvider.java
@@ -11,6 +11,7 @@ package org.openmrs.module.chartsearchai.api.provider;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -114,12 +115,18 @@ public class HubClinicalAnswerProvider implements ClinicalAnswerProvider {
 		boolean[] doneSeen = { false };
 		try {
 			transport.stream(call,
-					wire -> handleWire(wire, events, sequence, latestAnswer, streamError, doneSeen));
+					wire -> handleWire(wire, events, sequence, latestAnswer, streamError, doneSeen), cancellation);
 		}
 		catch (HubTransportException e) {
 			return failed(events, sequence, request.getMode(), problemCodeFromHubBody(e.getBody()));
 		}
 		catch (RuntimeException e) {
+			if (cancellation.isCancelled() && latestAnswer.get() != null) {
+				AnswerEnvelope answer = withInDepthInterrupted(latestAnswer.get());
+				events.accept(TurnEvent.of(TurnEventType.TURN_DONE, sequence.getAndIncrement(), PROVIDER_ID));
+				return CompletableFuture.completedFuture(
+						TurnResult.done(PROVIDER_ID, request.getMode(), answer));
+			}
 			log.warn("Hub provider turn failed for request {}", request.getRequestId(), e);
 			return failed(events, sequence, request.getMode(), PROBLEM_PROVIDER_FAILURE);
 		}
@@ -203,6 +210,26 @@ public class HubClinicalAnswerProvider implements ClinicalAnswerProvider {
 			default:
 				return null;
 		}
+	}
+
+	/**
+	 * Rewrites a dangling {@code inDepth.status == "pending"} to {@code "failed"} before this
+	 * answer is persisted. The persisted record is the source of truth for every future reader
+	 * (audit review, a reload's hydration, another UI) — leaving it saying "pending" forever would
+	 * be a lie, since a cancelled turn's In-Depth will never actually finish generating.
+	 */
+	@SuppressWarnings("unchecked")
+	private static AnswerEnvelope withInDepthInterrupted(AnswerEnvelope answer) {
+		Object inDepth = answer.getPayload().get("inDepth");
+		if (!(inDepth instanceof Map) || !"pending".equals(((Map<String, Object>) inDepth).get("status"))) {
+			return answer;
+		}
+		Map<String, Object> updatedInDepth = new LinkedHashMap<>((Map<String, Object>) inDepth);
+		updatedInDepth.put("status", "failed");
+		updatedInDepth.put("error", "In-Depth was interrupted.");
+		Map<String, Object> updatedPayload = new LinkedHashMap<>(answer.getPayload());
+		updatedPayload.put("inDepth", updatedInDepth);
+		return AnswerEnvelope.fromPayload(updatedPayload);
 	}
 
 	private static AnswerEnvelope envelopeOrNull(Map<String, Object> payload) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubStreamTransport.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubStreamTransport.java
@@ -1,0 +1,26 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.function.Consumer;
+
+/**
+ * Outbound med-agent-hub staged stream. Production uses HTTP SSE; tests inject a scripted
+ * implementation. Exactly one call is made per {@link HubClinicalAnswerProvider#execute}.
+ */
+public interface HubStreamTransport {
+
+	/**
+	 * Opens one hub product-profile stream and delivers parsed wire events in order.
+	 *
+	 * @throws HubTransportException for non-2xx hub HTTP responses
+	 */
+	void stream(HubCallRequest request, Consumer<HubWireEvent> sink);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubStreamTransport.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubStreamTransport.java
@@ -18,9 +18,12 @@ import java.util.function.Consumer;
 public interface HubStreamTransport {
 
 	/**
-	 * Opens one hub product-profile stream and delivers parsed wire events in order.
+	 * Opens one hub product-profile stream and delivers parsed wire events in order. Implementations
+	 * that hold a genuinely closeable resource (e.g. an open HTTP response body) should bind it to
+	 * {@code cancellation} via {@link TurnCancellation#bindCloseable} so a preempted turn's blocking
+	 * read gets forcibly unblocked instead of running to the hub's own natural completion.
 	 *
 	 * @throws HubTransportException for non-2xx hub HTTP responses
 	 */
-	void stream(HubCallRequest request, Consumer<HubWireEvent> sink);
+	void stream(HubCallRequest request, Consumer<HubWireEvent> sink, CancellationSignal cancellation);
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubTransportException.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubTransportException.java
@@ -1,0 +1,37 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+/**
+ * A non-success HTTP response from med-agent-hub. Carries the upstream status and raw body so the
+ * provider can extract the hub's machine-readable problem code without inventing one.
+ */
+public class HubTransportException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final int statusCode;
+
+	private final String body;
+
+	public HubTransportException(int statusCode, String body) {
+		super("Hub HTTP " + statusCode);
+		this.statusCode = statusCode;
+		this.body = body == null ? "" : body;
+	}
+
+	public int getStatusCode() {
+		return statusCode;
+	}
+
+	public String getBody() {
+		return body;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubWireEvent.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/HubWireEvent.java
@@ -1,0 +1,36 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** One parsed med-agent-hub SSE event before mapping onto {@link TurnEventType}. */
+public final class HubWireEvent {
+
+	private final String event;
+
+	private final Map<String, Object> payload;
+
+	public HubWireEvent(String event, Map<String, Object> payload) {
+		this.event = event;
+		this.payload = payload == null ? Collections.emptyMap()
+				: Collections.unmodifiableMap(new LinkedHashMap<>(payload));
+	}
+
+	public String getEvent() {
+		return event;
+	}
+
+	public Map<String, Object> getPayload() {
+		return payload;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderCapability.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderCapability.java
@@ -1,0 +1,71 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+/**
+ * A capability a clinical answer provider truthfully advertises. Optional turn events are
+ * capability-driven: a provider may only emit an optional {@link TurnEventType} when it advertises
+ * the capability that covers it (see {@link TurnLifecycleValidator}), and the UI may only offer a
+ * feature a provider actually advertises. Wire names are the stable identifiers shared with the
+ * dual-provider conformance fixtures, the ESM, and med-agent-hub.
+ */
+public enum ProviderCapability {
+
+	/** Answers patient-chart questions. Every usable provider advertises this. */
+	ANSWER("answer"),
+
+	/** Streams incremental answer and reasoning text while the answer is generated. */
+	TOKEN_STREAMING("token_streaming"),
+
+	/** Runs a deterministic post-answer check (temporal/citation gates) on the final answer. */
+	ANSWER_CHECK("answer_check"),
+
+	/** Runs an asynchronous post-answer review whose verdict may arrive after the answer. */
+	ANSWER_REVIEW("answer_review"),
+
+	/** Produces an asynchronous In-Depth elaboration after the primary answer. */
+	INDEPTH("indepth"),
+
+	/** Verifies that cited records actually support the answer text. */
+	GROUNDING("grounding"),
+
+	/** Raises deterministic drug-safety advisories alongside the answer. */
+	DRUG_SAFETY("drug_safety"),
+
+	/** Emits structured answer blocks beyond plain text. */
+	STRUCTURED_BLOCKS("structured_blocks"),
+
+	/** Carries prior clinical turns of the conversation into a new request. */
+	MULTI_TURN_CONTEXT("multi_turn_context");
+
+	private final String wireName;
+
+	ProviderCapability(String wireName) {
+		this.wireName = wireName;
+	}
+
+	public String getWireName() {
+		return wireName;
+	}
+
+	/**
+	 * Resolves a stable wire name (e.g. {@code "answer_review"}) to its capability.
+	 *
+	 * @throws IllegalArgumentException when the name is not a known capability
+	 */
+	public static ProviderCapability fromWireName(String wireName) {
+		for (ProviderCapability capability : values()) {
+			if (capability.wireName.equals(wireName)) {
+				return capability;
+			}
+		}
+		throw new IllegalArgumentException("Unknown provider capability: " + wireName);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderDescriptor.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderDescriptor.java
@@ -1,0 +1,92 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Immutable, truthful self-description of a clinical answer provider: identity, availability,
+ * offered modes, and advertised capabilities. The UI derives everything it shows — picker
+ * presence, disabled states, feature availability — from descriptors; it never infers an
+ * unadvertised capability, and an unavailable configured provider stays visible with its
+ * {@link #getUnavailableReason() reason} rather than silently disappearing.
+ */
+public final class ProviderDescriptor {
+
+	private final String id;
+
+	private final String label;
+
+	private final boolean enabled;
+
+	private final boolean ready;
+
+	private final boolean isDefault;
+
+	private final List<ProviderMode> modes;
+
+	private final Set<ProviderCapability> capabilities;
+
+	private final String unavailableReason;
+
+	public ProviderDescriptor(String id, String label, boolean enabled, boolean ready, boolean isDefault,
+			List<ProviderMode> modes, Set<ProviderCapability> capabilities, String unavailableReason) {
+		this.id = id;
+		this.label = label;
+		this.enabled = enabled;
+		this.ready = ready;
+		this.isDefault = isDefault;
+		this.modes = Collections.unmodifiableList(new java.util.ArrayList<>(modes));
+		this.capabilities = Collections.unmodifiableSet(capabilities.isEmpty()
+				? EnumSet.noneOf(ProviderCapability.class) : EnumSet.copyOf(capabilities));
+		this.unavailableReason = unavailableReason;
+	}
+
+	/** Stable provider identifier persisted on conversations (e.g. {@code "bundled"}, {@code "hub"}). */
+	public String getId() {
+		return id;
+	}
+
+	/** Human-readable provider name for the picker. */
+	public String getLabel() {
+		return label;
+	}
+
+	/** Whether configuration enables this provider at all. */
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	/** Whether the provider can currently serve a turn (e.g. its backend is reachable). */
+	public boolean isReady() {
+		return ready;
+	}
+
+	/** Whether this provider is the configured default. */
+	public boolean isDefault() {
+		return isDefault;
+	}
+
+	public List<ProviderMode> getModes() {
+		return modes;
+	}
+
+	public Set<ProviderCapability> getCapabilities() {
+		return capabilities;
+	}
+
+	/** Why the provider is not usable right now; {@code null} when enabled and ready. */
+	public String getUnavailableReason() {
+		return unavailableReason;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderMode.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderMode.java
@@ -1,0 +1,49 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+/**
+ * A context mode a provider offers for building the evidence a question is answered from. Both
+ * providers expose their modes through this one vocabulary so the UI and persistence layer never
+ * need provider-specific mode names. Wire names are shared with the dual-provider conformance
+ * contract.
+ */
+public enum ProviderMode {
+
+	/** Question-aware evidence slice: mandatory safety evidence plus records relevant to the question. */
+	QUERY_SCOPED("query_scoped"),
+
+	/** The complete deterministic patient ledger in stable bytes; fits or fails explicitly. */
+	FULL_CHART_STABLE("full_chart_stable");
+
+	private final String wireName;
+
+	ProviderMode(String wireName) {
+		this.wireName = wireName;
+	}
+
+	public String getWireName() {
+		return wireName;
+	}
+
+	/**
+	 * Resolves a stable wire name (e.g. {@code "query_scoped"}) to its mode.
+	 *
+	 * @throws IllegalArgumentException when the name is not a known mode
+	 */
+	public static ProviderMode fromWireName(String wireName) {
+		for (ProviderMode mode : values()) {
+			if (mode.wireName.equals(wireName)) {
+				return mode;
+			}
+		}
+		throw new IllegalArgumentException("Unknown provider mode: " + wireName);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderUnavailableException.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/ProviderUnavailableException.java
@@ -1,0 +1,31 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+/**
+ * A requested provider cannot serve a turn. Carries the normalized machine-readable problem code
+ * ({@code unknown_provider}, {@code provider_not_enabled}, or {@code provider_not_ready}) so the
+ * REST layer maps it to one canonical error instead of falling back to a different provider.
+ */
+public class ProviderUnavailableException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String problemCode;
+
+	public ProviderUnavailableException(String problemCode, String message) {
+		super(message);
+		this.problemCode = problemCode;
+	}
+
+	public String getProblemCode() {
+		return problemCode;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnCancellation.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnCancellation.java
@@ -1,0 +1,73 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link CancellationSignal} that can also forcibly interrupt whatever blocking resource a
+ * provider is currently waiting on. {@code isCancelled()} alone is enough for the "check at my
+ * next natural checkpoint" contract {@link CancellationSignal} documents, but a provider blocked
+ * inside one long synchronous call (e.g. {@link HttpHubStreamTransport} reading an SSE response
+ * body) has no such checkpoint to poll — it has to be unblocked from another thread. Binding the
+ * open {@link Closeable} here lets {@link #cancel()} do exactly that: closing it causes the
+ * blocked read to fail with an {@code IOException}, which also tears down the underlying HTTP
+ * connection to the far side (letting it observe the disconnect and free its own resources).
+ */
+public final class TurnCancellation implements CancellationSignal {
+
+	private static final Logger log = LoggerFactory.getLogger(TurnCancellation.class);
+
+	private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+	private final AtomicReference<Closeable> resource = new AtomicReference<>();
+
+	@Override
+	public boolean isCancelled() {
+		return cancelled.get();
+	}
+
+	/**
+	 * Registers the resource to force-close if this turn is cancelled. If this turn was already
+	 * cancelled before anything was bound (a fast preempt racing the provider's own setup), the
+	 * resource is closed immediately instead of being held.
+	 */
+	public void bindCloseable(Closeable closeable) {
+		resource.set(closeable);
+		if (cancelled.get()) {
+			closeQuietly(resource.getAndSet(null));
+		}
+	}
+
+	/** Cancels this turn and force-closes whatever resource is currently bound, if any. Idempotent. */
+	public void cancel() {
+		if (cancelled.compareAndSet(false, true)) {
+			closeQuietly(resource.getAndSet(null));
+		}
+	}
+
+	private static void closeQuietly(Closeable closeable) {
+		if (closeable == null) {
+			return;
+		}
+		try {
+			closeable.close();
+		}
+		catch (IOException e) {
+			log.debug("Ignoring close failure while cancelling a turn", e);
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEvent.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEvent.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.module.chartsearchai.api.provider;
 
-import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
-
 /**
  * One event in a provider turn's canonical lifecycle, as delivered to a {@link TurnEventSink}.
  * Which payload field is populated depends on the {@link TurnEventType}: delta events carry
@@ -28,12 +26,12 @@ public final class TurnEvent {
 
 	private final String textDelta;
 
-	private final ChartAnswer answer;
+	private final AnswerEnvelope answer;
 
 	private final String problemCode;
 
 	private TurnEvent(TurnEventType type, int sequence, String providerId, String textDelta,
-			ChartAnswer answer, String problemCode) {
+			AnswerEnvelope answer, String problemCode) {
 		this.type = type;
 		this.sequence = sequence;
 		this.providerId = providerId;
@@ -51,7 +49,7 @@ public final class TurnEvent {
 	}
 
 	public static TurnEvent withAnswer(TurnEventType type, int sequence, String providerId,
-			ChartAnswer answer) {
+			AnswerEnvelope answer) {
 		return new TurnEvent(type, sequence, providerId, null, answer, null);
 	}
 
@@ -77,7 +75,7 @@ public final class TurnEvent {
 	}
 
 	/** The answer as of this event; populated on {@code answer_done} and {@code evidence_updated}. */
-	public ChartAnswer getAnswer() {
+	public AnswerEnvelope getAnswer() {
 		return answer;
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEvent.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEvent.java
@@ -1,0 +1,88 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+
+/**
+ * One event in a provider turn's canonical lifecycle, as delivered to a {@link TurnEventSink}.
+ * Which payload field is populated depends on the {@link TurnEventType}: delta events carry
+ * {@link #getTextDelta()}, answer/evidence events carry {@link #getAnswer()}, and
+ * {@code turn_error} carries {@link #getProblemCode()}. Every event identifies its emitting
+ * provider and carries a per-turn monotonically increasing sequence number.
+ */
+public final class TurnEvent {
+
+	private final TurnEventType type;
+
+	private final int sequence;
+
+	private final String providerId;
+
+	private final String textDelta;
+
+	private final ChartAnswer answer;
+
+	private final String problemCode;
+
+	private TurnEvent(TurnEventType type, int sequence, String providerId, String textDelta,
+			ChartAnswer answer, String problemCode) {
+		this.type = type;
+		this.sequence = sequence;
+		this.providerId = providerId;
+		this.textDelta = textDelta;
+		this.answer = answer;
+		this.problemCode = problemCode;
+	}
+
+	public static TurnEvent of(TurnEventType type, int sequence, String providerId) {
+		return new TurnEvent(type, sequence, providerId, null, null, null);
+	}
+
+	public static TurnEvent delta(TurnEventType type, int sequence, String providerId, String textDelta) {
+		return new TurnEvent(type, sequence, providerId, textDelta, null, null);
+	}
+
+	public static TurnEvent withAnswer(TurnEventType type, int sequence, String providerId,
+			ChartAnswer answer) {
+		return new TurnEvent(type, sequence, providerId, null, answer, null);
+	}
+
+	public static TurnEvent error(int sequence, String providerId, String problemCode) {
+		return new TurnEvent(TurnEventType.TURN_ERROR, sequence, providerId, null, null, problemCode);
+	}
+
+	public TurnEventType getType() {
+		return type;
+	}
+
+	public int getSequence() {
+		return sequence;
+	}
+
+	public String getProviderId() {
+		return providerId;
+	}
+
+	/** Incremental answer or reasoning text; only populated on delta events. */
+	public String getTextDelta() {
+		return textDelta;
+	}
+
+	/** The answer as of this event; populated on {@code answer_done} and {@code evidence_updated}. */
+	public ChartAnswer getAnswer() {
+		return answer;
+	}
+
+	/** Normalized machine-readable failure code; only populated on {@code turn_error}. */
+	public String getProblemCode() {
+		return problemCode;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEventSink.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEventSink.java
@@ -1,0 +1,20 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+/**
+ * Receives a provider turn's events in emission order. Implementations relay them to the wire
+ * (e.g. SSE) or record them; providers call {@link #accept} synchronously and must emit a
+ * sequence {@link TurnLifecycleValidator} accepts for their advertised capabilities.
+ */
+public interface TurnEventSink {
+
+	void accept(TurnEvent event);
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEventType.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnEventType.java
@@ -1,0 +1,79 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+/**
+ * One event in the canonical provider turn lifecycle:
+ *
+ * <pre>
+ * turn_started -&gt; reasoning_delta* -&gt; answer_delta* -&gt; answer_done
+ *   -&gt; answer_validation? -&gt; evidence_updated? -&gt; indepth_pending?
+ *   -&gt; (indepth_done | indepth_error)? -&gt; (turn_done | turn_error)
+ * </pre>
+ *
+ * Every provider — bundled or hub — is normalized into this one contract so the ESM needs a
+ * single parser and reducer. {@code answer_done} and exactly one terminal event are required
+ * for a completed turn; the optional events are capability-driven (see
+ * {@link TurnLifecycleValidator}). Wire names are the stable identifiers shared with the
+ * dual-provider conformance fixtures.
+ */
+public enum TurnEventType {
+
+	TURN_STARTED("turn_started"),
+
+	REASONING_DELTA("reasoning_delta"),
+
+	ANSWER_DELTA("answer_delta"),
+
+	ANSWER_DONE("answer_done"),
+
+	ANSWER_VALIDATION("answer_validation"),
+
+	EVIDENCE_UPDATED("evidence_updated"),
+
+	INDEPTH_PENDING("indepth_pending"),
+
+	INDEPTH_DONE("indepth_done"),
+
+	INDEPTH_ERROR("indepth_error"),
+
+	TURN_DONE("turn_done"),
+
+	TURN_ERROR("turn_error");
+
+	private final String wireName;
+
+	TurnEventType(String wireName) {
+		this.wireName = wireName;
+	}
+
+	public String getWireName() {
+		return wireName;
+	}
+
+	/** Whether this event ends the turn. Exactly one terminal event is required, and it is last. */
+	public boolean isTerminal() {
+		return this == TURN_DONE || this == TURN_ERROR;
+	}
+
+	/**
+	 * Resolves a stable wire name (e.g. {@code "answer_done"}) to its event type.
+	 *
+	 * @throws IllegalArgumentException when the name is not a known event type
+	 */
+	public static TurnEventType fromWireName(String wireName) {
+		for (TurnEventType type : values()) {
+			if (type.wireName.equals(wireName)) {
+				return type;
+			}
+		}
+		throw new IllegalArgumentException("Unknown turn event type: " + wireName);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnLifecycleValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnLifecycleValidator.java
@@ -1,0 +1,160 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Validates one provider turn's ordered event sequence against the canonical lifecycle and the
+ * provider's advertised capabilities (see {@link TurnEventType} for the lifecycle and
+ * {@link ProviderCapability} for the capability-gating of optional events).
+ *
+ * <p>The rules it enforces:</p>
+ * <ol>
+ *   <li>A turn begins with exactly one {@code turn_started}.</li>
+ *   <li>A turn ends with exactly one terminal event ({@code turn_done} or {@code turn_error}),
+ *       and nothing follows it.</li>
+ *   <li>{@code turn_done} requires a preceding {@code answer_done}; {@code turn_error} does not,
+ *       because a turn may fail before any answer exists.</li>
+ *   <li>Events follow the canonical stage order; only the delta events may repeat, and the
+ *       reasoning stream ends once answer deltas begin.</li>
+ *   <li>Optional events require their advertised capability: deltas require
+ *       {@code token_streaming}; {@code answer_validation} requires {@code answer_check} or
+ *       {@code answer_review}; {@code evidence_updated} requires {@code grounding};
+ *       In-Depth events require {@code indepth}; producing an answer requires {@code answer}.</li>
+ *   <li>{@code indepth_done}/{@code indepth_error} require a preceding {@code indepth_pending},
+ *       and at most one of them may occur.</li>
+ * </ol>
+ */
+public final class TurnLifecycleValidator {
+
+	/** Canonical position of each event type; validation requires non-decreasing stages. */
+	private static final Map<TurnEventType, Integer> STAGES = new EnumMap<>(TurnEventType.class);
+
+	static {
+		STAGES.put(TurnEventType.TURN_STARTED, 0);
+		STAGES.put(TurnEventType.REASONING_DELTA, 1);
+		STAGES.put(TurnEventType.ANSWER_DELTA, 2);
+		STAGES.put(TurnEventType.ANSWER_DONE, 3);
+		STAGES.put(TurnEventType.ANSWER_VALIDATION, 4);
+		STAGES.put(TurnEventType.EVIDENCE_UPDATED, 5);
+		STAGES.put(TurnEventType.INDEPTH_PENDING, 6);
+		STAGES.put(TurnEventType.INDEPTH_DONE, 7);
+		STAGES.put(TurnEventType.INDEPTH_ERROR, 7);
+		STAGES.put(TurnEventType.TURN_DONE, 8);
+		STAGES.put(TurnEventType.TURN_ERROR, 8);
+	}
+
+	private TurnLifecycleValidator() {
+	}
+
+	/**
+	 * Checks a complete turn's event sequence.
+	 *
+	 * @param capabilities the capabilities the emitting provider advertises
+	 * @param events the turn's events in emission order
+	 * @return every violated lifecycle rule; empty when the sequence conforms
+	 */
+	public static List<String> violations(Set<ProviderCapability> capabilities, List<TurnEventType> events) {
+		List<String> violations = new ArrayList<>();
+
+		if (events == null || events.isEmpty()) {
+			violations.add("a turn must contain events");
+			return violations;
+		}
+		if (events.get(0) != TurnEventType.TURN_STARTED) {
+			violations.add("a turn must begin with turn_started");
+		}
+
+		Map<TurnEventType, Integer> counts = new EnumMap<>(TurnEventType.class);
+		int previousStage = -1;
+		boolean orderViolated = false;
+		int terminalIndex = -1;
+		for (int i = 0; i < events.size(); i++) {
+			TurnEventType event = events.get(i);
+			counts.merge(event, 1, Integer::sum);
+			int stage = STAGES.get(event);
+			if (stage < previousStage) {
+				orderViolated = true;
+			}
+			previousStage = stage;
+			if (event.isTerminal() && terminalIndex < 0) {
+				terminalIndex = i;
+			}
+		}
+		if (orderViolated) {
+			violations.add("events must follow the canonical stage order");
+		}
+
+		int terminalCount = count(counts, TurnEventType.TURN_DONE) + count(counts, TurnEventType.TURN_ERROR);
+		if (terminalCount == 0) {
+			violations.add("a turn must end with turn_done or turn_error");
+		} else if (terminalCount > 1) {
+			violations.add("a turn must contain exactly one terminal event");
+		} else if (terminalIndex != events.size() - 1) {
+			violations.add("no events may follow the terminal event");
+		}
+
+		for (TurnEventType onceOnly : new TurnEventType[] { TurnEventType.TURN_STARTED,
+				TurnEventType.ANSWER_DONE, TurnEventType.ANSWER_VALIDATION, TurnEventType.EVIDENCE_UPDATED,
+				TurnEventType.INDEPTH_PENDING }) {
+			if (count(counts, onceOnly) > 1) {
+				violations.add(onceOnly.getWireName() + " may occur at most once");
+			}
+		}
+
+		boolean answered = count(counts, TurnEventType.ANSWER_DONE) > 0;
+		if (count(counts, TurnEventType.TURN_DONE) > 0 && !answered) {
+			violations.add("turn_done requires a preceding answer_done");
+		}
+
+		int inDepthOutcomes = count(counts, TurnEventType.INDEPTH_DONE)
+				+ count(counts, TurnEventType.INDEPTH_ERROR);
+		if (inDepthOutcomes > 1) {
+			violations.add("at most one of indepth_done or indepth_error may occur");
+		}
+		if (inDepthOutcomes > 0 && count(counts, TurnEventType.INDEPTH_PENDING) == 0) {
+			violations.add("an In-Depth outcome requires a preceding indepth_pending");
+		}
+
+		requireCapability(violations, capabilities, ProviderCapability.ANSWER,
+				answered || count(counts, TurnEventType.ANSWER_DELTA) > 0,
+				"producing an answer");
+		requireCapability(violations, capabilities, ProviderCapability.TOKEN_STREAMING,
+				count(counts, TurnEventType.REASONING_DELTA) + count(counts, TurnEventType.ANSWER_DELTA) > 0,
+				"delta events");
+		if (count(counts, TurnEventType.ANSWER_VALIDATION) > 0
+				&& !capabilities.contains(ProviderCapability.ANSWER_CHECK)
+				&& !capabilities.contains(ProviderCapability.ANSWER_REVIEW)) {
+			violations.add("answer_validation requires the answer_check or answer_review capability");
+		}
+		requireCapability(violations, capabilities, ProviderCapability.GROUNDING,
+				count(counts, TurnEventType.EVIDENCE_UPDATED) > 0, "evidence_updated");
+		requireCapability(violations, capabilities, ProviderCapability.INDEPTH,
+				count(counts, TurnEventType.INDEPTH_PENDING) + inDepthOutcomes > 0, "In-Depth events");
+
+		return violations;
+	}
+
+	private static int count(Map<TurnEventType, Integer> counts, TurnEventType event) {
+		return counts.getOrDefault(event, 0);
+	}
+
+	private static void requireCapability(List<String> violations, Set<ProviderCapability> capabilities,
+			ProviderCapability required, boolean used, String usage) {
+		if (used && !capabilities.contains(required)) {
+			violations.add(usage + " requires the " + required.getWireName() + " capability");
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnPreemptionRegistry.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnPreemptionRegistry.java
@@ -1,0 +1,46 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks the one in-flight turn per conversation and cancels whichever turn currently holds that
+ * slot when a new turn starts for the same conversation. At most one turn is ever meant to be
+ * active per conversation (asking a new question always supersedes; two turns never run
+ * concurrently on purpose), so a new turn starting IS the preempt signal — there is no separate
+ * disconnect notification to wait for.
+ */
+public final class TurnPreemptionRegistry {
+
+	private final ConcurrentHashMap<String, TurnCancellation> inFlight = new ConcurrentHashMap<>();
+
+	/**
+	 * Registers a new in-flight turn for {@code conversationUuid}, cancelling whichever turn
+	 * currently holds that slot (if any). Returns the new turn's cancellation signal.
+	 */
+	public TurnCancellation begin(String conversationUuid) {
+		TurnCancellation next = new TurnCancellation();
+		TurnCancellation previous = inFlight.put(conversationUuid, next);
+		if (previous != null) {
+			previous.cancel();
+		}
+		return next;
+	}
+
+	/**
+	 * Clears the registry entry for a turn that has finished. Only removes the entry if it is
+	 * still {@code cancellation} — a newer turn may have already replaced it, and that newer
+	 * entry must survive this call.
+	 */
+	public void end(String conversationUuid, TurnCancellation cancellation) {
+		inFlight.remove(conversationUuid, cancellation);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnRequest.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnRequest.java
@@ -1,0 +1,64 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import org.openmrs.Patient;
+
+/**
+ * One turn's input to a {@link ClinicalAnswerProvider}. The common layer resolves and authorizes
+ * the patient before constructing a request, so providers receive an already-authorized
+ * {@link Patient} and never re-implement access control.
+ */
+public final class TurnRequest {
+
+	private final Patient patient;
+
+	private final String question;
+
+	private final String conversationId;
+
+	private final String requestId;
+
+	private final ProviderMode mode;
+
+	/**
+	 * @param mode the caller-requested context mode, or {@code null} to use the provider's
+	 *        configured default; a provider must fail explicitly rather than silently substitute
+	 *        a mode it does not offer
+	 */
+	public TurnRequest(Patient patient, String question, String conversationId, String requestId,
+			ProviderMode mode) {
+		this.patient = patient;
+		this.question = question;
+		this.conversationId = conversationId;
+		this.requestId = requestId;
+		this.mode = mode;
+	}
+
+	public Patient getPatient() {
+		return patient;
+	}
+
+	public String getQuestion() {
+		return question;
+	}
+
+	public String getConversationId() {
+		return conversationId;
+	}
+
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public ProviderMode getMode() {
+		return mode;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnRequest.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnRequest.java
@@ -9,7 +9,11 @@
  */
 package org.openmrs.module.chartsearchai.api.provider;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
 
 /**
  * One turn's input to a {@link ClinicalAnswerProvider}. The common layer resolves and authorizes
@@ -28,6 +32,10 @@ public final class TurnRequest {
 
 	private final ProviderMode mode;
 
+	private final String profileId;
+
+	private final List<PriorClinicalTurn> priorClinicalTurns;
+
 	/**
 	 * @param mode the caller-requested context mode, or {@code null} to use the provider's
 	 *        configured default; a provider must fail explicitly rather than silently substitute
@@ -35,11 +43,25 @@ public final class TurnRequest {
 	 */
 	public TurnRequest(Patient patient, String question, String conversationId, String requestId,
 			ProviderMode mode) {
+		this(patient, question, conversationId, requestId, mode, null, Collections.emptyList());
+	}
+
+	/**
+	 * @param profileId hub product-profile id when the selected provider requires one; ignored by
+	 *        providers that have no profile concept
+	 * @param priorClinicalTurns completed successful turns already owned by OpenMRS, replayed to
+	 *        a stateless engine as prose only
+	 */
+	public TurnRequest(Patient patient, String question, String conversationId, String requestId,
+			ProviderMode mode, String profileId, List<PriorClinicalTurn> priorClinicalTurns) {
 		this.patient = patient;
 		this.question = question;
 		this.conversationId = conversationId;
 		this.requestId = requestId;
 		this.mode = mode;
+		this.profileId = profileId;
+		this.priorClinicalTurns = priorClinicalTurns == null ? Collections.emptyList()
+				: Collections.unmodifiableList(priorClinicalTurns);
 	}
 
 	public Patient getPatient() {
@@ -60,5 +82,13 @@ public final class TurnRequest {
 
 	public ProviderMode getMode() {
 		return mode;
+	}
+
+	public String getProfileId() {
+		return profileId;
+	}
+
+	public List<PriorClinicalTurn> getPriorClinicalTurns() {
+		return priorClinicalTurns;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnResult.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnResult.java
@@ -1,0 +1,71 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+
+/**
+ * The final outcome of one provider turn: the terminal state, the final answer when the turn
+ * completed, and the normalized problem code when it failed. This is what the common layer
+ * persists and audits; the event stream carries the same information incrementally.
+ */
+public final class TurnResult {
+
+	private final String providerId;
+
+	private final ProviderMode mode;
+
+	private final TurnEventType terminalState;
+
+	private final ChartAnswer answer;
+
+	private final String problemCode;
+
+	private TurnResult(String providerId, ProviderMode mode, TurnEventType terminalState,
+			ChartAnswer answer, String problemCode) {
+		this.providerId = providerId;
+		this.mode = mode;
+		this.terminalState = terminalState;
+		this.answer = answer;
+		this.problemCode = problemCode;
+	}
+
+	public static TurnResult done(String providerId, ProviderMode mode, ChartAnswer answer) {
+		return new TurnResult(providerId, mode, TurnEventType.TURN_DONE, answer, null);
+	}
+
+	public static TurnResult error(String providerId, ProviderMode mode, String problemCode) {
+		return new TurnResult(providerId, mode, TurnEventType.TURN_ERROR, null, problemCode);
+	}
+
+	public String getProviderId() {
+		return providerId;
+	}
+
+	/** The context mode the turn actually ran with; {@code null} when the turn failed before one applied. */
+	public ProviderMode getMode() {
+		return mode;
+	}
+
+	/** {@link TurnEventType#TURN_DONE} or {@link TurnEventType#TURN_ERROR}. */
+	public TurnEventType getTerminalState() {
+		return terminalState;
+	}
+
+	/** The final (grounded, when grounding ran) answer; {@code null} on a failed turn. */
+	public ChartAnswer getAnswer() {
+		return answer;
+	}
+
+	/** Normalized machine-readable failure code; {@code null} on a completed turn. */
+	public String getProblemCode() {
+		return problemCode;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnResult.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/provider/TurnResult.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.module.chartsearchai.api.provider;
 
-import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
-
 /**
  * The final outcome of one provider turn: the terminal state, the final answer when the turn
  * completed, and the normalized problem code when it failed. This is what the common layer
@@ -24,12 +22,12 @@ public final class TurnResult {
 
 	private final TurnEventType terminalState;
 
-	private final ChartAnswer answer;
+	private final AnswerEnvelope answer;
 
 	private final String problemCode;
 
 	private TurnResult(String providerId, ProviderMode mode, TurnEventType terminalState,
-			ChartAnswer answer, String problemCode) {
+			AnswerEnvelope answer, String problemCode) {
 		this.providerId = providerId;
 		this.mode = mode;
 		this.terminalState = terminalState;
@@ -37,7 +35,7 @@ public final class TurnResult {
 		this.problemCode = problemCode;
 	}
 
-	public static TurnResult done(String providerId, ProviderMode mode, ChartAnswer answer) {
+	public static TurnResult done(String providerId, ProviderMode mode, AnswerEnvelope answer) {
 		return new TurnResult(providerId, mode, TurnEventType.TURN_DONE, answer, null);
 	}
 
@@ -60,7 +58,7 @@ public final class TurnResult {
 	}
 
 	/** The final (grounded, when grounding ran) answer; {@code null} on a failed turn. */
-	public ChartAnswer getAnswer() {
+	public AnswerEnvelope getAnswer() {
 		return answer;
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/ChartSearchAuditLog.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/ChartSearchAuditLog.java
@@ -46,6 +46,14 @@ public class ChartSearchAuditLog implements Serializable {
 
 	private String feedbackComment;
 
+	private String providerId;
+
+	private String providerMode;
+
+	private String conversationUuid;
+
+	private String requestId;
+
 	private Date dateCreated;
 
 	public Integer getAuditLogId() {
@@ -150,5 +158,41 @@ public class ChartSearchAuditLog implements Serializable {
 
 	public void setFeedbackComment(String feedbackComment) {
 		this.feedbackComment = feedbackComment;
+	}
+
+	/** Provider that produced this answer; nullable only for rows predating provider attribution. */
+	public String getProviderId() {
+		return providerId;
+	}
+
+	public void setProviderId(String providerId) {
+		this.providerId = providerId;
+	}
+
+	/** Provider mode used for the turn; nullable when the provider has no mode. */
+	public String getProviderMode() {
+		return providerMode;
+	}
+
+	public void setProviderMode(String providerMode) {
+		this.providerMode = providerMode;
+	}
+
+	/** Conversation UUID copied onto the audit row so attribution survives conversation retention. */
+	public String getConversationUuid() {
+		return conversationUuid;
+	}
+
+	public void setConversationUuid(String conversationUuid) {
+		this.conversationUuid = conversationUuid;
+	}
+
+	/** Request correlation id copied onto the audit row for trace reconstruction. */
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public void setRequestId(String requestId) {
+		this.requestId = requestId;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/ClinicalConversation.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/ClinicalConversation.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.UUID;
+
+import org.openmrs.Patient;
+import org.openmrs.User;
+
+/**
+ * Header for one provider-specific clinical conversation about a patient chart. Provider and mode
+ * are immutable conversation identity: selecting a different provider or changing context mode
+ * closes this conversation and starts another, preserving the original in history.
+ */
+public class ClinicalConversation implements Serializable {
+
+	public static final String STATUS_ACTIVE = "active";
+
+	public static final String STATUS_CLOSED = "closed";
+
+	public static final String STATUS_EXPIRED = "expired";
+
+	private static final long serialVersionUID = 1L;
+
+	private Integer conversationId;
+
+	private String uuid = UUID.randomUUID().toString();
+
+	private Patient patient;
+
+	private User user;
+
+	private String providerId;
+
+	private String providerMode;
+
+	private Date startedAt;
+
+	private Date lastActivityAt;
+
+	private Date endedAt;
+
+	private String title;
+
+	private String status = STATUS_ACTIVE;
+
+	public Integer getConversationId() {
+		return conversationId;
+	}
+
+	public void setConversationId(Integer conversationId) {
+		this.conversationId = conversationId;
+	}
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public Patient getPatient() {
+		return patient;
+	}
+
+	public void setPatient(Patient patient) {
+		this.patient = patient;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public void setUser(User user) {
+		this.user = user;
+	}
+
+	public String getProviderId() {
+		return providerId;
+	}
+
+	public void setProviderId(String providerId) {
+		this.providerId = providerId;
+	}
+
+	public String getProviderMode() {
+		return providerMode;
+	}
+
+	public void setProviderMode(String providerMode) {
+		this.providerMode = providerMode;
+	}
+
+	public Date getStartedAt() {
+		return startedAt;
+	}
+
+	public void setStartedAt(Date startedAt) {
+		this.startedAt = startedAt;
+	}
+
+	public Date getLastActivityAt() {
+		return lastActivityAt;
+	}
+
+	public void setLastActivityAt(Date lastActivityAt) {
+		this.lastActivityAt = lastActivityAt;
+	}
+
+	public Date getEndedAt() {
+		return endedAt;
+	}
+
+	public void setEndedAt(Date endedAt) {
+		this.endedAt = endedAt;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/model/ClinicalConversationTurn.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/model/ClinicalConversationTurn.java
@@ -1,0 +1,167 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.model;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * One user-question/provider-result pair in a {@link ClinicalConversation}. The canonical answer
+ * text is stored separately for display, audit, and history replay. {@code providerPayload} stores
+ * the complete serialized answer envelope without taking ownership of validation, evidence,
+ * safety, In-Depth, structured blocks, or provider extensions.
+ */
+public class ClinicalConversationTurn implements Serializable {
+
+	public static final String MEDIA_TYPE_JSON = "application/json";
+
+	private static final long serialVersionUID = 1L;
+
+	private Integer turnId;
+
+	private String uuid = UUID.randomUUID().toString();
+
+	private ClinicalConversation conversation;
+
+	private Integer ordinal;
+
+	private String requestId;
+
+	private String question;
+
+	private String answerText;
+
+	private String providerPayload;
+
+	private String payloadMediaType;
+
+	private String terminalState;
+
+	private String problemCode;
+
+	private Date startedAt;
+
+	private Date completedAt;
+
+	private ChartSearchAuditLog auditLog;
+
+	public Integer getTurnId() {
+		return turnId;
+	}
+
+	public void setTurnId(Integer turnId) {
+		this.turnId = turnId;
+	}
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public ClinicalConversation getConversation() {
+		return conversation;
+	}
+
+	public void setConversation(ClinicalConversation conversation) {
+		this.conversation = conversation;
+	}
+
+	public Integer getOrdinal() {
+		return ordinal;
+	}
+
+	public void setOrdinal(Integer ordinal) {
+		this.ordinal = ordinal;
+	}
+
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public void setRequestId(String requestId) {
+		this.requestId = requestId;
+	}
+
+	public String getQuestion() {
+		return question;
+	}
+
+	public void setQuestion(String question) {
+		this.question = question;
+	}
+
+	public String getAnswerText() {
+		return answerText;
+	}
+
+	public void setAnswerText(String answerText) {
+		this.answerText = answerText;
+	}
+
+	public String getProviderPayload() {
+		return providerPayload;
+	}
+
+	public void setProviderPayload(String providerPayload) {
+		this.providerPayload = providerPayload;
+	}
+
+	public String getPayloadMediaType() {
+		return payloadMediaType;
+	}
+
+	public void setPayloadMediaType(String payloadMediaType) {
+		this.payloadMediaType = payloadMediaType;
+	}
+
+	public String getTerminalState() {
+		return terminalState;
+	}
+
+	public void setTerminalState(String terminalState) {
+		this.terminalState = terminalState;
+	}
+
+	public String getProblemCode() {
+		return problemCode;
+	}
+
+	public void setProblemCode(String problemCode) {
+		this.problemCode = problemCode;
+	}
+
+	public Date getStartedAt() {
+		return startedAt;
+	}
+
+	public void setStartedAt(Date startedAt) {
+		this.startedAt = startedAt;
+	}
+
+	public Date getCompletedAt() {
+		return completedAt;
+	}
+
+	public void setCompletedAt(Date completedAt) {
+		this.completedAt = completedAt;
+	}
+
+	public ChartSearchAuditLog getAuditLog() {
+		return auditLog;
+	}
+
+	public void setAuditLog(ChartSearchAuditLog auditLog) {
+		this.auditLog = auditLog;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -104,12 +104,43 @@ public class DrugSafetyValidator {
 	 *  so a dose far from any drug name is ignored. */
 	private static final int MAX_ALIAS_TO_DOSE_DISTANCE = 120;
 
+	/** checked/limited/unavailable per the conformance contract: an empty warning list must never
+	 *  be read as "checked" when the check could not actually run. */
+	public static final String STATUS_CHECKED = "checked";
+
+	public static final String STATUS_LIMITED = "limited";
+
+	public static final String STATUS_UNAVAILABLE = "unavailable";
+
 	@Autowired
 	private DrugReferenceService drugReferenceService;
 
 	/** Test seam: production wires {@link DrugReferenceService} via {@link Autowired}. */
 	void setDrugReferenceService(DrugReferenceService drugReferenceService) {
 		this.drugReferenceService = drugReferenceService;
+	}
+
+	/** checked/limited/unavailable alongside the raised warnings (dual-provider-conformance.v1
+	 *  drug_safety_status) — the status-carrying superset of {@link #validate}. */
+	public static final class SafetyCheckResult {
+
+		private final String status;
+
+		private final List<SafetyWarning> warnings;
+
+		SafetyCheckResult(String status, List<SafetyWarning> warnings) {
+			this.status = status;
+			this.warnings = warnings;
+		}
+
+		/** One of {@link #STATUS_CHECKED}, {@link #STATUS_LIMITED}, {@link #STATUS_UNAVAILABLE}. */
+		public String getStatus() {
+			return status;
+		}
+
+		public List<SafetyWarning> getWarnings() {
+			return warnings;
+		}
 	}
 
 	/**
@@ -122,20 +153,57 @@ public class DrugSafetyValidator {
 	 * already exists.
 	 */
 	public List<SafetyWarning> validate(String answer, String question, Patient patient) {
+		return validateWithStatus(answer, question, patient).getWarnings();
+	}
+
+	/**
+	 * The status-carrying superset of {@link #validate(String, String, Patient)}. Unavailable when
+	 * the feature is disabled, there is no patient to build a clinical context from, or the check
+	 * raised; limited when a per-check GP toggle disabled a subset of dose/interaction/
+	 * contraindication checks; checked only when a full check ran to completion against a real
+	 * patient context.
+	 */
+	public SafetyCheckResult validateWithStatus(String answer, String question, Patient patient) {
 		try {
 			if (!ChartSearchAiUtils.isDrugReferenceEnabled()
 					|| !ChartSearchAiUtils.getBooleanGlobalProperty(
 							ChartSearchAiConstants.GP_DRUG_SAFETY_VALIDATE_ANSWERS,
 							ChartSearchAiConstants.DEFAULT_DRUG_SAFETY_VALIDATE_ANSWERS)) {
-				return new ArrayList<SafetyWarning>();
+				return new SafetyCheckResult(STATUS_UNAVAILABLE, new ArrayList<SafetyWarning>());
+			}
+			if (patient == null) {
+				return new SafetyCheckResult(STATUS_UNAVAILABLE, new ArrayList<SafetyWarning>());
 			}
 			PatientClinicalContext context = PatientClinicalContextBuilder.build(patient);
-			return validate(answer, question, context);
+			return validateWithStatus(answer, question, context);
 		}
 		catch (RuntimeException e) {
-			log.warn("Drug-safety validation failed; returning no warnings — the answer path is never broken", e);
-			return new ArrayList<SafetyWarning>();
+			log.warn("Drug-safety validation failed; returning unavailable status — the answer path is never broken", e);
+			return new SafetyCheckResult(STATUS_UNAVAILABLE, new ArrayList<SafetyWarning>());
 		}
+	}
+
+	/** Pure, testable status-aware check: honours all three per-check GP toggles. */
+	SafetyCheckResult validateWithStatus(String answer, String question, PatientClinicalContext context) {
+		boolean warnDose = toggle(ChartSearchAiConstants.GP_DRUG_SAFETY_WARN_ON_DOSE_EXCESS,
+				ChartSearchAiConstants.DEFAULT_DRUG_SAFETY_WARN_ON_DOSE_EXCESS);
+		boolean warnInteractions = toggle(ChartSearchAiConstants.GP_DRUG_SAFETY_WARN_ON_INTERACTIONS,
+				ChartSearchAiConstants.DEFAULT_DRUG_SAFETY_WARN_ON_INTERACTIONS);
+		boolean warnContra = toggle(ChartSearchAiConstants.GP_DRUG_SAFETY_WARN_ON_CONTRAINDICATIONS,
+				ChartSearchAiConstants.DEFAULT_DRUG_SAFETY_WARN_ON_CONTRAINDICATIONS);
+		return validateWithStatus(answer, question, context, warnDose, warnInteractions, warnContra);
+	}
+
+	/** As above, but with the three per-check toggles supplied explicitly (test seam — lets a
+	 *  fixture-driven "limited" scenario force a partial check without touching global properties). */
+	SafetyCheckResult validateWithStatus(String answer, String question, PatientClinicalContext context,
+			boolean warnDose, boolean warnInteractions, boolean warnContra) {
+		if (context == null) {
+			return new SafetyCheckResult(STATUS_UNAVAILABLE, new ArrayList<SafetyWarning>());
+		}
+		List<SafetyWarning> warnings = validate(answer, question, context, warnDose, warnInteractions, warnContra);
+		String status = (warnDose && warnInteractions && warnContra) ? STATUS_CHECKED : STATUS_LIMITED;
+		return new SafetyCheckResult(status, warnings);
 	}
 
 	/**
@@ -158,14 +226,19 @@ public class DrugSafetyValidator {
 	 * reads the dose from the answer, so a question-only drug with no stated dose yields no overdose.
 	 */
 	List<SafetyWarning> validate(String answer, String question, PatientClinicalContext context) {
-		List<SafetyWarning> warnings = new ArrayList<SafetyWarning>();
-
 		boolean warnDose = toggle(ChartSearchAiConstants.GP_DRUG_SAFETY_WARN_ON_DOSE_EXCESS,
 				ChartSearchAiConstants.DEFAULT_DRUG_SAFETY_WARN_ON_DOSE_EXCESS);
 		boolean warnInteractions = toggle(ChartSearchAiConstants.GP_DRUG_SAFETY_WARN_ON_INTERACTIONS,
 				ChartSearchAiConstants.DEFAULT_DRUG_SAFETY_WARN_ON_INTERACTIONS);
 		boolean warnContra = toggle(ChartSearchAiConstants.GP_DRUG_SAFETY_WARN_ON_CONTRAINDICATIONS,
 				ChartSearchAiConstants.DEFAULT_DRUG_SAFETY_WARN_ON_CONTRAINDICATIONS);
+		return validate(answer, question, context, warnDose, warnInteractions, warnContra);
+	}
+
+	/** As above, with the three per-check toggles supplied explicitly rather than read from GPs. */
+	private List<SafetyWarning> validate(String answer, String question, PatientClinicalContext context,
+			boolean warnDose, boolean warnInteractions, boolean warnContra) {
+		List<SafetyWarning> warnings = new ArrayList<SafetyWarning>();
 
 		String lower = answer == null ? "" : answer.toLowerCase(Locale.ROOT);
 		List<DrugReference> all = drugReferenceService.getAll();

--- a/api/src/main/resources/ChartSearchAuditLog.hbm.xml
+++ b/api/src/main/resources/ChartSearchAuditLog.hbm.xml
@@ -35,6 +35,14 @@
 
 		<property name="feedbackComment" column="feedback_comment" type="text"/>
 
+		<property name="providerId" column="provider_id" type="string" length="64"/>
+
+		<property name="providerMode" column="provider_mode" type="string" length="64"/>
+
+		<property name="conversationUuid" column="conversation_uuid" type="string" length="38"/>
+
+		<property name="requestId" column="request_id" type="string" length="100"/>
+
 	</class>
 
 </hibernate-mapping>

--- a/api/src/main/resources/ClinicalConversation.hbm.xml
+++ b/api/src/main/resources/ClinicalConversation.hbm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.chartsearchai.model">
+
+	<class name="ClinicalConversation" table="chartsearchai_conversation">
+
+		<id name="conversationId" column="conversation_id" type="int">
+			<generator class="native"/>
+		</id>
+
+		<property name="uuid" column="uuid" type="string" length="38" not-null="true" unique="true"/>
+
+		<many-to-one name="patient" class="org.openmrs.Patient" column="patient_id" not-null="true"/>
+
+		<many-to-one name="user" class="org.openmrs.User" column="user_id" not-null="true"/>
+
+		<property name="providerId" column="provider_id" type="string" length="64" not-null="true"/>
+
+		<property name="providerMode" column="provider_mode" type="string" length="64"/>
+
+		<property name="startedAt" column="started_at" type="timestamp" not-null="true"/>
+
+		<property name="lastActivityAt" column="last_activity_at" type="timestamp" not-null="true"/>
+
+		<property name="endedAt" column="ended_at" type="timestamp"/>
+
+		<property name="title" column="title" type="string" length="200"/>
+
+		<property name="status" column="status" type="string" length="20" not-null="true"/>
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/ClinicalConversationTurn.hbm.xml
+++ b/api/src/main/resources/ClinicalConversationTurn.hbm.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.chartsearchai.model">
+
+	<class name="ClinicalConversationTurn" table="chartsearchai_conversation_turn">
+
+		<id name="turnId" column="turn_id" type="int">
+			<generator class="native"/>
+		</id>
+
+		<property name="uuid" column="uuid" type="string" length="38" not-null="true" unique="true"/>
+
+		<many-to-one name="conversation" class="ClinicalConversation"
+				column="conversation_id" not-null="true"/>
+
+		<property name="ordinal" column="ordinal" type="int" not-null="true"/>
+
+		<property name="requestId" column="request_id" type="string" length="100" not-null="true"/>
+
+		<property name="question" column="question" type="text" not-null="true"/>
+
+		<property name="answerText" column="answer_text" type="text"/>
+
+		<property name="providerPayload" column="provider_payload" type="text"/>
+
+		<property name="payloadMediaType" column="payload_media_type" type="string" length="100"/>
+
+		<property name="terminalState" column="terminal_state" type="string" length="32"/>
+
+		<property name="problemCode" column="problem_code" type="string" length="100"/>
+
+		<property name="startedAt" column="started_at" type="timestamp" not-null="true"/>
+
+		<property name="completedAt" column="completed_at" type="timestamp"/>
+
+		<many-to-one name="auditLog" class="ChartSearchAuditLog" column="audit_log_id"/>
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -70,4 +70,130 @@
 		</createIndex>
 	</changeSet>
 
+	<changeSet id="chartsearchai-010" author="openmrs">
+		<comment>
+			Provider-neutral clinical conversations. A conversation is bound to one provider and
+			mode; selecting another provider or mode creates a new header while preserving history.
+			Each turn stores canonical answer text plus the complete provider envelope as opaque JSON.
+			Audit rows copy provider, mode, conversation, and request attribution so regulatory
+			history remains self-describing after shorter-lived conversation rows are purged.
+		</comment>
+
+		<addColumn tableName="chartsearchai_audit_log">
+			<column name="provider_id" type="varchar(64)"/>
+			<column name="provider_mode" type="varchar(64)"/>
+			<column name="conversation_uuid" type="char(38)"/>
+			<column name="request_id" type="varchar(100)"/>
+		</addColumn>
+		<createIndex tableName="chartsearchai_audit_log"
+				indexName="idx_chartsearchai_audit_log_conversation">
+			<column name="conversation_uuid"/>
+		</createIndex>
+		<createIndex tableName="chartsearchai_audit_log"
+				indexName="idx_chartsearchai_audit_log_request">
+			<column name="request_id"/>
+		</createIndex>
+
+		<createTable tableName="chartsearchai_conversation">
+			<column name="conversation_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true"
+						uniqueConstraintName="uk_chartsearchai_conversation_uuid"/>
+			</column>
+			<column name="patient_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="user_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="provider_id" type="varchar(64)">
+				<constraints nullable="false"/>
+			</column>
+			<column name="provider_mode" type="varchar(64)"/>
+			<column name="started_at" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+			<column name="last_activity_at" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+			<column name="ended_at" type="datetime"/>
+			<column name="title" type="varchar(200)"/>
+			<column name="status" type="varchar(20)" defaultValue="active">
+				<constraints nullable="false"/>
+			</column>
+		</createTable>
+		<addForeignKeyConstraint baseTableName="chartsearchai_conversation"
+				baseColumnNames="patient_id" referencedTableName="patient"
+				referencedColumnNames="patient_id"
+				constraintName="fk_chartsearchai_conversation_patient"/>
+		<addForeignKeyConstraint baseTableName="chartsearchai_conversation"
+				baseColumnNames="user_id" referencedTableName="users"
+				referencedColumnNames="user_id"
+				constraintName="fk_chartsearchai_conversation_user"/>
+		<createIndex tableName="chartsearchai_conversation"
+				indexName="idx_chartsearchai_conversation_lookup">
+			<column name="patient_id"/>
+			<column name="user_id"/>
+			<column name="status"/>
+			<column name="last_activity_at"/>
+		</createIndex>
+
+		<createTable tableName="chartsearchai_conversation_turn">
+			<column name="turn_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true"
+						uniqueConstraintName="uk_chartsearchai_conversation_turn_uuid"/>
+			</column>
+			<column name="conversation_id" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="ordinal" type="int">
+				<constraints nullable="false"/>
+			</column>
+			<column name="request_id" type="varchar(100)">
+				<constraints nullable="false"/>
+			</column>
+			<column name="question" type="text">
+				<constraints nullable="false"/>
+			</column>
+			<column name="answer_text" type="mediumtext"/>
+			<column name="provider_payload" type="mediumtext"/>
+			<column name="payload_media_type" type="varchar(100)"/>
+			<column name="terminal_state" type="varchar(32)"/>
+			<column name="problem_code" type="varchar(100)"/>
+			<column name="started_at" type="datetime">
+				<constraints nullable="false"/>
+			</column>
+			<column name="completed_at" type="datetime"/>
+			<column name="audit_log_id" type="int"/>
+		</createTable>
+		<addForeignKeyConstraint baseTableName="chartsearchai_conversation_turn"
+				baseColumnNames="conversation_id"
+				referencedTableName="chartsearchai_conversation"
+				referencedColumnNames="conversation_id"
+				constraintName="fk_chartsearchai_conversation_turn_conversation"/>
+		<addForeignKeyConstraint baseTableName="chartsearchai_conversation_turn"
+				baseColumnNames="audit_log_id"
+				referencedTableName="chartsearchai_audit_log"
+				referencedColumnNames="audit_log_id"
+				constraintName="fk_chartsearchai_conversation_turn_audit"
+				onDelete="SET NULL"/>
+		<addUniqueConstraint tableName="chartsearchai_conversation_turn"
+				columnNames="conversation_id,ordinal"
+				constraintName="uk_chartsearchai_conversation_turn_ordinal"/>
+		<createIndex tableName="chartsearchai_conversation_turn"
+				indexName="idx_chartsearchai_conversation_turn_history">
+			<column name="conversation_id"/>
+			<column name="completed_at"/>
+		</createIndex>
+		<createIndex tableName="chartsearchai_conversation_turn"
+				indexName="idx_chartsearchai_conversation_turn_request">
+			<column name="request_id"/>
+		</createIndex>
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/conversation/ConversationServicePersistenceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/conversation/ConversationServicePersistenceTest.java
@@ -1,0 +1,211 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.conversation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.api.AuditLogPurgeTask;
+import org.openmrs.module.chartsearchai.api.AuditLogService;
+import org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope;
+import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
+import org.openmrs.module.chartsearchai.api.provider.TurnEventType;
+import org.openmrs.module.chartsearchai.api.provider.TurnResult;
+import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Provider-neutral conversation persistence through the real Spring service, Hibernate mappings,
+ * Liquibase-created tables, and audit DAO. The tests deliberately use an unknown nested provider
+ * extension to prove Java stores the payload without taking ownership of its schema.
+ */
+public class ConversationServicePersistenceTest extends BaseModuleContextSensitiveTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@Autowired
+	private ConversationService conversationService;
+
+	@Autowired
+	private ConversationDAO conversationDAO;
+
+	@Autowired
+	private AuditLogService auditLogService;
+
+	private Patient patient;
+
+	@BeforeEach
+	public void setUp() {
+		patient = Context.getPatientService().getPatient(2);
+		assertNotNull(patient, "standard test patient 2 must exist");
+	}
+
+	@Test
+	public void reusesOnlyAnActiveConversationWithTheSameProviderAndMode() {
+		ClinicalConversation first = conversationService.openOrCreate(patient, "bundled",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversation same = conversationService.openOrCreate(patient, "bundled",
+				ProviderMode.QUERY_SCOPED);
+		assertEquals(first.getUuid(), same.getUuid());
+
+		ClinicalConversation switchedProvider = conversationService.openOrCreate(patient, "hub",
+				ProviderMode.QUERY_SCOPED);
+		assertNotEquals(first.getUuid(), switchedProvider.getUuid(),
+				"provider switching must start a new conversation");
+		assertEquals(ClinicalConversation.STATUS_CLOSED, first.getStatus());
+		assertEquals("hub", switchedProvider.getProviderId());
+		assertEquals(ProviderMode.QUERY_SCOPED.getWireName(), switchedProvider.getProviderMode());
+
+		ClinicalConversation switchedMode = conversationService.openOrCreate(patient, "hub",
+				ProviderMode.FULL_CHART_STABLE);
+		assertNotEquals(switchedProvider.getUuid(), switchedMode.getUuid(),
+				"changing context semantics must not silently reuse prior conversation state");
+		assertEquals(ClinicalConversation.STATUS_CLOSED, switchedProvider.getStatus());
+	}
+
+	@Test
+	public void completedTurnPersistsOpaquePayloadAndIndependentAuditAttribution() throws Exception {
+		ClinicalConversation conversation = conversationService.openOrCreate(patient, "hub",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversationTurn turn = conversationService.startTurn(conversation, "request-1",
+				"Can ibuprofen be used?");
+
+		Map<String, Object> providerExtension = new LinkedHashMap<>();
+		providerExtension.put("opaque", true);
+		providerExtension.put("futureValue", Collections.singletonMap("score", 0.73));
+		Map<String, Object> reference = new LinkedHashMap<>();
+		reference.put("resourceType", "obs");
+		reference.put("resourceUuid", "obs-1");
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", "Use caution [1].");
+		payload.put("references", Collections.singletonList(reference));
+		payload.put("answerValidation", Collections.singletonMap("status", "needs_review"));
+		payload.put("providerExtension", providerExtension);
+
+		conversationService.finishTurn(turn,
+				TurnResult.done("hub", ProviderMode.QUERY_SCOPED,
+						AnswerEnvelope.fromPayload(payload)),
+				125L);
+		String turnUuid = turn.getUuid();
+		Context.flushSession();
+		Context.clearSession();
+
+		ClinicalConversationTurn reloaded = conversationDAO.getTurnByUuid(turnUuid);
+		assertNotNull(reloaded);
+		assertEquals(TurnEventType.TURN_DONE.getWireName(), reloaded.getTerminalState());
+		assertEquals("Use caution [1].", reloaded.getAnswerText());
+		JsonNode stored = MAPPER.readTree(reloaded.getProviderPayload());
+		assertEquals(true, stored.get("providerExtension").get("opaque").asBoolean());
+		assertEquals(0.73,
+				stored.get("providerExtension").get("futureValue").get("score").asDouble());
+		assertEquals("needs_review",
+				stored.get("answerValidation").get("status").asText());
+
+		ChartSearchAuditLog audit = reloaded.getAuditLog();
+		assertNotNull(audit, "every accepted turn is independently auditable");
+		assertEquals("hub", audit.getProviderId());
+		assertEquals(ProviderMode.QUERY_SCOPED.getWireName(), audit.getProviderMode());
+		assertEquals(conversation.getUuid(), audit.getConversationUuid());
+		assertEquals("request-1", audit.getRequestId());
+		assertEquals("Use caution [1].", audit.getAnswer());
+		assertEquals(1, audit.getReferenceCount());
+
+		List<PriorClinicalTurn> prior = conversationService.priorClinicalTurns(
+				reloaded.getConversation());
+		assertEquals(1, prior.size());
+		assertEquals("Can ibuprofen be used?", prior.get(0).getQuestion());
+		assertEquals("Use caution [1].", prior.get(0).getAnswer());
+	}
+
+	@Test
+	public void failedTurnIsAuditedButNeverReplayedAsClinicalHistory() {
+		ClinicalConversation conversation = conversationService.openOrCreate(patient, "hub",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversationTurn turn = conversationService.startTurn(conversation, "request-failed",
+				"What medications is this patient on?");
+
+		conversationService.finishTurn(turn,
+				TurnResult.error("hub", ProviderMode.QUERY_SCOPED, "provider_timeout"), 5000L);
+
+		assertEquals(TurnEventType.TURN_ERROR.getWireName(), turn.getTerminalState());
+		assertEquals("provider_timeout", turn.getProblemCode());
+		assertNull(turn.getAnswerText());
+		assertNull(turn.getProviderPayload());
+		assertNotNull(turn.getAuditLog());
+		assertEquals("", turn.getAuditLog().getAnswer());
+		assertEquals(0, conversationService.priorClinicalTurns(conversation).size(),
+				"failed output cannot become context for a later clinical answer");
+	}
+
+	@Test
+	public void auditRetentionDoesNotDeleteAYoungerConversationTurn() {
+		ClinicalConversation conversation = conversationService.openOrCreate(patient, "bundled",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversationTurn turn = conversationService.startTurn(conversation, "request-retention",
+				"What medications is this patient on?");
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", "Lisinopril 10mg.");
+		payload.put("references", Collections.emptyList());
+		conversationService.finishTurn(turn,
+				TurnResult.done("bundled", ProviderMode.QUERY_SCOPED,
+						AnswerEnvelope.fromPayload(payload)),
+				10L);
+
+		turn.getAuditLog().setDateCreated(
+				new Date(System.currentTimeMillis() - 200L * 24L * 60L * 60L * 1000L));
+		auditLogService.saveAuditLog(turn.getAuditLog());
+		String turnUuid = turn.getUuid();
+		Context.flushSession();
+
+		new AuditLogPurgeTask().execute();
+		Context.flushSession();
+		Context.clearSession();
+
+		ClinicalConversationTurn survivor = conversationDAO.getTurnByUuid(turnUuid);
+		assertNotNull(survivor, "conversation history has an independent retention horizon");
+		assertNull(survivor.getAuditLog(),
+				"the audit link is nulled when its independently retained row is purged");
+		assertEquals("Lisinopril 10mg.", survivor.getAnswerText());
+	}
+
+	@Test
+	public void finishTurnRejectsProviderOrModeDriftFromTheConversation() {
+		ClinicalConversation conversation = conversationService.openOrCreate(patient, "bundled",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversationTurn providerDrift = conversationService.startTurn(conversation, "request-2", "q");
+		assertThrows(IllegalArgumentException.class,
+				() -> conversationService.finishTurn(providerDrift,
+						TurnResult.error("hub", ProviderMode.QUERY_SCOPED, "provider_failure"), 1L));
+
+		ClinicalConversationTurn modeDrift = conversationService.startTurn(conversation, "request-3", "q");
+		assertThrows(IllegalArgumentException.class,
+				() -> conversationService.finishTurn(modeDrift,
+						TurnResult.error("bundled", ProviderMode.FULL_CHART_STABLE, "provider_failure"), 1L));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/conversation/ConversationServicePersistenceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/conversation/ConversationServicePersistenceTest.java
@@ -10,10 +10,12 @@
 package org.openmrs.module.chartsearchai.api.conversation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.Date;
@@ -173,6 +175,45 @@ public class ConversationServicePersistenceTest extends BaseModuleContextSensiti
 		assertEquals("", turn.getAuditLog().getAnswer());
 		assertEquals(0, conversationService.priorClinicalTurns(conversation).size(),
 				"failed output cannot become context for a later clinical answer");
+	}
+
+	@Test
+	public void checkedAnswerIsAvailableForFollowUpBeforeTheInDepthTailCompletes() throws Exception {
+		ClinicalConversation conversation = conversationService.openOrCreate(patient, "hub",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversationTurn turn = conversationService.startTurn(conversation, "request-checked",
+				"What was the most recent visit date?");
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", "2026-01-26");
+		payload.put("answerValidation", Collections.singletonMap("status", "checked"));
+		payload.put("inDepth", Collections.singletonMap("status", "pending"));
+		assertTrue(conversationService.recordCheckedAnswer(turn, AnswerEnvelope.fromPayload(payload)));
+		assertNull(turn.getTerminalState(), "the In-Depth tail has not completed yet");
+		assertNull(turn.getAuditLog(), "only the terminal turn creates the immutable audit row");
+		Context.flushSession();
+		Context.clearSession();
+
+		List<PriorClinicalTurn> prior = conversationService.priorClinicalTurns(
+				conversationDAO.getTurnByUuid(turn.getUuid()).getConversation());
+		assertEquals(1, prior.size(),
+				"a checked answer must be usable as history while its optional In-Depth tail runs");
+		assertEquals("What was the most recent visit date?", prior.get(0).getQuestion());
+		assertEquals("2026-01-26", prior.get(0).getAnswer());
+	}
+
+	@Test
+	public void needsReviewAnswerNeverBecomesFollowUpContext() {
+		ClinicalConversation conversation = conversationService.openOrCreate(patient, "hub",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversationTurn turn = conversationService.startTurn(conversation, "request-needs-review",
+				"What was the most recent visit date?");
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", "Unreviewed answer");
+		payload.put("answerValidation", Collections.singletonMap("status", "needs_review"));
+
+		assertFalse(conversationService.recordCheckedAnswer(turn, AnswerEnvelope.fromPayload(payload)));
+		assertNull(turn.getAnswerText());
+		assertEquals(0, conversationService.priorClinicalTurns(conversation).size());
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/conversation/ConversationServicePersistenceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/conversation/ConversationServicePersistenceTest.java
@@ -90,6 +90,18 @@ public class ConversationServicePersistenceTest extends BaseModuleContextSensiti
 	}
 
 	@Test
+	public void startNewAlwaysClosesActiveConversationEvenWhenProviderAndModeMatch() {
+		ClinicalConversation first = conversationService.openOrCreate(patient, "bundled",
+				ProviderMode.QUERY_SCOPED);
+		ClinicalConversation fresh = conversationService.startNew(patient, "bundled",
+				ProviderMode.QUERY_SCOPED);
+		assertNotEquals(first.getUuid(), fresh.getUuid());
+		assertEquals(ClinicalConversation.STATUS_CLOSED, first.getStatus());
+		assertEquals(ClinicalConversation.STATUS_ACTIVE, fresh.getStatus());
+		assertEquals("bundled", fresh.getProviderId());
+	}
+
+	@Test
 	public void completedTurnPersistsOpaquePayloadAndIndependentAuditAttribution() throws Exception {
 		ClinicalConversation conversation = conversationService.openOrCreate(patient, "hub",
 				ProviderMode.QUERY_SCOPED);

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CountingQueryStoreStub.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CountingQueryStoreStub.java
@@ -62,6 +62,128 @@ final class CountingQueryStoreStub implements QueryStoreService {
 		return stubChart;
 	}
 
+	int getContextSliceCalls = 0;
+
+	org.openmrs.module.querystore.model.ContextSliceRequest lastSliceRequest;
+
+	String lastSliceQuestion;
+
+	/**
+	 * Delegates to the REAL {@code QueryStoreServiceImpl} slice policy over {@code stubChart} /
+	 * {@code stubHits} — the builder tests then exercise querystore's actual shared selection
+	 * (ADR Decision 17), not a re-implementation of it in test code. Counters and the captured
+	 * request stay chartsearchai-side so tests can pin the caller's question interpretation.
+	 */
+	@Override
+	public org.openmrs.module.querystore.model.ContextSlice getContextSlice(String patientUuid,
+			String question, org.openmrs.module.querystore.model.ContextSliceRequest request) {
+		getContextSliceCalls++;
+		lastSliceQuestion = question;
+		lastSliceRequest = request;
+		org.openmrs.module.querystore.api.impl.QueryStoreServiceImpl real =
+				new org.openmrs.module.querystore.api.impl.QueryStoreServiceImpl();
+		real.setBackend(new BridgeBackend());
+		return real.getContextSlice(patientUuid, question, request);
+	}
+
+	/** Serves {@code stubChart}/{@code stubHits} to the real slice impl, keeping the outer
+	 *  similarity counters/captures coherent with the direct {@code searchByPatient} path. */
+	private final class BridgeBackend implements org.openmrs.module.querystore.backend.BackendStore {
+
+		@Override
+		public boolean existsByPatient(String patientUuid) {
+			return true;
+		}
+
+		@Override
+		public List<QueryDocument> findAllByPatient(String patientUuid) {
+			return stubChart;
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.SearchResult hybrid(
+				org.openmrs.module.querystore.backend.SearchRequest req) {
+			searchByPatientCalls++;
+			lastSearchTopK = req.getLimit();
+			lastSearchQuery = req.getQueryText();
+			if (throwOnSearch) {
+				throw new RuntimeException("simulated similarity RPC failure");
+			}
+			List<org.openmrs.module.querystore.backend.Hit> out =
+					new ArrayList<org.openmrs.module.querystore.backend.Hit>();
+			for (int i = 0; i < stubHits.size(); i++) {
+				out.add(new org.openmrs.module.querystore.backend.Hit(stubHits.get(i), 1.0 - i * 0.1, i + 1));
+			}
+			return new org.openmrs.module.querystore.backend.SearchResult(out);
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.SearchResult bm25(
+				org.openmrs.module.querystore.backend.SearchRequest req) {
+			return hybrid(req);
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.SearchResult knn(
+				org.openmrs.module.querystore.backend.SearchRequest req) {
+			return org.openmrs.module.querystore.backend.SearchResult.empty();
+		}
+
+		@Override
+		public void ensureSchema(String resourceType, org.openmrs.module.querystore.backend.SchemaSpec spec) {
+		}
+
+		@Override
+		public void deleteSchema(String resourceType) {
+		}
+
+		@Override
+		public WriteResult upsert(QueryDocument doc) {
+			return WriteResult.success();
+		}
+
+		@Override
+		public WriteResult delete(String resourceType, String resourceUuid) {
+			return WriteResult.success();
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.BulkWriteResult bulkUpsert(List<QueryDocument> docs) {
+			return new org.openmrs.module.querystore.backend.BulkWriteResult(docs.size(), docs.size(),
+					java.util.Collections.<org.openmrs.module.querystore.backend.DocFailure> emptyList());
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.BulkWriteResult bulkDelete(String resourceType,
+				List<String> uuids) {
+			return new org.openmrs.module.querystore.backend.BulkWriteResult(0, 0,
+					java.util.Collections.<org.openmrs.module.querystore.backend.DocFailure> emptyList());
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.BulkWriteResult bulkDeleteByPatient(String patientUuid) {
+			return new org.openmrs.module.querystore.backend.BulkWriteResult(0, 0,
+					java.util.Collections.<org.openmrs.module.querystore.backend.DocFailure> emptyList());
+		}
+
+		@Override
+		public long countByType(String resourceType) {
+			return stubChart.size();
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.BackendCapabilities capabilities() {
+			return new org.openmrs.module.querystore.backend.BackendCapabilities(false, false, false, 1_000_000,
+					java.util.EnumSet.allOf(org.openmrs.module.querystore.backend.Filter.Kind.class));
+		}
+
+		@Override
+		public org.openmrs.module.querystore.backend.HealthStatus health() {
+			return new org.openmrs.module.querystore.backend.HealthStatus(
+					org.openmrs.module.querystore.backend.HealthStatus.State.HEALTHY, null);
+		}
+	}
+
 	@Override
 	public List<QueryDocument> search(String question, int topK) {
 		throw new UnsupportedOperationException("not used by chartsearchai");

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/HubProfileServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/HubProfileServiceTest.java
@@ -1,0 +1,68 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
+
+public class HubProfileServiceTest extends BaseModuleContextSensitiveTest {
+
+	@Test
+	public void modelsUriDerivesFromTheOneConfiguredHubChatEndpoint() {
+		assertEquals("http://hub:8080/v1/models",
+				HubProfileService.modelsUri("http://hub:8080/v1/chat/completions").toString());
+		assertThrows(IllegalArgumentException.class,
+				() -> HubProfileService.modelsUri("http://hub:8080/other"));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void listProfilesRelaysHubMetadataWithoutCuratingIt() throws Exception {
+		String response = "{\"object\":\"list\",\"data\":[{"
+				+ "\"id\":\"single-e4b-checked\",\"label\":\"Fast checked E4B\","
+				+ "\"staged\":true,\"validation\":true,\"default\":true}]}";
+		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/v1/models", exchange -> {
+			byte[] body = response.getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(200, body.length);
+			try (OutputStream output = exchange.getResponseBody()) {
+				output.write(body);
+			}
+		});
+		server.start();
+		try {
+			Context.getAdministrationService().setGlobalProperty(
+					ChartSearchAiConstants.GP_HUB_ENDPOINT_URL,
+					"http://localhost:" + server.getAddress().getPort() + "/v1/chat/completions");
+			Map<String, Object> payload = new HubProfileService().listProfiles();
+			List<Map<String, Object>> profiles = (List<Map<String, Object>>) payload.get("data");
+			assertEquals(1, profiles.size());
+			assertEquals("Fast checked E4B", profiles.get(0).get("label"));
+			assertTrue((Boolean) profiles.get(0).get("default"));
+		}
+		finally {
+			server.stop(0);
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LocalLlmEngineTest.java
@@ -11,6 +11,7 @@ package org.openmrs.module.chartsearchai.api.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -633,6 +634,24 @@ public class LocalLlmEngineTest {
 		assertFalse(LocalLlmEngine.isContextOverflowError("not json at all"));
 		assertFalse(LocalLlmEngine.isContextOverflowError(""));
 		assertFalse(LocalLlmEngine.isContextOverflowError(null));
+	}
+
+	@Test
+	public void parseTokenizeResponse_countsTheTokensArray() throws Exception {
+		assertEquals(4, LlmResponseParser.parseTokenizeResponse("{\"tokens\":[1,2,3,4]}"));
+		assertEquals(0, LlmResponseParser.parseTokenizeResponse("{\"tokens\":[]}"));
+	}
+
+	@Test
+	public void parseTokenizeResponse_acceptsTheSummaryCountShapes() throws Exception {
+		assertEquals(7, LlmResponseParser.parseTokenizeResponse("{\"n_tokens\":7}"));
+	}
+
+	@Test
+	public void parseTokenizeResponse_rejectsAResponseWithNoTokenCount() {
+		assertThrows(IOException.class,
+				() -> LlmResponseParser.parseTokenizeResponse("{\"unrelated\":true}"));
+		assertThrows(IOException.class, () -> LlmResponseParser.parseTokenizeResponse("not json"));
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderBudgetTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderBudgetTest.java
@@ -1,0 +1,258 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.InsufficientContextException;
+import org.openmrs.module.chartsearchai.api.scope.QueryScopeContributor;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+import org.openmrs.module.querystore.QueryStoreConstants;
+import org.openmrs.module.querystore.model.QueryDocument;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * {@code context.mandatory-overflow-abstains}: mandatory clinical evidence (demographics,
+ * allergies, active conditions) is never droppable (ADR Decision 17), so when it alone exceeds
+ * the model's input budget the turn must abstain with {@link InsufficientContextException}
+ * rather than silently sending a truncated or oversized prompt. When mandatory content fits but
+ * the full slice does not, non-mandatory records are trimmed (a ceiling, not a target) while
+ * mandatory records and chart order are always preserved — mirrors med-agent-hub's
+ * {@code select_context}. Uses a fake {@link TokenCounter} (word count as token count, matching
+ * the fixture-driven hub test's own {@code ExactWordCounter}) — no live llama-server needed.
+ */
+public class QueryStoreChartBuilderBudgetTest {
+
+	private static Patient patient() {
+		Patient p = new Patient();
+		p.setPatientId(1);
+		p.setUuid("patient-uuid-1");
+		return p;
+	}
+
+	private static QueryDocument doc(String type, String uuid, String text, LocalDate date) {
+		QueryDocument d = new QueryDocument();
+		d.setResourceType(type);
+		d.setResourceUuid(uuid);
+		d.setText(text);
+		d.setDate(date);
+		return d;
+	}
+
+	private static String words(int count) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < count; i++) {
+			sb.append("word ");
+		}
+		return sb.toString().trim();
+	}
+
+	/** Word-count-as-token-count, matching the fixture-driven Python/Java adapters already in
+	 *  this codebase (test_dual_provider_conformance_adapter.py's _ExactWordCounter). */
+	private static final class FakeTokenCounter implements TokenCounter {
+
+		boolean available = true;
+
+		int budget = 100;
+
+		@Override
+		public boolean isAvailable() {
+			return available;
+		}
+
+		@Override
+		public int count(String text) {
+			return text == null || text.trim().isEmpty() ? 0 : text.trim().split("\\s+").length;
+		}
+
+		@Override
+		public int inputBudget() {
+			return budget;
+		}
+	}
+
+	private CountingQueryStoreStub queryStore;
+
+	private TestableScopedBuilder builder;
+
+	private FakeTokenCounter tokenCounter;
+
+	@BeforeEach
+	public void setUp() {
+		queryStore = new CountingQueryStoreStub();
+		builder = new TestableScopedBuilder(queryStore);
+		builder.setChartSerializer(new PatientChartSerializer());
+		tokenCounter = new FakeTokenCounter();
+		builder.setTokenCounter(tokenCounter);
+	}
+
+	private static List<String> mappedUuids(PatientChart chart) {
+		List<String> uuids = new ArrayList<String>();
+		for (RecordMapping mapping : chart.getMappings()) {
+			uuids.add(mapping.getResourceUuid());
+		}
+		return uuids;
+	}
+
+	@Test
+	public void mandatoryOverflowAbstainsPerFixture() throws IOException {
+		JsonNode fixtureCase = fixtureCase("context.mandatory-overflow-abstains");
+		int budgetTokens = fixtureCase.get("budget_tokens").asInt();
+		int mandatoryTokens = fixtureCase.get("mandatory_tokens").asInt();
+		tokenCounter.budget = budgetTokens;
+
+		queryStore.stubChart = new ArrayList<QueryDocument>(Collections.singletonList(
+				condition("cond-active", words(mandatoryTokens), LocalDate.of(2026, 1, 1), "ACTIVE")));
+
+		InsufficientContextException thrown = assertThrows(InsufficientContextException.class,
+				() -> builder.buildScoped(patient(), "anything?"));
+
+		assertTrue(thrown.getMandatoryRecordIds().contains("cond-active"),
+				"exceeding mandatory record must be named; got " + thrown.getMandatoryRecordIds());
+	}
+
+	@Test
+	public void mandatoryContentAloneFittingIsNeverAbstained() {
+		tokenCounter.budget = 100;
+		queryStore.stubChart = new ArrayList<QueryDocument>(Collections.singletonList(
+				condition("cond-active", words(10), LocalDate.of(2026, 1, 1), "ACTIVE")));
+
+		PatientChart chart = builder.buildScoped(patient(), "anything?");
+
+		assertTrue(mappedUuids(chart).contains("cond-active"));
+	}
+
+	@Test
+	public void excessOptionalContentIsTrimmedNotHardFailed() {
+		tokenCounter.budget = 50;
+		List<QueryDocument> chart = new ArrayList<QueryDocument>();
+		chart.add(condition("cond-active", words(5), LocalDate.of(2026, 6, 1), "ACTIVE"));
+		// Ten similarity-only records, 20 words each: fits none of them within budget alongside
+		// the mandatory record, individually or in combination once several are already selected.
+		for (int i = 0; i < 10; i++) {
+			chart.add(doc("obs", "sim-" + i, words(20), LocalDate.of(2026, 5, 1).minusDays(i)));
+		}
+		queryStore.stubChart = new ArrayList<QueryDocument>(chart);
+		queryStore.stubHits = new ArrayList<QueryDocument>(chart.subList(1, chart.size()));
+
+		PatientChart result = builder.buildScoped(patient(), "shoes?");
+
+		List<String> uuids = mappedUuids(result);
+		assertTrue(uuids.contains("cond-active"), "mandatory record must always survive trimming");
+		assertFalse(uuids.containsAll(similarityIds(10)),
+				"excess optional content must be trimmed, not all included; got " + uuids);
+	}
+
+	@Test
+	public void everythingFittingIsUnchangedFromTodaysBehavior() {
+		tokenCounter.budget = 10_000;
+		queryStore.stubChart = new ArrayList<QueryDocument>(Collections.singletonList(
+				condition("cond-active", words(5), LocalDate.of(2026, 1, 1), "ACTIVE")));
+
+		PatientChart chart = builder.buildScoped(patient(), "anything?");
+
+		assertTrue(mappedUuids(chart).contains("cond-active"));
+	}
+
+	@Test
+	public void counterUnavailableSkipsEnforcementEntirely() {
+		tokenCounter.available = false;
+		tokenCounter.budget = 1;
+		queryStore.stubChart = new ArrayList<QueryDocument>(Collections.singletonList(
+				condition("cond-active", words(500), LocalDate.of(2026, 1, 1), "ACTIVE")));
+
+		PatientChart chart = builder.buildScoped(patient(), "anything?");
+
+		assertTrue(mappedUuids(chart).contains("cond-active"),
+				"with no counter available, behavior must be unchanged from before this feature");
+	}
+
+	private static List<String> similarityIds(int count) {
+		List<String> ids = new ArrayList<String>();
+		for (int i = 0; i < count; i++) {
+			ids.add("sim-" + i);
+		}
+		return ids;
+	}
+
+	private static QueryDocument condition(String uuid, String text, LocalDate date, String status) {
+		QueryDocument d = doc("condition", uuid, text, date);
+		d.putMetadata(QueryStoreConstants.FIELD_CLINICAL_STATUS, status);
+		return d;
+	}
+
+	private static JsonNode fixtureCase(String id) throws IOException {
+		try (java.io.InputStream is = QueryStoreChartBuilderBudgetTest.class
+				.getResourceAsStream("/conformance/dual-provider-conformance.v1.json")) {
+			JsonNode root = new ObjectMapper().readTree(is);
+			for (JsonNode candidate : root.get("context_policy")) {
+				if (id.equals(candidate.get("id").asText())) {
+					return candidate;
+				}
+			}
+			throw new IllegalArgumentException("No context_policy fixture case '" + id + "'");
+		}
+	}
+
+	private static final class TestableScopedBuilder extends QueryStoreChartBuilder {
+
+		private final org.openmrs.module.querystore.api.QueryStoreService stub;
+
+		TestableScopedBuilder(org.openmrs.module.querystore.api.QueryStoreService stub) {
+			this.stub = stub;
+		}
+
+		@Override
+		protected List<QueryScopeContributor> resolveScopeContributors() {
+			return new ArrayList<QueryScopeContributor>();
+		}
+
+		@Override
+		protected org.openmrs.module.querystore.api.QueryStoreService resolveQueryStoreService() {
+			return stub;
+		}
+
+		@Override
+		protected int resolveQueryStoreTopK() {
+			return 20;
+		}
+
+		@Override
+		protected int resolveScopedRecencyAnchor() {
+			return 0;
+		}
+
+		@Override
+		protected boolean resolveUsePreFilter() {
+			return false;
+		}
+
+		@Override
+		protected boolean resolveDedupGroupLabels() {
+			return false;
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
@@ -38,7 +38,9 @@ import org.openmrs.module.querystore.model.QueryDocument;
  * <p>Contract under test:
  * <ul>
  *   <li>The slice = ALL records of the intent's typed scope (complete by construction)
- *       ∪ the similarity top-K ∪ the patient demographics record.</li>
+ *       ∪ the similarity top-K ∪ the mandatory clinical core (allergies + active conditions,
+ *       fixture {@code context.enumerated-medications-are-complete}) ∪ the patient
+ *       demographics record.</li>
  *   <li>Slice records keep the CHART's date-desc order (the "most recent first" contract the
  *       system prompt asserts), never the similarity ranking's order.</li>
  *   <li>A similarity failure degrades to the typed slice alone (never blocks the answer).</li>
@@ -103,7 +105,8 @@ public class QueryStoreChartBuilderScopedTest {
 		List<String> uuids = mappedUuids(chart);
 		assertTrue(uuids.containsAll(Arrays.asList("p-1", "o-1", "d-1", "d-2")),
 				"slice must carry the patient record, the similarity hit, and EVERY drug_order; got " + uuids);
-		assertFalse(uuids.contains("c-1"), "conditions are outside the medications scope");
+		assertTrue(uuids.containsAll(Arrays.asList("a-1", "c-1")),
+				"the mandatory clinical core (allergy + active condition) rides every slice; got " + uuids);
 		assertFalse(uuids.contains("o-3"), "records outside typed scope and similarity hits are excluded");
 		assertEquals(1, queryStore.getPatientChartCalls, "slice is filtered from the one chart fetch");
 	}
@@ -126,7 +129,7 @@ public class QueryStoreChartBuilderScopedTest {
 						+ "a medications cue matched too; got " + uuids);
 		assertTrue(uuids.containsAll(Arrays.asList("d-1", "d-2")),
 				"the medications side of the union stays complete as well; got " + uuids);
-		assertFalse(uuids.contains("c-1"), "unmatched types stay outside the union; got " + uuids);
+		assertFalse(uuids.contains("o-2"), "unmatched plain obs stay outside the union; got " + uuids);
 	}
 
 	@Test
@@ -181,9 +184,10 @@ public class QueryStoreChartBuilderScopedTest {
 
 		PatientChart chart = builder.buildScoped(patient(1), "What is the patient's most recent weight?");
 
-		assertEquals(Arrays.asList("p-1", "o-1", "d-1"), mappedUuids(chart),
+		assertEquals(Arrays.asList("p-1", "o-1", "d-1", "c-1", "a-1"), mappedUuids(chart),
 				"temporal slice must carry the 3 most recent chart records (the demographics "
-						+ "record is itself the newest, so it sits inside the anchor)");
+						+ "record is itself the newest, so it sits inside the anchor) plus the "
+						+ "mandatory clinical core, in chart date order");
 	}
 
 	@Test
@@ -196,8 +200,34 @@ public class QueryStoreChartBuilderScopedTest {
 
 		PatientChart chart = builder.buildScoped(patient(1), "Does the patient have any eye problems?");
 
-		assertEquals(Arrays.asList("p-1"), mappedUuids(chart),
-				"non-temporal topical question with no similarity hits reduces to demographics");
+		assertEquals(Arrays.asList("p-1", "c-1", "a-1"), mappedUuids(chart),
+				"non-temporal topical question carries no anchored vitals — only demographics "
+						+ "plus the mandatory clinical core");
+	}
+
+	@Test
+	public void buildScoped_shouldAlwaysCarryTheMandatoryClinicalCore() {
+		// Fixture context.enumerated-medications-are-complete (dual-provider-conformance.v1)
+		// pins mandatory_ids: patient + allergy for a MEDICATION question — the mandatory
+		// clinical core (allergies + ACTIVE conditions) is safety context every scoped slice
+		// carries regardless of matched intent. Measured 2026-07-22: a medication slice
+		// without the penicillin allergy record. Similarity returns NOTHING, so the core can
+		// only arrive via its mandatory status.
+		queryStore.stubChart.add(
+				doc("condition", "c-2", "Condition: Asthma. Status: INACTIVE", LocalDate.of(2026, 2, 1)));
+		queryStore.stubHits = new ArrayList<QueryDocument>();
+
+		PatientChart chart = builder.buildScoped(patient(1), "What medications is the patient taking?");
+
+		List<String> uuids = mappedUuids(chart);
+		assertTrue(uuids.contains("a-1"),
+				"the allergy record is mandatory clinical core in every slice; got " + uuids);
+		assertTrue(uuids.contains("c-1"),
+				"an ACTIVE condition is mandatory clinical core in every slice; got " + uuids);
+		assertFalse(uuids.contains("c-2"),
+				"an INACTIVE condition is not mandatory — only active problems ride every slice; got " + uuids);
+		assertFalse(uuids.contains("o-3"),
+				"plain obs outside typed scope and similarity stay excluded; got " + uuids);
 	}
 
 	@Test
@@ -355,8 +385,8 @@ public class QueryStoreChartBuilderScopedTest {
 
 		assertEquals(0, queryStore.searchByPatientCalls,
 				"blank question has no ranking signal — no similarity RPC");
-		assertEquals(Arrays.asList("p-1"), mappedUuids(chart),
-				"blank topical question reduces to the demographics record");
+		assertEquals(Arrays.asList("p-1", "c-1", "a-1"), mappedUuids(chart),
+				"blank topical question reduces to demographics plus the mandatory clinical core");
 	}
 
 	/** A test contributor claiming a fixed type set when the question contains a cue word. */

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
@@ -216,10 +216,11 @@ public class QueryStoreChartBuilderScopedTest {
 	}
 
 	@Test
-	public void buildScoped_delegatesSelectionToTheSharedQuerystoreSlice() {
-		// The shared context-selection contract (querystore ADR Decision 17; roadmap amendment
-		// 2026-07-22): selection runs ONCE in querystore's getContextSlice; this builder's job
-		// shrinks to question interpretation (intent types + temporal flag) and serialization.
+	public void buildScoped_delegatesSelectionAndInterpretationToTheSharedQuerystoreSlice() {
+		// The shared context contract (querystore ADR Decisions 17+18): selection AND question
+		// interpretation run ONCE in querystore — the RAW question goes over with
+		// interpretQuestion set, so cue routing and retrieval preprocessing cannot drift between
+		// consumers. This builder's own contributions: contributed scopes + the anchor knob.
 		queryStore.stubHits = new ArrayList<QueryDocument>();
 		builder.recencyAnchor = 3;
 
@@ -227,11 +228,13 @@ public class QueryStoreChartBuilderScopedTest {
 
 		assertEquals(1, queryStore.getContextSliceCalls,
 				"selection must go through the shared querystore slice contract");
-		assertTrue(queryStore.lastSliceRequest.getTypes().contains("drug_order"),
-				"the MEDICATIONS intent's typed scope rides the request; got "
+		assertTrue(queryStore.lastSliceRequest.isInterpretQuestion(),
+				"interpretation is querystore's — the request opts into server-side cues");
+		assertEquals("What is the patient's most recent medication?", queryStore.lastSliceQuestion,
+				"the RAW question goes over; preprocessing is querystore's now");
+		assertTrue(queryStore.lastSliceRequest.getTypes().isEmpty(),
+				"no locally-derived types — only contributed scopes would ride here; got "
 						+ queryStore.lastSliceRequest.getTypes());
-		assertTrue(queryStore.lastSliceRequest.isTemporal(),
-				"temporal phrasing rides the request as the caller's interpretation");
 		assertEquals(3, queryStore.lastSliceRequest.getRecencyAnchorSize());
 	}
 

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
@@ -65,6 +65,15 @@ public class QueryStoreChartBuilderScopedTest {
 		return d;
 	}
 
+	/** Condition documents carry their status as {@code clinical_status} METADATA — the real
+	 *  contract querystore's ConditionRecordSerializer emits and the shared slice's mandatory
+	 *  tier reads (no text sniffing). */
+	private static QueryDocument condition(String uuid, String text, LocalDate date, String status) {
+		QueryDocument d = doc("condition", uuid, text, date);
+		d.putMetadata(org.openmrs.module.querystore.QueryStoreConstants.FIELD_CLINICAL_STATUS, status);
+		return d;
+	}
+
 	private CountingQueryStoreStub queryStore;
 	private TestableScopedBuilder builder;
 
@@ -79,7 +88,7 @@ public class QueryStoreChartBuilderScopedTest {
 				doc("obs", "o-1", "Systolic blood pressure: 142 mmHg", LocalDate.of(2026, 6, 30)),
 				doc("drug_order", "d-1", "Drug order: Lisinopril 10 mg daily", LocalDate.of(2026, 6, 29)),
 				doc("obs", "o-2", "Serum creatinine: 90 umol/L", LocalDate.of(2026, 6, 28)),
-				doc("condition", "c-1", "Condition: Essential hypertension. Status: ACTIVE", LocalDate.of(2026, 6, 27)),
+				condition("c-1", "Condition: Essential hypertension. Status: ACTIVE", LocalDate.of(2026, 6, 27), "ACTIVE"),
 				doc("drug_order", "d-2", "Drug order: Amoxicillin 500 mg twice daily", LocalDate.of(2026, 5, 1)),
 				doc("allergy", "a-1", "Allergy: Penicillin. Reaction: rash", LocalDate.of(2026, 4, 2)),
 				doc("obs", "o-3", "Weight: 70 kg", LocalDate.of(2026, 3, 3))));
@@ -108,7 +117,8 @@ public class QueryStoreChartBuilderScopedTest {
 		assertTrue(uuids.containsAll(Arrays.asList("a-1", "c-1")),
 				"the mandatory clinical core (allergy + active condition) rides every slice; got " + uuids);
 		assertFalse(uuids.contains("o-3"), "records outside typed scope and similarity hits are excluded");
-		assertEquals(1, queryStore.getPatientChartCalls, "slice is filtered from the one chart fetch");
+		assertEquals(1, queryStore.getContextSliceCalls,
+				"one slice RPC; selection (and its single chart fetch) is querystore's job");
 	}
 
 	@Test
@@ -206,6 +216,26 @@ public class QueryStoreChartBuilderScopedTest {
 	}
 
 	@Test
+	public void buildScoped_delegatesSelectionToTheSharedQuerystoreSlice() {
+		// The shared context-selection contract (querystore ADR Decision 17; roadmap amendment
+		// 2026-07-22): selection runs ONCE in querystore's getContextSlice; this builder's job
+		// shrinks to question interpretation (intent types + temporal flag) and serialization.
+		queryStore.stubHits = new ArrayList<QueryDocument>();
+		builder.recencyAnchor = 3;
+
+		builder.buildScoped(patient(1), "What is the patient's most recent medication?");
+
+		assertEquals(1, queryStore.getContextSliceCalls,
+				"selection must go through the shared querystore slice contract");
+		assertTrue(queryStore.lastSliceRequest.getTypes().contains("drug_order"),
+				"the MEDICATIONS intent's typed scope rides the request; got "
+						+ queryStore.lastSliceRequest.getTypes());
+		assertTrue(queryStore.lastSliceRequest.isTemporal(),
+				"temporal phrasing rides the request as the caller's interpretation");
+		assertEquals(3, queryStore.lastSliceRequest.getRecencyAnchorSize());
+	}
+
+	@Test
 	public void buildScoped_shouldAlwaysCarryTheMandatoryClinicalCore() {
 		// Fixture context.enumerated-medications-are-complete (dual-provider-conformance.v1)
 		// pins mandatory_ids: patient + allergy for a MEDICATION question — the mandatory
@@ -214,7 +244,7 @@ public class QueryStoreChartBuilderScopedTest {
 		// without the penicillin allergy record. Similarity returns NOTHING, so the core can
 		// only arrive via its mandatory status.
 		queryStore.stubChart.add(
-				doc("condition", "c-2", "Condition: Asthma. Status: INACTIVE", LocalDate.of(2026, 2, 1)));
+				condition("c-2", "Condition: Asthma. Status: INACTIVE", LocalDate.of(2026, 2, 1), "INACTIVE"));
 		queryStore.stubHits = new ArrayList<QueryDocument>();
 
 		PatientChart chart = builder.buildScoped(patient(1), "What medications is the patient taking?");

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngineTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/RemoteLlmEngineTest.java
@@ -34,6 +34,26 @@ public class RemoteLlmEngineTest {
 	private final RemoteLlmEngine engine = new RemoteLlmEngine();
 
 	@Test
+	public void errorResponse_withContextOverflow_throwsChartTooLarge_notGenericApiException() {
+		// Explicit-overflow parity with LocalLlmEngine (roadmap G11): llama-server's
+		// exceed_context_size_error 400 must surface as chart_too_large through the provider,
+		// never as a generic provider_failure — the remote engine is the shared-engine parity
+		// configuration, so a silent generic error would hide every scoped-slice overflow.
+		org.openmrs.module.chartsearchai.api.ChartTooLargeException overflow =
+				org.junit.jupiter.api.Assertions.assertThrows(
+						org.openmrs.module.chartsearchai.api.ChartTooLargeException.class,
+						() -> RemoteLlmEngine.throwForErrorResponse(400,
+								"{\"error\":{\"type\":\"exceed_context_size_error\",\"message\":\"...\"}}"));
+		assertTrue(overflow.getMessage().contains("context window"),
+				"the operator remediation must name the context window; got " + overflow.getMessage());
+
+		org.junit.jupiter.api.Assertions.assertThrows(org.openmrs.api.APIException.class,
+				() -> RemoteLlmEngine.throwForErrorResponse(400, "{\"error\":\"bad request\"}"));
+		org.junit.jupiter.api.Assertions.assertThrows(org.openmrs.api.APIException.class,
+				() -> RemoteLlmEngine.throwForErrorResponse(503, ""));
+	}
+
+	@Test
 	public void buildRequestBody_shouldContainModelAndMessages() throws IOException {
 		String body = engine.buildRequestBody("system prompt", "user message", "gpt-4o", false);
 		JsonNode root = MAPPER.readTree(body);

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/AnswerEnvelopeTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/AnswerEnvelopeTest.java
@@ -1,0 +1,72 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the content-agnostic provider-answer boundary: Java understands only the canonical
+ * {@code answer} text needed for display, history replay, and audit; every other provider field is
+ * preserved unchanged for persistence and relay.
+ */
+public class AnswerEnvelopeTest {
+
+	@Test
+	public void preservesUnknownProviderFieldsWithoutReshapingThem() {
+		Map<String, Object> validation = new LinkedHashMap<>();
+		validation.put("status", "needs_review");
+		validation.put("futureProviderField", Collections.singletonMap("score", 0.73));
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", "Final answer");
+		payload.put("answerValidation", validation);
+		payload.put("providerExtension", Collections.singletonMap("opaque", true));
+
+		AnswerEnvelope envelope = AnswerEnvelope.fromPayload(payload);
+
+		assertEquals("Final answer", envelope.getText());
+		assertSame(validation, envelope.getPayload().get("answerValidation"),
+				"nested provider content is preserved, not converted to Java-owned domain types");
+		assertSame(payload.get("providerExtension"), envelope.getPayload().get("providerExtension"));
+	}
+
+	@Test
+	public void snapshotsTheTopLevelPayloadAndExposesItReadOnly() {
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", "Original");
+
+		AnswerEnvelope envelope = AnswerEnvelope.fromPayload(payload);
+		payload.put("answer", "Mutated");
+
+		assertEquals("Original", envelope.getText());
+		assertEquals("Original", envelope.getPayload().get("answer"));
+		assertThrows(UnsupportedOperationException.class,
+				() -> envelope.getPayload().put("newField", "not allowed"));
+	}
+
+	@Test
+	public void requiresCanonicalAnswerTextButDoesNotRequireAnyOptionalField() {
+		assertEquals("Only text",
+				AnswerEnvelope.fromPayload(Collections.<String, Object>singletonMap("answer", "Only text"))
+						.getText());
+		assertThrows(IllegalArgumentException.class,
+				() -> AnswerEnvelope.fromPayload(Collections.<String, Object>emptyMap()));
+		assertThrows(IllegalArgumentException.class,
+				() -> AnswerEnvelope.fromPayload(
+						Collections.<String, Object>singletonMap("answer", 42)));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
@@ -479,6 +479,49 @@ public class BundledClinicalAnswerProviderTest {
 	}
 
 	@Test
+	public void remoteEngineBehindAProxyWhoseUpstreamIsDownIsNotReady() throws Exception {
+		// A relay in front of the engine (tap/gateway) answers 502 when the engine is down —
+		// an HTTP response that must still count as NOT ready, or a dead engine hides behind
+		// its proxy.
+		com.sun.net.httpserver.HttpServer server = com.sun.net.httpserver.HttpServer
+				.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/", exchange -> {
+			exchange.sendResponseHeaders(502, -1);
+			exchange.close();
+		});
+		server.start();
+		try {
+			String endpoint = "http://127.0.0.1:" + server.getAddress().getPort()
+					+ "/v1/chat/completions";
+			BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+					new ScriptedChartSearchService()) {
+
+				@Override
+				protected String gp(String property, String defaultValue) {
+					if (ChartSearchAiConstants.GP_LLM_ENGINE.equals(property)) {
+						return ChartSearchAiConstants.LLM_ENGINE_REMOTE;
+					}
+					if (ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL.equals(property)) {
+						return endpoint;
+					}
+					if (ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME.equals(property)) {
+						return "gemma-e4b";
+					}
+					return defaultValue;
+				}
+			};
+
+			ProviderDescriptor descriptor = provider.descriptor();
+			assertFalse(descriptor.isReady(),
+					"a 5xx from the engine endpoint means the engine cannot serve");
+			assertTrue(descriptor.getUnavailableReason().contains("unreachable"));
+		}
+		finally {
+			server.stop(0);
+		}
+	}
+
+	@Test
 	public void localEngineWithAMissingModelFileIsNotReady() {
 		BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
 				new ScriptedChartSearchService()) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
@@ -1,0 +1,374 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.ChartSearchService;
+import org.openmrs.module.chartsearchai.api.ChartTooLargeException;
+
+/**
+ * {@link BundledClinicalAnswerProvider} adapts the bundled ChartSearchAI pipeline (the
+ * {@code ChartSearchService} router) onto the provider-neutral {@link ClinicalAnswerProvider}
+ * boundary without changing bundled behavior. These tests drive the adapter through the real
+ * production boundary — {@code execute} — with a scripted downstream service, and hold every
+ * emitted sequence to the canonical lifecycle the conformance fixture pins.
+ */
+public class BundledClinicalAnswerProviderTest {
+
+	private static final String QUESTION = "What medications is this patient on?";
+
+	private static Patient patient() {
+		Patient patient = new Patient();
+		patient.setUuid("patient-uuid-1");
+		return patient;
+	}
+
+	private static TurnRequest request() {
+		return new TurnRequest(patient(), QUESTION, "conversation-1", "request-1", null);
+	}
+
+	/** Collects every event the provider emits, in order. */
+	private static class CollectingSink implements TurnEventSink {
+
+		final List<TurnEvent> events = new ArrayList<>();
+
+		@Override
+		public void accept(TurnEvent event) {
+			events.add(event);
+		}
+
+		List<TurnEventType> types() {
+			return events.stream().map(TurnEvent::getType).collect(Collectors.toList());
+		}
+
+		TurnEvent single(TurnEventType type) {
+			List<TurnEvent> matches = events.stream().filter(e -> e.getType() == type)
+					.collect(Collectors.toList());
+			assertEquals(1, matches.size(), "expected exactly one " + type.getWireName());
+			return matches.get(0);
+		}
+	}
+
+	/**
+	 * Scripted stand-in for the bundled router: drives the streaming consumers exactly the way
+	 * the production {@code LlmInferenceService} does (reasoning, tokens, ungrounded answer,
+	 * then the grounded return), so the adapter is exercised against the real seam contract.
+	 */
+	private static class ScriptedChartSearchService implements ChartSearchService {
+
+		ChartAnswer ungrounded;
+
+		ChartAnswer groundedResult;
+
+		RuntimeException failure;
+
+		boolean fireUngroundedSeam = true;
+
+		@Override
+		public ChartAnswer search(Patient patient, String question) {
+			throw new UnsupportedOperationException("adapter must use the streaming path");
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer) {
+			throw new UnsupportedOperationException("adapter must use the full streaming overload");
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer,
+				Consumer<String> reasoningConsumer, Consumer<List<RecordReference>> citationsConsumer,
+				Consumer<ChartAnswer> ungroundedAnswerConsumer) {
+			return searchStreaming(patient, question, tokenConsumer, reasoningConsumer, citationsConsumer,
+					ungroundedAnswerConsumer, ignored -> {
+					});
+		}
+
+		@Override
+		public ChartAnswer searchStreaming(Patient patient, String question, Consumer<String> tokenConsumer,
+				Consumer<String> reasoningConsumer, Consumer<List<RecordReference>> citationsConsumer,
+				Consumer<ChartAnswer> ungroundedAnswerConsumer, Consumer<String> preliminaryReasoningConsumer) {
+			if (failure != null) {
+				throw failure;
+			}
+			preliminaryReasoningConsumer.accept("preview ");
+			reasoningConsumer.accept("thinking ");
+			tokenConsumer.accept("Aspirin ");
+			tokenConsumer.accept("81mg");
+			if (fireUngroundedSeam) {
+				citationsConsumer.accept(ungrounded.getReferences());
+				ungroundedAnswerConsumer.accept(ungrounded);
+			}
+			return groundedResult;
+		}
+	}
+
+	private static ChartSearchService.RecordReference reference(int index, Boolean grounded) {
+		return new ChartSearchService.RecordReference(index, "obs", "obs-uuid-" + index, new Date(), grounded);
+	}
+
+	private static ChartSearchService.ChartAnswer answer(String text,
+			List<ChartSearchService.RecordReference> references) {
+		return new ChartSearchService.ChartAnswer(text, references, 100, 20, 5);
+	}
+
+	/** Provider with grounding enabled so the full canonical lifecycle (evidence_updated) runs. */
+	private static BundledClinicalAnswerProvider provider(ChartSearchService service) {
+		return new BundledClinicalAnswerProvider(service) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				if (ChartSearchAiConstants.GP_GROUNDING_ENABLED.equals(property)) {
+					return "true";
+				}
+				return defaultValue;
+			}
+		};
+	}
+
+	/** Provider with every optional GP left at its upstream default (grounding and drug safety off). */
+	private static BundledClinicalAnswerProvider defaultConfigProvider(ChartSearchService service) {
+		return new BundledClinicalAnswerProvider(service) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				return defaultValue;
+			}
+		};
+	}
+
+	@Test
+	public void aLiveStreamedTurnEmitsTheCanonicalLifecycle() throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		service.ungrounded = answer("Aspirin 81mg [1]", Arrays.asList(reference(1, null)));
+		service.groundedResult = answer("Aspirin 81mg [1]", Arrays.asList(reference(1, Boolean.TRUE)));
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request(), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals(Arrays.asList(TurnEventType.TURN_STARTED, TurnEventType.REASONING_DELTA,
+				TurnEventType.REASONING_DELTA, TurnEventType.ANSWER_DELTA, TurnEventType.ANSWER_DELTA,
+				TurnEventType.ANSWER_DONE, TurnEventType.EVIDENCE_UPDATED, TurnEventType.TURN_DONE),
+				sink.types());
+		assertTrue(TurnLifecycleValidator
+				.violations(provider.descriptor().getCapabilities(), sink.types()).isEmpty(),
+				"emitted events must satisfy the provider's own advertised capabilities");
+
+		assertEquals("Aspirin ", sink.events.get(3).getTextDelta());
+		TurnEvent answerDone = sink.single(TurnEventType.ANSWER_DONE);
+		assertEquals("Aspirin 81mg [1]", answerDone.getAnswer().getAnswer());
+		assertNull(answerDone.getAnswer().getReferences().get(0).getGrounded(),
+				"answer_done fires before grounding, so verdicts are still null");
+		TurnEvent evidence = sink.single(TurnEventType.EVIDENCE_UPDATED);
+		assertEquals(Boolean.TRUE, evidence.getAnswer().getReferences().get(0).getGrounded());
+
+		assertEquals(TurnEventType.TURN_DONE, result.getTerminalState());
+		assertEquals(BundledClinicalAnswerProvider.PROVIDER_ID, result.getProviderId());
+		assertEquals(Boolean.TRUE, result.getAnswer().getReferences().get(0).getGrounded(),
+				"the result carries the grounded answer");
+		assertNull(result.getProblemCode());
+	}
+
+	@Test
+	public void everyEventCarriesTheProviderIdentityAndAMonotonicSequence() throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		service.ungrounded = answer("a", Collections.emptyList());
+		service.groundedResult = answer("a", Collections.emptyList());
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		provider.execute(request(), sink, CancellationSignal.NONE).toCompletableFuture().get();
+
+		int previous = -1;
+		for (TurnEvent event : sink.events) {
+			assertEquals(BundledClinicalAnswerProvider.PROVIDER_ID, event.getProviderId());
+			assertTrue(event.getSequence() > previous, "sequence must increase monotonically");
+			previous = event.getSequence();
+		}
+	}
+
+	@Test
+	public void aCachedAnswerEmitsAnswerDoneFromTheFinalResultWithoutASeparateEvidenceEvent()
+			throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		service.fireUngroundedSeam = false;
+		service.groundedResult = answer("cached [1]", Arrays.asList(reference(1, Boolean.TRUE)));
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request(), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		TurnEvent answerDone = sink.single(TurnEventType.ANSWER_DONE);
+		assertEquals("cached [1]", answerDone.getAnswer().getAnswer());
+		assertEquals(Boolean.TRUE, answerDone.getAnswer().getReferences().get(0).getGrounded(),
+				"a cached answer is already final, so answer_done carries its grounded verdicts");
+		assertFalse(sink.types().contains(TurnEventType.EVIDENCE_UPDATED),
+				"no separate evidence event when the answer arrived final");
+		assertEquals(TurnEventType.TURN_DONE, result.getTerminalState());
+	}
+
+	@Test
+	public void aPipelineFailureEndsInTurnErrorWithANormalizedProblemCode() throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		service.failure = new IllegalStateException("engine exploded");
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request(), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals(Arrays.asList(TurnEventType.TURN_STARTED, TurnEventType.TURN_ERROR), sink.types());
+		assertEquals("provider_failure", result.getProblemCode());
+		assertEquals(TurnEventType.TURN_ERROR, result.getTerminalState());
+		assertNull(result.getAnswer());
+		assertEquals("provider_failure", sink.single(TurnEventType.TURN_ERROR).getProblemCode());
+	}
+
+	@Test
+	public void aTooLargeChartMapsToItsOwnProblemCode() throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		service.failure = new ChartTooLargeException("chart exceeds context window");
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request(), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals("chart_too_large", result.getProblemCode());
+		assertEquals(TurnEventType.TURN_ERROR, result.getTerminalState());
+	}
+
+	@Test
+	public void theDescriptorAdvertisesBundledIdentityAndTruthfulDefaultCapabilities() {
+		BundledClinicalAnswerProvider provider = defaultConfigProvider(new ScriptedChartSearchService());
+
+		ProviderDescriptor descriptor = provider.descriptor();
+		assertEquals(BundledClinicalAnswerProvider.PROVIDER_ID, descriptor.getId());
+		assertNotNull(descriptor.getLabel());
+		assertTrue(descriptor.getCapabilities().contains(ProviderCapability.ANSWER));
+		assertTrue(descriptor.getCapabilities().contains(ProviderCapability.TOKEN_STREAMING));
+		assertFalse(descriptor.getCapabilities().contains(ProviderCapability.GROUNDING),
+				"grounding defaults off upstream, so it must not be advertised");
+		assertFalse(descriptor.getCapabilities().contains(ProviderCapability.DRUG_SAFETY),
+				"drug reference defaults off upstream, so it must not be advertised");
+		assertFalse(descriptor.getCapabilities().contains(ProviderCapability.INDEPTH),
+				"bundled has no In-Depth stage");
+		assertEquals(Collections.singletonList(ProviderMode.QUERY_SCOPED), descriptor.getModes(),
+				"bundled advertises the configured chart mode (queryScoped is the upstream default)");
+	}
+
+	@Test
+	public void groundingAndDrugSafetyCapabilitiesFollowTheirGlobalProperties() {
+		BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+				new ScriptedChartSearchService()) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				if (ChartSearchAiConstants.GP_GROUNDING_ENABLED.equals(property)
+						|| ChartSearchAiConstants.GP_DRUG_REFERENCE_ENABLED.equals(property)) {
+					return "true";
+				}
+				return defaultValue;
+			}
+		};
+
+		assertTrue(provider.descriptor().getCapabilities().contains(ProviderCapability.GROUNDING));
+		assertTrue(provider.descriptor().getCapabilities().contains(ProviderCapability.DRUG_SAFETY));
+	}
+
+	@Test
+	public void withGroundingOffTheAnswerIsFinalAtAnswerDoneAndNoEvidenceEventFollows()
+			throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		// With grounding off the pipeline returns the same answer the ungrounded seam carried.
+		service.ungrounded = answer("Aspirin 81mg [1]", Arrays.asList(reference(1, null)));
+		service.groundedResult = service.ungrounded;
+		BundledClinicalAnswerProvider provider = defaultConfigProvider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request(), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertFalse(sink.types().contains(TurnEventType.EVIDENCE_UPDATED),
+				"a provider that does not advertise grounding must not emit evidence_updated");
+		assertTrue(TurnLifecycleValidator
+				.violations(provider.descriptor().getCapabilities(), sink.types()).isEmpty());
+		assertEquals(TurnEventType.TURN_DONE, result.getTerminalState());
+	}
+
+	@Test
+	public void theConfiguredFullChartModeIsAdvertisedAsFullChartStable() {
+		BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+				new ScriptedChartSearchService()) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				if (ChartSearchAiConstants.GP_CHART_MODE.equals(property)) {
+					return ChartSearchAiConstants.CHART_MODE_FULL_CHART;
+				}
+				return defaultValue;
+			}
+		};
+
+		assertEquals(Collections.singletonList(ProviderMode.FULL_CHART_STABLE),
+				provider.descriptor().getModes());
+	}
+
+	@Test
+	public void aRequestForAModeTheProviderDoesNotOfferFailsExplicitlyInsteadOfSilentlySwitching()
+			throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		service.ungrounded = answer("a", Collections.emptyList());
+		service.groundedResult = answer("a", Collections.emptyList());
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnRequest fullChartRequest = new TurnRequest(patient(), QUESTION, "conversation-1", "request-1",
+				ProviderMode.FULL_CHART_STABLE);
+		TurnResult result = provider.execute(fullChartRequest, sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals(TurnEventType.TURN_ERROR, result.getTerminalState());
+		assertEquals("unsupported_mode", result.getProblemCode());
+	}
+
+	@Test
+	public void aCancelledRequestNeverReachesThePipeline() throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		// If cancellation is honored the pipeline never runs; if it runs anyway, this failure
+		// surfaces as provider_failure instead of cancelled and the assertion below catches it.
+		service.failure = new IllegalStateException("pipeline must not run after cancellation");
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request(), sink, () -> true).toCompletableFuture().get();
+
+		assertEquals(Arrays.asList(TurnEventType.TURN_STARTED, TurnEventType.TURN_ERROR), sink.types());
+		assertEquals("cancelled", result.getProblemCode());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -134,6 +135,11 @@ public class BundledClinicalAnswerProviderTest {
 		return new ChartSearchService.ChartAnswer(text, references, 100, 20, 5);
 	}
 
+	@SuppressWarnings("unchecked")
+	private static List<Map<String, Object>> references(AnswerEnvelope answer) {
+		return (List<Map<String, Object>>) answer.getPayload().get("references");
+	}
+
 	/** Provider with grounding enabled so the full canonical lifecycle (evidence_updated) runs. */
 	private static BundledClinicalAnswerProvider provider(ChartSearchService service) {
 		return new BundledClinicalAnswerProvider(service) {
@@ -180,16 +186,19 @@ public class BundledClinicalAnswerProviderTest {
 
 		assertEquals("Aspirin ", sink.events.get(3).getTextDelta());
 		TurnEvent answerDone = sink.single(TurnEventType.ANSWER_DONE);
-		assertEquals("Aspirin 81mg [1]", answerDone.getAnswer().getAnswer());
-		assertNull(answerDone.getAnswer().getReferences().get(0).getGrounded(),
+		assertEquals("Aspirin 81mg [1]", answerDone.getAnswer().getText());
+		assertNull(references(answerDone.getAnswer()).get(0).get("grounded"),
 				"answer_done fires before grounding, so verdicts are still null");
 		TurnEvent evidence = sink.single(TurnEventType.EVIDENCE_UPDATED);
-		assertEquals(Boolean.TRUE, evidence.getAnswer().getReferences().get(0).getGrounded());
+		assertEquals(Boolean.TRUE, references(evidence.getAnswer()).get(0).get("grounded"));
 
 		assertEquals(TurnEventType.TURN_DONE, result.getTerminalState());
 		assertEquals(BundledClinicalAnswerProvider.PROVIDER_ID, result.getProviderId());
-		assertEquals(Boolean.TRUE, result.getAnswer().getReferences().get(0).getGrounded(),
+		assertEquals(Boolean.TRUE, references(result.getAnswer()).get(0).get("grounded"),
 				"the result carries the grounded answer");
+		assertEquals(100, result.getAnswer().getPayload().get("inputTokens"));
+		assertEquals(20, result.getAnswer().getPayload().get("outputTokens"));
+		assertEquals(5, result.getAnswer().getPayload().get("cachedTokens"));
 		assertNull(result.getProblemCode());
 	}
 
@@ -224,8 +233,8 @@ public class BundledClinicalAnswerProviderTest {
 				.toCompletableFuture().get();
 
 		TurnEvent answerDone = sink.single(TurnEventType.ANSWER_DONE);
-		assertEquals("cached [1]", answerDone.getAnswer().getAnswer());
-		assertEquals(Boolean.TRUE, answerDone.getAnswer().getReferences().get(0).getGrounded(),
+		assertEquals("cached [1]", answerDone.getAnswer().getText());
+		assertEquals(Boolean.TRUE, references(answerDone.getAnswer()).get(0).get("grounded"),
 				"a cached answer is already final, so answer_done carries its grounded verdicts");
 		assertFalse(sink.types().contains(TurnEventType.EVIDENCE_UPDATED),
 				"no separate evidence event when the answer arrived final");

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
@@ -380,4 +380,144 @@ public class BundledClinicalAnswerProviderTest {
 		assertEquals(Arrays.asList(TurnEventType.TURN_STARTED, TurnEventType.TURN_ERROR), sink.types());
 		assertEquals("cancelled", result.getProblemCode());
 	}
+
+	// Readiness must reflect whether the configured engine is actually usable: a provider that
+	// advertises ready:true while its engine cannot serve breaks the picker AND every readiness
+	// gate downstream (registry.require rejects with provider_not_ready instead of failing
+	// mid-turn with provider_failure).
+
+	@Test
+	public void remoteEngineWithoutAnEndpointIsNotReady() {
+		BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+				new ScriptedChartSearchService()) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				if (ChartSearchAiConstants.GP_LLM_ENGINE.equals(property)) {
+					return ChartSearchAiConstants.LLM_ENGINE_REMOTE;
+				}
+				return defaultValue;
+			}
+		};
+
+		ProviderDescriptor descriptor = provider.descriptor();
+		assertFalse(descriptor.isReady());
+		assertTrue(descriptor.getUnavailableReason()
+				.contains(ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL));
+	}
+
+	@Test
+	public void remoteEngineWithAnUnreachableEndpointIsNotReady() {
+		BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+				new ScriptedChartSearchService()) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				if (ChartSearchAiConstants.GP_LLM_ENGINE.equals(property)) {
+					return ChartSearchAiConstants.LLM_ENGINE_REMOTE;
+				}
+				if (ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL.equals(property)) {
+					return "http://127.0.0.1:9/v1/chat/completions";
+				}
+				if (ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME.equals(property)) {
+					return "gemma-e4b";
+				}
+				return defaultValue;
+			}
+
+			@Override
+			protected boolean engineReachable(String endpointUrl) {
+				return false; // deterministic stand-in for a stopped engine server
+			}
+		};
+
+		ProviderDescriptor descriptor = provider.descriptor();
+		assertFalse(descriptor.isReady());
+		assertTrue(descriptor.getUnavailableReason().contains("unreachable"));
+	}
+
+	@Test
+	public void remoteEngineWithAReachableEndpointIsReady() throws Exception {
+		com.sun.net.httpserver.HttpServer server = com.sun.net.httpserver.HttpServer
+				.create(new java.net.InetSocketAddress("127.0.0.1", 0), 0);
+		// Any HTTP response proves the engine endpoint is up — a chat-completions URL
+		// answers GET with 405, which must still count as reachable.
+		server.createContext("/", exchange -> {
+			exchange.sendResponseHeaders(405, -1);
+			exchange.close();
+		});
+		server.start();
+		try {
+			String endpoint = "http://127.0.0.1:" + server.getAddress().getPort()
+					+ "/v1/chat/completions";
+			BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+					new ScriptedChartSearchService()) {
+
+				@Override
+				protected String gp(String property, String defaultValue) {
+					if (ChartSearchAiConstants.GP_LLM_ENGINE.equals(property)) {
+						return ChartSearchAiConstants.LLM_ENGINE_REMOTE;
+					}
+					if (ChartSearchAiConstants.GP_LLM_REMOTE_ENDPOINT_URL.equals(property)) {
+						return endpoint;
+					}
+					if (ChartSearchAiConstants.GP_LLM_REMOTE_MODEL_NAME.equals(property)) {
+						return "gemma-e4b";
+					}
+					return defaultValue;
+				}
+			};
+
+			ProviderDescriptor descriptor = provider.descriptor();
+			assertTrue(descriptor.isReady(),
+					"a live engine endpoint must probe as ready through the real reachability check");
+			assertNull(descriptor.getUnavailableReason());
+		}
+		finally {
+			server.stop(0);
+		}
+	}
+
+	@Test
+	public void localEngineWithAMissingModelFileIsNotReady() {
+		BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+				new ScriptedChartSearchService()) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				return defaultValue; // engine defaults to local
+			}
+
+			@Override
+			protected String requireLocalModel(String configuredPath) {
+				throw new IllegalStateException(
+						"Model file not found: /openmrs/data/chartsearchai/gemma-4-E4B-it-Q4_K_M.gguf");
+			}
+		};
+
+		ProviderDescriptor descriptor = provider.descriptor();
+		assertFalse(descriptor.isReady());
+		assertTrue(descriptor.getUnavailableReason().contains("Model file not found"));
+	}
+
+	@Test
+	public void localEngineWithAResolvableModelFileIsReady() {
+		BundledClinicalAnswerProvider provider = new BundledClinicalAnswerProvider(
+				new ScriptedChartSearchService()) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				return defaultValue;
+			}
+
+			@Override
+			protected String requireLocalModel(String configuredPath) {
+				return "/openmrs/data/chartsearchai/gemma-4-E4B-it-Q4_K_M.gguf";
+			}
+		};
+
+		ProviderDescriptor descriptor = provider.descriptor();
+		assertTrue(descriptor.isReady());
+		assertNull(descriptor.getUnavailableReason());
+	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/BundledClinicalAnswerProviderTest.java
@@ -273,6 +273,22 @@ public class BundledClinicalAnswerProviderTest {
 	}
 
 	@Test
+	public void mandatoryContextOverflowMapsToInsufficientContext() throws Exception {
+		ScriptedChartSearchService service = new ScriptedChartSearchService();
+		service.failure = new org.openmrs.module.chartsearchai.api.InsufficientContextException(
+				"mandatory evidence exceeds the model input budget",
+				java.util.Collections.singletonList("allergy-1"));
+		BundledClinicalAnswerProvider provider = provider(service);
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request(), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals("insufficient_context", result.getProblemCode());
+		assertEquals(TurnEventType.TURN_ERROR, result.getTerminalState());
+	}
+
+	@Test
 	public void theDescriptorAdvertisesBundledIdentityAndTruthfulDefaultCapabilities() {
 		BundledClinicalAnswerProvider provider = defaultConfigProvider(new ScriptedChartSearchService());
 

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransportTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransportTest.java
@@ -12,17 +12,28 @@ package org.openmrs.module.chartsearchai.api.provider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
 
@@ -34,6 +45,20 @@ import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
 public class HttpHubStreamTransportTest {
 
 	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private HttpServer server;
+
+	private ExecutorService executor;
+
+	@AfterEach
+	public void tearDown() {
+		if (server != null) {
+			server.stop(0);
+		}
+		if (executor != null) {
+			executor.shutdownNow();
+		}
+	}
 
 	@Test
 	@SuppressWarnings("unchecked")
@@ -82,6 +107,69 @@ public class HttpHubStreamTransportTest {
 		assertEquals("answer_done", events.get(0).getEvent());
 		assertEquals("Aspirin", events.get(0).getPayload().get("answer"));
 		assertEquals("done", events.get(1).getEvent());
+	}
+
+	@Test
+	public void cancellingAnInFlightStreamUnblocksItInsteadOfRunningToTheHubsOwnCompletion() throws Exception {
+		// Reproduces the actual production hang this class exists to fix: a preempted turn must
+		// not keep reading from the hub until the hub decides it's done. Binding the open response
+		// body to a TurnCancellation (see HttpHubStreamTransport#stream) and closing it from another
+		// thread has to unblock the reader's BufferedReader#readLine() promptly.
+		CountDownLatch firstEventSent = new CountDownLatch(1);
+		CountDownLatch serverMayFinish = new CountDownLatch(1);
+		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/stream", exchange -> {
+			exchange.getResponseHeaders().set("Content-Type", "text/event-stream");
+			exchange.sendResponseHeaders(200, 0);
+			try (OutputStream body = exchange.getResponseBody()) {
+				body.write("event: reasoning_delta\ndata: {\"delta\":\"thinking\"}\n\n"
+						.getBytes(StandardCharsets.UTF_8));
+				body.flush();
+				firstEventSent.countDown();
+				// Hold the connection open — a real hub still generating In-Depth. If cancellation
+				// does not actually unblock the client, the test below times out waiting on
+				// streamReturned, proving the bug rather than merely asserting it away.
+				serverMayFinish.await(10, TimeUnit.SECONDS);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		});
+		server.start();
+
+		HttpHubStreamTransport transport = new HttpHubStreamTransport();
+		HubCallRequest request = new HubCallRequest(
+				"http://127.0.0.1:" + server.getAddress().getPort() + "/stream", "product-a",
+				"patient-1", "conversation-1", "request-1", "question", Collections.emptyList());
+		TurnCancellation cancellation = new TurnCancellation();
+		List<HubWireEvent> received = Collections.synchronizedList(new ArrayList<>());
+
+		executor = Executors.newSingleThreadExecutor();
+		Future<Exception> streamReturned = executor.submit(() -> {
+			try {
+				transport.stream(request, received::add, cancellation);
+				return null;
+			}
+			catch (Exception e) {
+				return e;
+			}
+		});
+
+		assertTrue(firstEventSent.await(5, TimeUnit.SECONDS), "server never sent its first event");
+		cancellation.cancel();
+
+		Exception thrown;
+		try {
+			thrown = streamReturned.get(5, TimeUnit.SECONDS);
+		}
+		catch (java.util.concurrent.TimeoutException e) {
+			fail("cancel() did not unblock the in-flight hub read within 5s — the connection to the "
+					+ "hub was not actually torn down, so a preempted turn would keep running to the "
+					+ "hub's own completion instead of freeing its router slot");
+			return;
+		}
+		assertTrue(thrown != null, "the interrupted read should surface as a failure, not a silent success");
+		serverMayFinish.countDown();
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransportTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HttpHubStreamTransportTest.java
@@ -1,0 +1,94 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+
+/**
+ * Pins the med-agent-hub request envelope and SSE framing used by
+ * {@link HttpHubStreamTransport}. Network I/O is not exercised here — only the pure request and
+ * parse seams the production transport shares with the old relay.
+ */
+public class HttpHubStreamTransportTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void requestJsonCarriesProfilePatientPriorsAndProductContext() throws Exception {
+		HubCallRequest request = new HubCallRequest(
+				"http://hub.example/v1/chat/completions", "product-a", "patient-1",
+				"conversation-1", "request-1", "current question",
+				Collections.singletonList(new PriorClinicalTurn("earlier q", "earlier a")));
+
+		String json = HttpHubStreamTransport.requestJson(request);
+		Map<String, Object> root = MAPPER.readValue(json, Map.class);
+
+		assertEquals("product-a", root.get("model"));
+		assertEquals(Boolean.TRUE, root.get("stream"));
+		assertEquals("patient-1", root.get("patient"));
+		List<Map<String, Object>> messages = (List<Map<String, Object>>) root.get("messages");
+		assertEquals(3, messages.size());
+		assertEquals("user", messages.get(0).get("role"));
+		assertEquals("earlier q", messages.get(0).get("content"));
+		assertEquals("assistant", messages.get(1).get("role"));
+		assertEquals("earlier a", messages.get(1).get("content"));
+		assertEquals("user", messages.get(2).get("role"));
+		assertEquals("current question", messages.get(2).get("content"));
+
+		Map<String, Object> context = (Map<String, Object>) root.get("context");
+		assertEquals(Boolean.TRUE, context.get("require_product_profile"));
+		assertEquals("conversation-1", context.get("session"));
+		assertEquals("request-1", context.get("request_id"));
+	}
+
+	@Test
+	public void sseParserEmitsEventsAndIgnoresHeartbeats() throws Exception {
+		String sse = ""
+				+ ": hb\n\n"
+				+ "event: answer_done\n"
+				+ "data: {\"answer\":\"Aspirin\",\"references\":[]}\n"
+				+ "\n"
+				+ "event: done\n"
+				+ "data: {\"answer\":\"Aspirin\",\"references\":[]}\n"
+				+ "\n";
+		List<HubWireEvent> events = new ArrayList<>();
+		try (InputStream in = new ByteArrayInputStream(sse.getBytes(StandardCharsets.UTF_8))) {
+			HttpHubStreamTransport.parseSse(in, events::add);
+		}
+		assertEquals(2, events.size());
+		assertEquals("answer_done", events.get(0).getEvent());
+		assertEquals("Aspirin", events.get(0).getPayload().get("answer"));
+		assertEquals("done", events.get(1).getEvent());
+	}
+
+	@Test
+	public void nonSuccessStatusThrowsHubTransportExceptionWithBody() {
+		HubTransportException failure = assertThrows(HubTransportException.class,
+				() -> HttpHubStreamTransport.requireSuccess(422, "{\"detail\":{\"code\":\"x\"}}"));
+		assertEquals(422, failure.getStatusCode());
+		assertTrue(failure.getBody().contains("\"code\":\"x\""));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProviderTest.java
@@ -79,18 +79,28 @@ public class HubClinicalAnswerProviderTest {
 
 		String errorBody;
 
+		CancellationSignal lastCancellation;
+
 		@Override
-		public void stream(HubCallRequest request, Consumer<HubWireEvent> sink) {
+		public void stream(HubCallRequest request, Consumer<HubWireEvent> sink, CancellationSignal cancellation) {
 			calls.incrementAndGet();
 			lastRequest = request;
-			if (failure != null) {
-				throw failure;
-			}
+			lastCancellation = cancellation;
 			if (httpStatus < 200 || httpStatus >= 300) {
 				throw new HubTransportException(httpStatus, errorBody == null ? "" : errorBody);
 			}
 			for (HubWireEvent event : events) {
 				sink.accept(event);
+			}
+			// Thrown AFTER emitting events — reproduces a real preempt: the connection is force-closed
+			// mid-stream, after some events (e.g. answer_done) already arrived. Production gets here
+			// because cancel() itself closed the resource; mirror that causality instead of the test
+			// pre-cancelling (which would trip execute()'s own "not started yet" guard).
+			if (failure != null) {
+				if (cancellation instanceof TurnCancellation) {
+					((TurnCancellation) cancellation).cancel();
+				}
+				throw failure;
 			}
 		}
 	}
@@ -224,6 +234,89 @@ public class HubClinicalAnswerProviderTest {
 		assertTrue(sink.types().contains(TurnEventType.ANSWER_DONE));
 		assertTrue(sink.types().contains(TurnEventType.TURN_ERROR));
 		assertFalse(sink.types().contains(TurnEventType.TURN_DONE));
+	}
+
+	@Test
+	public void theCallersCancellationSignalIsHandedToTheTransport() throws Exception {
+		// So a preempting turn can force-close the hub's open response body (via
+		// TurnCancellation.bindCloseable) rather than the hub connection running to its own
+		// natural completion. A silently-dropped cancellation here is exactly what let a
+		// preempted turn keep occupying the hub's router slot indefinitely.
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		transport.events = Collections.singletonList(wire("done", answerPayload("Aspirin 81mg.")));
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+		CollectingSink sink = new CollectingSink();
+		TurnCancellation cancellation = new TurnCancellation();
+
+		provider.execute(request("product-profile-a"), sink, cancellation).toCompletableFuture().get();
+
+		assertTrue(transport.lastCancellation == cancellation);
+	}
+
+	@Test
+	public void aCancelledStreamThatAlreadyProducedAnAnswerCompletesAsDoneWithThatAnswer() throws Exception {
+		// The real preempt shape: a fast answer already arrived (answer_done/answer_validation),
+		// only In-Depth was still generating when this turn got cancelled. The answer itself is
+		// not wrong just because a later stage got cut short — discarding it as a generic failure
+		// would silently drop a perfectly good answer from history instead of persisting it (with
+		// In-Depth left at whatever partial state it reached).
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		Map<String, Object> answer = answerPayload("Aspirin 81mg.");
+		transport.events = Collections.singletonList(wire("answer_done", answer));
+		transport.failure = new RuntimeException("connection reset");
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+		CollectingSink sink = new CollectingSink();
+		TurnCancellation cancellation = new TurnCancellation();
+
+		TurnResult result = provider.execute(request("product-profile-a"), sink, cancellation)
+				.toCompletableFuture().get();
+
+		assertEquals(TurnEventType.TURN_DONE, result.getTerminalState());
+		assertEquals("Aspirin 81mg.", result.getAnswer().getText());
+		assertNull(result.getProblemCode());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void aCancelledStreamsDanglingPendingInDepthIsPersistedAsFailedNotLeftPending() throws Exception {
+		// The persisted record is the source of truth for every future reader (audit review,
+		// re-hydrating a reload, another UI) — not just this session's frontend, which separately
+		// reinterprets a dangling "pending" as failed on its own hydration path. No further
+		// generation will ever happen for this turn, so the stored record must say so, not claim
+		// forever that In-Depth is still running.
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		Map<String, Object> answer = answerPayload("Aspirin 81mg.");
+		answer.put("inDepth", new LinkedHashMap<>(Collections.singletonMap("status", "pending")));
+		transport.events = Collections.singletonList(wire("indepth_pending", answer));
+		transport.failure = new RuntimeException("connection reset");
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+		CollectingSink sink = new CollectingSink();
+		TurnCancellation cancellation = new TurnCancellation();
+
+		TurnResult result = provider.execute(request("product-profile-a"), sink, cancellation)
+				.toCompletableFuture().get();
+
+		Map<String, Object> inDepth = (Map<String, Object>) result.getAnswer().getPayload().get("inDepth");
+		assertEquals("failed", inDepth.get("status"));
+	}
+
+	@Test
+	public void aCancelledStreamThatNeverProducedAnAnswerStillFailsNormally() throws Exception {
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		transport.failure = new RuntimeException("connection reset");
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+		CollectingSink sink = new CollectingSink();
+		TurnCancellation cancellation = new TurnCancellation();
+
+		TurnResult result = provider.execute(request("product-profile-a"), sink, cancellation)
+				.toCompletableFuture().get();
+
+		assertEquals(TurnEventType.TURN_ERROR, result.getTerminalState());
+		assertNull(result.getAnswer());
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/HubClinicalAnswerProviderTest.java
@@ -1,0 +1,242 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+
+/**
+ * {@link HubClinicalAnswerProvider} makes one med-agent-hub product-profile call and maps the
+ * hub's staged SSE wire onto the canonical turn lifecycle. These tests drive the provider through
+ * a scripted transport so the mapping, single-call contract, and readiness rules are pinned without
+ * a live hub.
+ */
+public class HubClinicalAnswerProviderTest {
+
+	private static Patient patient() {
+		Patient patient = new Patient();
+		patient.setUuid("patient-uuid-1");
+		return patient;
+	}
+
+	private static TurnRequest request(String profileId) {
+		return new TurnRequest(patient(), "What medications is this patient on?", "conversation-1",
+				"request-1", ProviderMode.QUERY_SCOPED, profileId,
+				Collections.singletonList(new PriorClinicalTurn("prior q", "prior a")));
+	}
+
+	private static class CollectingSink implements TurnEventSink {
+
+		final List<TurnEvent> events = new ArrayList<>();
+
+		@Override
+		public void accept(TurnEvent event) {
+			events.add(event);
+		}
+
+		List<TurnEventType> types() {
+			return events.stream().map(TurnEvent::getType).collect(Collectors.toList());
+		}
+	}
+
+	/** Scripted hub transport: records calls and emits a prepared SSE sequence. */
+	private static class ScriptedHubTransport implements HubStreamTransport {
+
+		final AtomicInteger calls = new AtomicInteger();
+
+		HubCallRequest lastRequest;
+
+		List<HubWireEvent> events = Collections.emptyList();
+
+		RuntimeException failure;
+
+		int httpStatus = 200;
+
+		String errorBody;
+
+		@Override
+		public void stream(HubCallRequest request, Consumer<HubWireEvent> sink) {
+			calls.incrementAndGet();
+			lastRequest = request;
+			if (failure != null) {
+				throw failure;
+			}
+			if (httpStatus < 200 || httpStatus >= 300) {
+				throw new HubTransportException(httpStatus, errorBody == null ? "" : errorBody);
+			}
+			for (HubWireEvent event : events) {
+				sink.accept(event);
+			}
+		}
+	}
+
+	private static HubClinicalAnswerProvider provider(ScriptedHubTransport transport, String endpoint) {
+		return new HubClinicalAnswerProvider(transport) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				if (ChartSearchAiConstants.GP_HUB_ENDPOINT_URL.equals(property)) {
+					return endpoint;
+				}
+				return defaultValue;
+			}
+		};
+	}
+
+	private static Map<String, Object> answerPayload(String answer) {
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", answer);
+		payload.put("references", Collections.emptyList());
+		payload.put("answerValidation", Collections.singletonMap("status", "checking"));
+		return payload;
+	}
+
+	private static HubWireEvent wire(String event, Map<String, Object> payload) {
+		return new HubWireEvent(event, payload);
+	}
+
+	@Test
+	public void descriptorIsNotReadyWhenTheHubEndpointIsUnset() {
+		HubClinicalAnswerProvider provider = provider(new ScriptedHubTransport(), "");
+		ProviderDescriptor descriptor = provider.descriptor();
+		assertEquals(HubClinicalAnswerProvider.PROVIDER_ID, descriptor.getId());
+		assertFalse(descriptor.isReady());
+		assertNotNull(descriptor.getUnavailableReason());
+		assertTrue(descriptor.getCapabilities().contains(ProviderCapability.ANSWER));
+		assertTrue(descriptor.getCapabilities().contains(ProviderCapability.INDEPTH));
+		assertTrue(descriptor.getCapabilities().contains(ProviderCapability.ANSWER_REVIEW));
+	}
+
+	@Test
+	public void aStagedHubStreamMapsOntoTheCanonicalLifecycleInOneCall() throws Exception {
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		Map<String, Object> answer = answerPayload("Aspirin 81mg.");
+		Map<String, Object> validated = new LinkedHashMap<>(answer);
+		validated.put("answerValidation", Collections.singletonMap("status", "checked"));
+		Map<String, Object> pending = new LinkedHashMap<>(validated);
+		pending.put("inDepth", Collections.singletonMap("status", "pending"));
+		Map<String, Object> indepthDone = new LinkedHashMap<>(validated);
+		indepthDone.put("inDepth", Collections.singletonMap("status", "done"));
+		Map<String, Object> done = new LinkedHashMap<>(indepthDone);
+		transport.events = Arrays.asList(
+				wire("answer_done", answer),
+				wire("answer_validation", validated),
+				wire("indepth_pending", pending),
+				wire("indepth_done", indepthDone),
+				wire("done", done));
+
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request("product-profile-a"), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals(1, transport.calls.get(), "exactly one hub call per turn");
+		assertEquals("product-profile-a", transport.lastRequest.getProfileId());
+		assertEquals("patient-uuid-1", transport.lastRequest.getPatientUuid());
+		assertEquals("conversation-1", transport.lastRequest.getConversationId());
+		assertEquals(1, transport.lastRequest.getPriorTurns().size());
+		assertEquals("prior q", transport.lastRequest.getPriorTurns().get(0).getQuestion());
+
+		assertEquals(Arrays.asList(TurnEventType.TURN_STARTED, TurnEventType.ANSWER_DONE,
+				TurnEventType.ANSWER_VALIDATION, TurnEventType.INDEPTH_PENDING,
+				TurnEventType.INDEPTH_DONE, TurnEventType.TURN_DONE), sink.types());
+		assertTrue(TurnLifecycleValidator
+				.violations(provider.descriptor().getCapabilities(), sink.types()).isEmpty());
+		assertEquals(TurnEventType.TURN_DONE, result.getTerminalState());
+		assertEquals("Aspirin 81mg.", result.getAnswer().getText());
+		assertEquals("checked",
+				((Map<?, ?>) result.getAnswer().getPayload().get("answerValidation")).get("status"));
+		assertNull(result.getProblemCode());
+	}
+
+	@Test
+	public void aMissingProfileFailsExplicitlyWithoutCallingTheHub() throws Exception {
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider
+				.execute(request(null), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals(0, transport.calls.get());
+		assertEquals(TurnEventType.TURN_ERROR, result.getTerminalState());
+		assertEquals("profile_required", result.getProblemCode());
+	}
+
+	@Test
+	public void aHubRejectionEndsInTurnErrorWithTheHubProblemCode() throws Exception {
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		transport.httpStatus = 422;
+		transport.errorBody = "{\"detail\":{\"code\":\"insufficient_context\",\"message\":\"chart too large\"}}";
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request("product-profile-a"), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals(1, transport.calls.get());
+		assertEquals(Arrays.asList(TurnEventType.TURN_STARTED, TurnEventType.TURN_ERROR), sink.types());
+		assertEquals("insufficient_context", result.getProblemCode());
+		assertNull(result.getAnswer());
+	}
+
+	@Test
+	public void aStreamThatEndsWithoutDoneIsATurnError() throws Exception {
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		transport.events = Collections.singletonList(wire("answer_done", answerPayload("partial")));
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request("product-profile-a"), sink, CancellationSignal.NONE)
+				.toCompletableFuture().get();
+
+		assertEquals(TurnEventType.TURN_ERROR, result.getTerminalState());
+		assertEquals("hub_stream_incomplete", result.getProblemCode());
+		assertTrue(sink.types().contains(TurnEventType.ANSWER_DONE));
+		assertTrue(sink.types().contains(TurnEventType.TURN_ERROR));
+		assertFalse(sink.types().contains(TurnEventType.TURN_DONE));
+	}
+
+	@Test
+	public void cancellationBeforeTheHubCallNeverContactsTheTransport() throws Exception {
+		ScriptedHubTransport transport = new ScriptedHubTransport();
+		HubClinicalAnswerProvider provider = provider(transport,
+				"http://hub.example/v1/chat/completions");
+
+		CollectingSink sink = new CollectingSink();
+		TurnResult result = provider.execute(request("product-profile-a"), sink, () -> true)
+				.toCompletableFuture().get();
+
+		assertEquals(0, transport.calls.get());
+		assertEquals("cancelled", result.getProblemCode());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/ProviderRegistryConformanceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/ProviderRegistryConformanceTest.java
@@ -1,0 +1,201 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Conformance adapter for the {@code provider_capabilities} family of
+ * {@code conformance/dual-provider-conformance.v1.json} plus the configuration rules the roadmap
+ * fixes: bundled is the fresh-install default, the picker appears only with more than one
+ * configured provider, an unavailable configured provider stays visible but disabled, and there
+ * is never a silent fallback to a different provider.
+ */
+public class ProviderRegistryConformanceTest {
+
+	private static final String FIXTURE = "/conformance/dual-provider-conformance.v1.json";
+
+	/** Provider whose identity and readiness are scripted for registry tests. */
+	private static class FakeProvider implements ClinicalAnswerProvider {
+
+		private final String id;
+
+		private final boolean ready;
+
+		FakeProvider(String id, boolean ready) {
+			this.id = id;
+			this.ready = ready;
+		}
+
+		@Override
+		public ProviderDescriptor descriptor() {
+			return new ProviderDescriptor(id, id + " provider", true, ready, false,
+					Collections.singletonList(ProviderMode.QUERY_SCOPED),
+					EnumSet.of(ProviderCapability.ANSWER), ready ? null : "backend unreachable");
+		}
+
+		@Override
+		public CompletionStage<TurnResult> execute(TurnRequest request, TurnEventSink events,
+				CancellationSignal cancellation) {
+			throw new UnsupportedOperationException("registry tests never execute turns");
+		}
+	}
+
+	/** Registry whose global-property reads come from an in-memory map. */
+	private static class StubRegistry extends ClinicalAnswerProviderRegistry {
+
+		final Map<String, String> gps = new HashMap<>();
+
+		StubRegistry(List<ClinicalAnswerProvider> providers) {
+			super(providers);
+		}
+
+		@Override
+		protected String gp(String property, String defaultValue) {
+			return gps.containsKey(property) ? gps.get(property) : defaultValue;
+		}
+	}
+
+	private static StubRegistry registry(String enabledGp, ClinicalAnswerProvider... providers) {
+		StubRegistry registry = new StubRegistry(Arrays.asList(providers));
+		if (enabledGp != null) {
+			registry.gps.put(ClinicalAnswerProviderRegistry.GP_PROVIDERS_ENABLED, enabledGp);
+		}
+		return registry;
+	}
+
+	@Test
+	public void everyProviderCapabilitiesFixtureCaseHolds() throws Exception {
+		JsonNode cases;
+		try (InputStream in = getClass().getResourceAsStream(FIXTURE)) {
+			cases = new ObjectMapper().readTree(in).get("provider_capabilities");
+		}
+		assertTrue(cases != null && cases.isArray() && cases.size() > 0);
+
+		for (JsonNode fixtureCase : cases) {
+			String id = fixtureCase.get("id").asText();
+			if (fixtureCase.has("expected_picker")) {
+				boolean hubReady = !fixtureCase.has("hub_ready") || fixtureCase.get("hub_ready").asBoolean();
+				StringBuilder enabled = new StringBuilder();
+				for (JsonNode provider : fixtureCase.get("providers")) {
+					if (enabled.length() > 0) {
+						enabled.append(',');
+					}
+					enabled.append(provider.asText());
+				}
+				StubRegistry registry = registry(enabled.toString(),
+						new FakeProvider("bundled", true), new FakeProvider("hub", hubReady));
+
+				assertEquals(fixtureCase.get("expected_picker").asBoolean(), registry.isPickerVisible(), id);
+				assertEquals(fixtureCase.get("default_provider").asText(),
+						registry.getDefaultProviderId(), id);
+				if (fixtureCase.has("expected_hub_state")) {
+					ProviderDescriptor hub = registry.descriptors().stream()
+							.filter(d -> "hub".equals(d.getId())).findFirst().orElse(null);
+					assertNotNull(hub, id + ": configured hub must stay visible");
+					assertEquals("disabled", fixtureCase.get("expected_hub_state").asText(), id);
+					assertTrue(hub.isEnabled(), id + ": configured hub remains enabled in config");
+					assertFalse(hub.isReady(), id + ": unready hub must not claim readiness");
+					assertNotNull(hub.getUnavailableReason(), id);
+				}
+			} else if (fixtureCase.has("switch_to")) {
+				assertEquals("new_conversation", fixtureCase.get("expected").asText());
+				assertTrue(ClinicalAnswerProviderRegistry.switchRequiresNewConversation(
+						fixtureCase.get("switch_from").asText(), fixtureCase.get("switch_to").asText()), id);
+			}
+		}
+	}
+
+	@Test
+	public void bundledIsTheFreshInstallDefaultWithNoConfiguration() {
+		StubRegistry registry = registry(null, new FakeProvider("bundled", true),
+				new FakeProvider("hub", true));
+
+		assertEquals(Collections.singletonList("bundled"),
+				registry.descriptors().stream().map(ProviderDescriptor::getId)
+						.collect(java.util.stream.Collectors.toList()),
+				"an unconfigured install exposes only bundled");
+		assertEquals("bundled", registry.getDefaultProviderId());
+		assertFalse(registry.isPickerVisible());
+	}
+
+	@Test
+	public void theDefaultDescriptorIsMarkedDefaultAndOthersAreNot() {
+		StubRegistry registry = registry("bundled,hub", new FakeProvider("bundled", true),
+				new FakeProvider("hub", true));
+
+		for (ProviderDescriptor descriptor : registry.descriptors()) {
+			assertEquals("bundled".equals(descriptor.getId()), descriptor.isDefault());
+		}
+		assertTrue(registry.isPickerVisible());
+	}
+
+	@Test
+	public void aConfiguredProviderWithNoImplementationStaysVisibleButUnavailable() {
+		StubRegistry registry = registry("bundled,hub", new FakeProvider("bundled", true));
+
+		ProviderDescriptor hub = registry.descriptors().stream().filter(d -> "hub".equals(d.getId()))
+				.findFirst().orElse(null);
+		assertNotNull(hub, "a configured provider must not silently disappear");
+		assertFalse(hub.isReady());
+		assertNotNull(hub.getUnavailableReason());
+	}
+
+	@Test
+	public void requireRejectsUnknownDisabledAndUnreadyProvidersInsteadOfFallingBack() {
+		StubRegistry registry = registry("bundled,hub", new FakeProvider("bundled", true),
+				new FakeProvider("hub", false));
+
+		assertEquals("bundled", registry.require("bundled").descriptor().getId());
+		ProviderUnavailableException unknown = assertThrows(ProviderUnavailableException.class,
+				() -> registry.require("nonsense"));
+		assertEquals("unknown_provider", unknown.getProblemCode());
+		ProviderUnavailableException unready = assertThrows(ProviderUnavailableException.class,
+				() -> registry.require("hub"));
+		assertEquals("provider_not_ready", unready.getProblemCode());
+
+		StubRegistry bundledOnly = registry("bundled", new FakeProvider("bundled", true),
+				new FakeProvider("hub", true));
+		ProviderUnavailableException disabled = assertThrows(ProviderUnavailableException.class,
+				() -> bundledOnly.require("hub"));
+		assertEquals("provider_not_enabled", disabled.getProblemCode());
+	}
+
+	@Test
+	public void theConfiguredDefaultMustBeAnEnabledProvider() {
+		StubRegistry registry = registry("bundled,hub", new FakeProvider("bundled", true),
+				new FakeProvider("hub", true));
+		registry.gps.put(ClinicalAnswerProviderRegistry.GP_DEFAULT_PROVIDER, "hub");
+		assertEquals("hub", registry.getDefaultProviderId());
+
+		// A default pointing at a provider that is not enabled falls back to bundled — the
+		// fresh-install default — rather than exposing a dead default.
+		registry.gps.put(ClinicalAnswerProviderRegistry.GP_DEFAULT_PROVIDER, "nonsense");
+		assertEquals("bundled", registry.getDefaultProviderId());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/ProviderRegistryConformanceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/ProviderRegistryConformanceTest.java
@@ -202,5 +202,12 @@ public class ProviderRegistryConformanceTest {
 		// fresh-install default — rather than exposing a dead default.
 		registry.gps.put(ClinicalAnswerProviderRegistry.GP_DEFAULT_PROVIDER, "nonsense");
 		assertEquals("bundled", registry.getDefaultProviderId());
+
+		// A hub-only deployment cannot fall back to the disabled fresh-install default.
+		StubRegistry hubOnly = registry("hub", new FakeProvider("bundled", true),
+				new FakeProvider("hub", true));
+		hubOnly.gps.put(ClinicalAnswerProviderRegistry.GP_DEFAULT_PROVIDER, "nonsense");
+		assertEquals("hub", hubOnly.getDefaultProviderId());
+		assertTrue(hubOnly.descriptors().get(0).isDefault());
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/ProviderRegistryConformanceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/ProviderRegistryConformanceTest.java
@@ -53,6 +53,11 @@ public class ProviderRegistryConformanceTest {
 		}
 
 		@Override
+		public String id() {
+			return id;
+		}
+
+		@Override
 		public ProviderDescriptor descriptor() {
 			return new ProviderDescriptor(id, id + " provider", true, ready, false,
 					Collections.singletonList(ProviderMode.QUERY_SCOPED),

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TemporalGateRelayConformanceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TemporalGateRelayConformanceTest.java
@@ -1,0 +1,143 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+
+/**
+ * Red-first conformance adapter for the {@code temporal_gate} family of
+ * {@code conformance/dual-provider-conformance.v1.json}. Bundled chartsearchai has no temporal-gate
+ * engine of its own — {@link ProviderCapability#ANSWER_CHECK} is advertised only by
+ * {@link HubClinicalAnswerProvider} (see its capability set), which relays the hub's already-gated
+ * {@code temporalGate} object opaquely (per {@link AnswerEnvelope}'s javadoc: "preserved without
+ * converting ... into Java-owned domain types"). So the Java-side obligation for this family is not
+ * to re-derive a gate result (the hub's Python {@code run_temporal_gate} owns that, proven by
+ * med-agent-hub's own {@code test_dual_provider_conformance_adapter.py}), but to prove the relay
+ * never drops or reshapes the gate's {@code status} on its way through
+ * {@link HubClinicalAnswerProvider#execute}. Each fixture case's {@code expected_status} becomes the
+ * status the scripted hub transport sends for that case, so a relay regression that dropped or
+ * reset {@code temporalGate} would fail here even though every case in this fixture version happens
+ * to expect {@code "fail"}.
+ */
+public class TemporalGateRelayConformanceTest {
+
+	private static final String FIXTURE = "/conformance/dual-provider-conformance.v1.json";
+
+	private static JsonNode temporalGateCases() throws Exception {
+		try (InputStream in = TemporalGateRelayConformanceTest.class.getResourceAsStream(FIXTURE)) {
+			JsonNode root = new ObjectMapper().readTree(in);
+			JsonNode cases = root.get("temporal_gate");
+			assertTrue(cases != null && cases.isArray() && cases.size() > 0,
+					"fixture must contain temporal_gate cases");
+			return cases;
+		}
+	}
+
+	private static Patient patient() {
+		Patient patient = new Patient();
+		patient.setUuid("patient-uuid-1");
+		return patient;
+	}
+
+	private static TurnRequest request() {
+		return new TurnRequest(patient(), "When was the last visit?", "conversation-1", "request-1",
+				ProviderMode.QUERY_SCOPED, "product-profile-a",
+				Collections.singletonList(new PriorClinicalTurn("prior q", "prior a")));
+	}
+
+	/** Scripted hub transport that emits exactly one prepared SSE sequence. */
+	private static final class ScriptedHubTransport implements HubStreamTransport {
+
+		private final java.util.List<HubWireEvent> events;
+
+		ScriptedHubTransport(java.util.List<HubWireEvent> events) {
+			this.events = events;
+		}
+
+		@Override
+		public void stream(HubCallRequest request, Consumer<HubWireEvent> sink, CancellationSignal cancellation) {
+			for (HubWireEvent event : events) {
+				sink.accept(event);
+			}
+		}
+	}
+
+	private static HubClinicalAnswerProvider provider(HubStreamTransport transport) {
+		return new HubClinicalAnswerProvider(transport) {
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				if (ChartSearchAiConstants.GP_HUB_ENDPOINT_URL.equals(property)) {
+					return "http://hub.example/v1/chat/completions";
+				}
+				return defaultValue;
+			}
+		};
+	}
+
+	/** A staged done-envelope payload carrying a real-shaped temporalGate object. */
+	private static Map<String, Object> payloadWithTemporalGate(String answer, String gateStatus) {
+		Map<String, Object> temporalGate = new LinkedHashMap<>();
+		temporalGate.put("schema_version", "temporal_gate.v1");
+		temporalGate.put("mode", "enforce");
+		temporalGate.put("status", gateStatus);
+		temporalGate.put("checks", Collections.emptyList());
+
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", answer);
+		payload.put("references", Collections.emptyList());
+		payload.put("temporalGate", temporalGate);
+		return payload;
+	}
+
+	@Test
+	public void everyTemporalGateFixtureCaseSurvivesRelayUnaltered() throws Exception {
+		int caseCount = 0;
+		for (JsonNode fixtureCase : temporalGateCases()) {
+			String id = fixtureCase.get("id").asText();
+			String expectedStatus = fixtureCase.get("expected_status").asText();
+
+			Map<String, Object> done = payloadWithTemporalGate("An answer.", expectedStatus);
+			ScriptedHubTransport transport = new ScriptedHubTransport(Arrays.asList(
+					new HubWireEvent("answer_done", done),
+					new HubWireEvent("done", done)));
+
+			TurnResult result = provider(transport)
+					.execute(request(), event -> { }, CancellationSignal.NONE)
+					.toCompletableFuture().get();
+
+			Object relayedGate = result.getAnswer().getPayload().get("temporalGate");
+			assertTrue(relayedGate instanceof Map, id + ": temporalGate must survive relay as an object");
+			assertEquals(expectedStatus, ((Map<?, ?>) relayedGate).get("status"),
+					id + ": relayed temporalGate.status must match the fixture's expected_status");
+			assertEquals("temporal_gate.v1", ((Map<?, ?>) relayedGate).get("schema_version"),
+					id + ": relay must not drop sibling fields of the gate object");
+
+			caseCount++;
+		}
+		assertEquals(4, caseCount, "sanity: every fixture case actually ran");
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TurnCancellationTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TurnCancellationTest.java
@@ -1,0 +1,84 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+public class TurnCancellationTest {
+
+	private static final class CountingCloseable implements Closeable {
+
+		final AtomicInteger closes = new AtomicInteger();
+
+		@Override
+		public void close() throws IOException {
+			closes.incrementAndGet();
+		}
+	}
+
+	@Test
+	public void startsNotCancelled() {
+		assertFalse(new TurnCancellation().isCancelled());
+	}
+
+	@Test
+	public void cancelClosesTheBoundResourceAndFlipsTheFlag() {
+		TurnCancellation cancellation = new TurnCancellation();
+		CountingCloseable resource = new CountingCloseable();
+		cancellation.bindCloseable(resource);
+
+		cancellation.cancel();
+
+		assertTrue(cancellation.isCancelled());
+		assertEquals(1, resource.closes.get());
+	}
+
+	@Test
+	public void cancelIsIdempotentAndOnlyClosesOnce() {
+		TurnCancellation cancellation = new TurnCancellation();
+		CountingCloseable resource = new CountingCloseable();
+		cancellation.bindCloseable(resource);
+
+		cancellation.cancel();
+		cancellation.cancel();
+
+		assertEquals(1, resource.closes.get());
+	}
+
+	@Test
+	public void bindingAfterCancellationClosesImmediately() {
+		// A fast preempt can race the provider's own setup — cancel() may run before the
+		// provider has anything open to bind yet.
+		TurnCancellation cancellation = new TurnCancellation();
+		cancellation.cancel();
+
+		CountingCloseable resource = new CountingCloseable();
+		cancellation.bindCloseable(resource);
+
+		assertEquals(1, resource.closes.get());
+	}
+
+	@Test
+	public void neverCancelledNeverTouchesTheBoundResource() {
+		TurnCancellation cancellation = new TurnCancellation();
+		CountingCloseable resource = new CountingCloseable();
+		cancellation.bindCloseable(resource);
+
+		assertEquals(0, resource.closes.get());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TurnLifecycleConformanceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TurnLifecycleConformanceTest.java
@@ -1,0 +1,201 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Red-first conformance adapter for the {@code provider_lifecycle} family of
+ * {@code conformance/dual-provider-conformance.v1.json}, a versioned copy of the
+ * dual-provider conformance fixture shared across the ChartSearchAI, ESM, and
+ * med-agent-hub repositories. Every provider implementation must emit turn events
+ * that {@link TurnLifecycleValidator} accepts against its advertised capabilities.
+ */
+public class TurnLifecycleConformanceTest {
+
+	private static final String FIXTURE = "/conformance/dual-provider-conformance.v1.json";
+
+	private static JsonNode fixtureRoot() throws Exception {
+		try (InputStream in = TurnLifecycleConformanceTest.class.getResourceAsStream(FIXTURE)) {
+			return new ObjectMapper().readTree(in);
+		}
+	}
+
+	@Test
+	public void everyProviderLifecycleFixtureCaseValidatesAsExpected() throws Exception {
+		JsonNode cases = fixtureRoot().get("provider_lifecycle");
+		assertTrue(cases != null && cases.isArray() && cases.size() > 0,
+				"fixture must contain provider_lifecycle cases");
+
+		for (JsonNode fixtureCase : cases) {
+			String id = fixtureCase.get("id").asText();
+			Set<ProviderCapability> capabilities = EnumSet.noneOf(ProviderCapability.class);
+			for (JsonNode capability : fixtureCase.get("capabilities")) {
+				capabilities.add(ProviderCapability.fromWireName(capability.asText()));
+			}
+			List<TurnEventType> events = new ArrayList<>();
+			for (JsonNode event : fixtureCase.get("events")) {
+				events.add(TurnEventType.fromWireName(event.asText()));
+			}
+
+			List<String> violations = TurnLifecycleValidator.violations(capabilities, events);
+			if ("accept".equals(fixtureCase.get("expected").asText())) {
+				assertTrue(violations.isEmpty(),
+						id + " must be accepted but was rejected: " + violations);
+			} else {
+				assertFalse(violations.isEmpty(), id + " must be rejected but was accepted");
+			}
+		}
+	}
+
+	@Test
+	public void fixtureCapabilityAndEventNamesAllResolve() throws Exception {
+		JsonNode cases = fixtureRoot().get("provider_lifecycle");
+		Set<String> seenEvents = new java.util.HashSet<>();
+		for (JsonNode fixtureCase : cases) {
+			for (JsonNode capability : fixtureCase.get("capabilities")) {
+				assertEquals(capability.asText(),
+						ProviderCapability.fromWireName(capability.asText()).getWireName());
+			}
+			for (JsonNode event : fixtureCase.get("events")) {
+				seenEvents.add(event.asText());
+				assertEquals(event.asText(), TurnEventType.fromWireName(event.asText()).getWireName());
+			}
+		}
+		assertTrue(seenEvents.contains("turn_started"));
+	}
+
+	// --- Rejection rules the fixture's accept-only cases do not pin down ---
+
+	private static final Set<ProviderCapability> FULL_CAPABILITIES = EnumSet.allOf(ProviderCapability.class);
+
+	private static List<TurnEventType> events(String... wireNames) {
+		List<TurnEventType> events = new ArrayList<>();
+		for (String wireName : wireNames) {
+			events.add(TurnEventType.fromWireName(wireName));
+		}
+		return events;
+	}
+
+	private static String joinedViolations(Set<ProviderCapability> capabilities, List<TurnEventType> events) {
+		return TurnLifecycleValidator.violations(capabilities, events).stream()
+				.collect(Collectors.joining("; "));
+	}
+
+	@Test
+	public void aTurnMustBeginWithTurnStarted() {
+		String violations = joinedViolations(FULL_CAPABILITIES, events("answer_done", "turn_done"));
+		assertTrue(violations.contains("turn_started"), violations);
+	}
+
+	@Test
+	public void aTurnMustEndWithExactlyOneTerminalEvent() {
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES, events("turn_started", "answer_done")).isEmpty(),
+				"missing terminal event must be rejected");
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES, events("turn_started", "answer_done", "turn_done", "turn_error"))
+				.isEmpty(), "two terminal events must be rejected");
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES,
+						events("turn_started", "answer_done", "turn_done", "evidence_updated"))
+				.isEmpty(), "events after the terminal event must be rejected");
+	}
+
+	@Test
+	public void turnDoneRequiresAnswerDoneButTurnErrorDoesNot() {
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES, events("turn_started", "turn_done")).isEmpty(),
+				"turn_done without answer_done must be rejected");
+		assertTrue(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES, events("turn_started", "turn_error")).isEmpty(),
+				"an error before any answer is a valid failed turn");
+	}
+
+	@Test
+	public void answerDoneMayOccurOnlyOnce() {
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES,
+						events("turn_started", "answer_done", "answer_done", "turn_done"))
+				.isEmpty());
+	}
+
+	@Test
+	public void eventsMustFollowTheCanonicalStageOrder() {
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES,
+						events("turn_started", "answer_validation", "answer_done", "turn_done"))
+				.isEmpty(), "answer_validation before answer_done must be rejected");
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES,
+						events("turn_started", "answer_delta", "reasoning_delta", "answer_done", "turn_done"))
+				.isEmpty(), "reasoning after answer deltas must be rejected");
+		assertTrue(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES,
+						events("turn_started", "reasoning_delta", "reasoning_delta", "answer_delta",
+								"answer_delta", "answer_done", "answer_validation", "evidence_updated",
+								"indepth_pending", "indepth_done", "turn_done"))
+				.isEmpty(), "the full canonical sequence with repeated deltas must be accepted");
+	}
+
+	@Test
+	public void optionalEventsRequireTheirAdvertisedCapability() {
+		Set<ProviderCapability> answerOnly = EnumSet.of(ProviderCapability.ANSWER);
+		assertFalse(TurnLifecycleValidator
+				.violations(answerOnly, events("turn_started", "answer_delta", "answer_done", "turn_done"))
+				.isEmpty(), "answer_delta without token_streaming must be rejected");
+		assertFalse(TurnLifecycleValidator
+				.violations(answerOnly,
+						events("turn_started", "answer_done", "answer_validation", "turn_done"))
+				.isEmpty(), "answer_validation without a checking/review capability must be rejected");
+		assertFalse(TurnLifecycleValidator
+				.violations(answerOnly,
+						events("turn_started", "answer_done", "evidence_updated", "turn_done"))
+				.isEmpty(), "evidence_updated without grounding must be rejected");
+		assertFalse(TurnLifecycleValidator
+				.violations(answerOnly,
+						events("turn_started", "answer_done", "indepth_pending", "indepth_done", "turn_done"))
+				.isEmpty(), "indepth events without the indepth capability must be rejected");
+	}
+
+	@Test
+	public void anAnsweringTurnRequiresTheAnswerCapability() {
+		Set<ProviderCapability> none = EnumSet.noneOf(ProviderCapability.class);
+		assertFalse(TurnLifecycleValidator
+				.violations(none, events("turn_started", "answer_done", "turn_done")).isEmpty());
+	}
+
+	@Test
+	public void inDepthTerminalEventsRequireAPrecedingPending() {
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES,
+						events("turn_started", "answer_done", "indepth_done", "turn_done"))
+				.isEmpty(), "indepth_done without indepth_pending must be rejected");
+		assertFalse(TurnLifecycleValidator
+				.violations(FULL_CAPABILITIES,
+						events("turn_started", "answer_done", "indepth_pending", "indepth_done",
+								"indepth_error", "turn_done"))
+				.isEmpty(), "both indepth_done and indepth_error must be rejected");
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TurnPreemptionRegistryTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/provider/TurnPreemptionRegistryTest.java
@@ -1,0 +1,70 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.provider;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TurnPreemptionRegistryTest {
+
+	@Test
+	public void aSecondTurnOnTheSameConversationCancelsTheFirst() {
+		TurnPreemptionRegistry registry = new TurnPreemptionRegistry();
+
+		TurnCancellation first = registry.begin("conversation-1");
+		assertFalse(first.isCancelled());
+
+		TurnCancellation second = registry.begin("conversation-1");
+
+		assertTrue(first.isCancelled());
+		assertFalse(second.isCancelled());
+	}
+
+	@Test
+	public void turnsOnDifferentConversationsDoNotCancelEachOther() {
+		TurnPreemptionRegistry registry = new TurnPreemptionRegistry();
+
+		TurnCancellation a = registry.begin("conversation-a");
+		TurnCancellation b = registry.begin("conversation-b");
+
+		assertFalse(a.isCancelled());
+		assertFalse(b.isCancelled());
+	}
+
+	@Test
+	public void endOnlyClearsTheEntryIfItIsStillTheCurrentTurn() {
+		TurnPreemptionRegistry registry = new TurnPreemptionRegistry();
+		TurnCancellation first = registry.begin("conversation-1");
+		TurnCancellation second = registry.begin("conversation-1");
+
+		// The first turn finishing (e.g. its provider noticed cancellation and returned) must not
+		// clear the SECOND turn's still-active entry out from under it.
+		registry.end("conversation-1", first);
+		TurnCancellation third = registry.begin("conversation-1");
+
+		assertTrue(second.isCancelled(), "second should have been cancelled by third starting");
+		assertFalse(third.isCancelled());
+	}
+
+	@Test
+	public void endClearsTheEntryWhenItIsStillCurrent() {
+		TurnPreemptionRegistry registry = new TurnPreemptionRegistry();
+		TurnCancellation first = registry.begin("conversation-1");
+
+		registry.end("conversation-1", first);
+		TurnCancellation second = registry.begin("conversation-1");
+
+		// Nothing was left registered for "conversation-1" after end(), so this second begin()
+		// must not find (and cancel) anything.
+		assertFalse(second.isCancelled());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyStatusTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyStatusTest.java
@@ -1,0 +1,108 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Hub-side adapter for the shared drug_safety_status conformance fixture (see
+ * med-agent-hub's mirror-image test_drug_safety_status.py). Drives
+ * {@link DrugSafetyValidator#validateWithStatus(String, String, PatientClinicalContext)} against
+ * the fixture's 3 scenarios (per the conformance contract's Temporal, Citation, and Safety
+ * Contract: checked/limited/unavailable are honest states — neither an empty warning list nor a
+ * missing source package implies checked). The fixture's mapping_complete/exposure_complete/
+ * execution_complete flags are conceptual; each case is translated to the closest concrete
+ * real-code scenario, exactly mirroring the Python adapter's translation:
+ *
+ * <ul>
+ *   <li>complete-check-is-checked: a resolved patient context, all three check categories enabled.</li>
+ *   <li>partial-check-is-limited: a resolved context, but the caller only asked for a subset of
+ *       the checks (contraindications disabled via the GP toggle) — a deliberately partial,
+ *       specifically described check.</li>
+ *   <li>missing-package-is-unavailable: no patient context at all, mirroring
+ *       {@code DrugSafetyValidator#validateWithStatus(String, String, Patient)}'s real
+ *       "no patient" path.</li>
+ * </ul>
+ */
+public class DrugSafetyStatusTest {
+
+	private static JsonNode fixture() throws IOException {
+		try (InputStream is = DrugSafetyStatusTest.class
+				.getResourceAsStream("/conformance/dual-provider-conformance.v1.json")) {
+			return new ObjectMapper().readTree(is);
+		}
+	}
+
+	private static JsonNode fixtureCase(String id) throws IOException {
+		for (JsonNode candidate : fixture().path("drug_safety_status")) {
+			if (id.equals(candidate.path("id").asText())) {
+				return candidate;
+			}
+		}
+		throw new IllegalArgumentException("No drug_safety_status fixture case '" + id + "'");
+	}
+
+	private DrugSafetyValidator validator() {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.bundledService());
+	}
+
+	@Test
+	public void completeCheckIsChecked() throws IOException {
+		JsonNode fixtureCase = fixtureCase("drug-safety.complete-check-is-checked");
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(30, null, null, null, null, null);
+
+		DrugSafetyValidator.SafetyCheckResult result =
+				validator().validateWithStatus("Ibuprofen 200 mg as needed.", null, context);
+
+		assertEquals(fixtureCase.path("expected_status").asText(), result.getStatus());
+	}
+
+	@Test
+	public void partialCheckIsLimited() throws IOException {
+		JsonNode fixtureCase = fixtureCase("drug-safety.partial-check-is-limited");
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(30, null, null, null, null, null);
+
+		DrugSafetyValidator.SafetyCheckResult result = validator().validateWithStatus(
+				"Ibuprofen 200 mg as needed.", null, context, false, true, true);
+
+		assertEquals(fixtureCase.path("expected_status").asText(), result.getStatus());
+	}
+
+	@Test
+	public void missingContextIsUnavailable() throws IOException {
+		JsonNode fixtureCase = fixtureCase("drug_safety.missing-package-is-unavailable");
+
+		DrugSafetyValidator.SafetyCheckResult result =
+				validator().validateWithStatus("Ibuprofen 200 mg as needed.", null, (PatientClinicalContext) null);
+
+		assertEquals(fixtureCase.path("expected_status").asText(), result.getStatus());
+	}
+
+	@Test
+	public void checkedStatusStillSurfacesRealWarnings() {
+		// The status is orthogonal to warning content — a checked result can still flag something.
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(5, null, null, null, null, null);
+
+		DrugSafetyValidator.SafetyCheckResult result = validator().validateWithStatus(
+				"Ibuprofen 600 mg every 6 hours can be given for pain.", null, context);
+
+		assertEquals(DrugSafetyValidator.STATUS_CHECKED, result.getStatus());
+		assertTrue(DrugReferenceTestSupport.has(result.getWarnings(), SafetyWarning.TYPE_OVERDOSE, "ibuprofen"));
+	}
+}

--- a/api/src/test/resources/chartsearchai-hibernate.cfg.xml
+++ b/api/src/test/resources/chartsearchai-hibernate.cfg.xml
@@ -5,5 +5,7 @@
 <hibernate-configuration>
 	<session-factory>
 		<mapping resource="ChartSearchAuditLog.hbm.xml"/>
+		<mapping resource="ClinicalConversation.hbm.xml"/>
+		<mapping resource="ClinicalConversationTurn.hbm.xml"/>
 	</session-factory>
 </hibernate-configuration>

--- a/api/src/test/resources/conformance/dual-provider-conformance.v1.json
+++ b/api/src/test/resources/conformance/dual-provider-conformance.v1.json
@@ -77,9 +77,9 @@
       "id": "context.enumerated-medications-are-complete",
       "mode": "query_scoped",
       "question_kind": "medication_enumeration",
-      "mandatory_ids": ["patient", "allergy-1"],
+      "mandatory_ids": ["p-1", "allergy-1", "cond-active"],
       "typed_complete_ids": ["med-1", "med-2", "med-3"],
-      "expected_included": ["patient", "allergy-1", "med-1", "med-2", "med-3"]
+      "expected_included": ["p-1", "allergy-1", "cond-active", "med-1", "med-2", "med-3"]
     },
     {
       "id": "context.temporal-adds-recency-anchor",
@@ -94,6 +94,7 @@
       "question_kind": "medication_enumeration",
       "budget_tokens": 1000,
       "selected_tokens": 420,
+      "must_exclude_ids": ["recent-1", "visit-1"],
       "expected": "accept_without_extra_records"
     },
     {

--- a/api/src/test/resources/conformance/dual-provider-conformance.v1.json
+++ b/api/src/test/resources/conformance/dual-provider-conformance.v1.json
@@ -1,0 +1,158 @@
+{
+  "schema_version": "dual_provider_conformance.v1",
+  "description": "Provider-neutral fixtures for the dual-provider foundational-parity roadmap. Records are synthetic contract data, not patient evidence.",
+  "provider_lifecycle": [
+    {
+      "id": "provider.lifecycle.required-answer-and-terminal",
+      "capabilities": ["answer"],
+      "events": ["turn_started", "answer_done", "turn_done"],
+      "expected": "accept"
+    },
+    {
+      "id": "provider.lifecycle.review-is-optional",
+      "capabilities": ["answer", "answer_review", "indepth"],
+      "events": ["turn_started", "answer_done", "answer_validation", "indepth_pending", "indepth_done", "turn_done"],
+      "expected": "accept"
+    },
+    {
+      "id": "provider.lifecycle.no-silent-fallback",
+      "capabilities": ["answer"],
+      "events": ["turn_started", "turn_error"],
+      "expected": "accept"
+    }
+  ],
+  "provider_capabilities": [
+    {
+      "id": "provider.capabilities.single-provider-no-picker",
+      "providers": ["bundled"],
+      "default_provider": "bundled",
+      "expected_picker": false
+    },
+    {
+      "id": "provider.capabilities.configured-hub-visible-when-unready",
+      "providers": ["bundled", "hub"],
+      "default_provider": "bundled",
+      "hub_ready": false,
+      "expected_picker": true,
+      "expected_hub_state": "disabled"
+    },
+    {
+      "id": "provider.capabilities.switch-starts-new-conversation",
+      "providers": ["bundled", "hub"],
+      "switch_from": "bundled",
+      "switch_to": "hub",
+      "expected": "new_conversation"
+    }
+  ],
+  "querystore_records": [
+    {
+      "id": "querystore.record.obs-clinical-date",
+      "resource_type": "obs",
+      "date": "2026-01-15",
+      "clinical_date": "2026-01-15",
+      "date_kind": "clinical_event",
+      "last_modified": "2026-01-16T12:00:00Z"
+    },
+    {
+      "id": "querystore.record.patient-administrative-date",
+      "resource_type": "patient",
+      "date": "2026-01-15",
+      "clinical_date": null,
+      "date_kind": "administrative",
+      "last_modified": "2026-01-16T12:00:00Z"
+    },
+    {
+      "id": "querystore.snapshot.all-pages-agree",
+      "snapshot_ids": ["snapshot-a", "snapshot-a"],
+      "expected": "accept"
+    },
+    {
+      "id": "querystore.snapshot.mixed-pages-rejected",
+      "snapshot_ids": ["snapshot-a", "snapshot-b"],
+      "expected": "reject_after_one_retry"
+    }
+  ],
+  "context_policy": [
+    {
+      "id": "context.enumerated-medications-are-complete",
+      "mode": "query_scoped",
+      "question_kind": "medication_enumeration",
+      "mandatory_ids": ["patient", "allergy-1"],
+      "typed_complete_ids": ["med-1", "med-2", "med-3"],
+      "expected_included": ["patient", "allergy-1", "med-1", "med-2", "med-3"]
+    },
+    {
+      "id": "context.temporal-adds-recency-anchor",
+      "mode": "query_scoped",
+      "question_kind": "temporal",
+      "recency_anchor_ids": ["visit-1"],
+      "expected_included": ["visit-1"]
+    },
+    {
+      "id": "context.non-temporal-does-not-fill-budget",
+      "mode": "query_scoped",
+      "question_kind": "medication_enumeration",
+      "budget_tokens": 1000,
+      "selected_tokens": 420,
+      "expected": "accept_without_extra_records"
+    },
+    {
+      "id": "context.mandatory-overflow-abstains",
+      "mode": "query_scoped",
+      "budget_tokens": 100,
+      "mandatory_tokens": 101,
+      "expected": "insufficient_context"
+    }
+  ],
+  "temporal_gate": [
+    {
+      "id": "temporal.malformed-date-fails",
+      "answer": "The next visit is 2025-10-//13.",
+      "expected_status": "fail"
+    },
+    {
+      "id": "temporal.non-ledger-date-fails",
+      "answer": "The last visit was 2026-02-17.",
+      "ledger_dates": ["2026-02-16"],
+      "expected_status": "fail"
+    },
+    {
+      "id": "temporal.date-value-binding-fails",
+      "answer": "Weight was 60 kg on 2026-01-01.",
+      "numeric_series": [{"date": "2026-01-01", "value": 58}],
+      "expected_status": "fail"
+    },
+    {
+      "id": "temporal.single-point-trend-fails",
+      "answer": "Weight is increasing.",
+      "numeric_series": [{"date": "2026-01-01", "value": 58}],
+      "expected_status": "fail"
+    }
+  ],
+  "drug_safety_status": [
+    {
+      "id": "drug-safety.complete-check-is-checked",
+      "source_package": "reviewed-package-v1",
+      "mapping_complete": true,
+      "exposure_complete": true,
+      "execution_complete": true,
+      "expected_status": "checked"
+    },
+    {
+      "id": "drug-safety.partial-check-is-limited",
+      "source_package": "reviewed-package-v1",
+      "mapping_complete": false,
+      "exposure_complete": true,
+      "execution_complete": true,
+      "expected_status": "limited"
+    },
+    {
+      "id": "drug_safety.missing-package-is-unavailable",
+      "source_package": null,
+      "mapping_complete": false,
+      "exposure_complete": false,
+      "execution_complete": false,
+      "expected_status": "unavailable"
+    }
+  ]
+}

--- a/api/src/test/resources/conformance/dual-provider-conformance.v1.json
+++ b/api/src/test/resources/conformance/dual-provider-conformance.v1.json
@@ -102,6 +102,23 @@
       "budget_tokens": 100,
       "mandatory_tokens": 101,
       "expected": "insufficient_context"
+    },
+    {
+      "id": "context.panel-completion-includes-all-members",
+      "similarity_matched_ids": ["panel-1"],
+      "panel_members": {"panel-1": ["member-1", "member-2"]},
+      "expected_included": ["panel-1", "member-1", "member-2"],
+      "expected_tier": {"panel-1": "similarity", "member-1": "panel", "member-2": "panel"}
+    },
+    {
+      "id": "context.stable-ordering-preserves-chart-order-and-highest-tier-wins",
+      "chart_order_ids": ["p-1", "recent-1", "cond-active", "allergy-1"],
+      "mandatory_ids": ["allergy-1"],
+      "typed_complete_ids": ["allergy-1"],
+      "similarity_matched_ids": ["allergy-1"],
+      "expected_no_duplicates": true,
+      "expected_order_precedes": [["p-1", "recent-1"], ["recent-1", "allergy-1"]],
+      "expected_tier": {"allergy-1": "mandatory"}
     }
   ],
   "temporal_gate": [
@@ -119,12 +136,14 @@
     {
       "id": "temporal.date-value-binding-fails",
       "answer": "Weight was 60 kg on 2026-01-01.",
+      "concept": "Weight",
       "numeric_series": [{"date": "2026-01-01", "value": 58}],
       "expected_status": "fail"
     },
     {
       "id": "temporal.single-point-trend-fails",
       "answer": "Weight is increasing.",
+      "concept": "Weight",
       "numeric_series": [{"date": "2026-01-01", "value": 58}],
       "expected_status": "fail"
     }

--- a/docs/embedding-improvement-plan.md
+++ b/docs/embedding-improvement-plan.md
@@ -1,5 +1,10 @@
 # Semantic Similarity Search — Improvement Plan
 
+> **Status: historical and superseded.** This plan describes ChartSearchAI's former local
+> embedding pre-filter. QueryStore now owns the shared clinical-record projection and context-slice
+> selection contract; current dual-provider work is recorded in the validation harness roadmap.
+> The analysis is retained for retrieval-research background only and is not an implementation plan.
+
 The embedding pre-filter in `LlmInferenceService.findSimilar()` returns inconsistent results: sometimes too many irrelevant records, sometimes missing relevant ones. This document analyzes the root causes and proposes improvements.
 
 ## Root Cause Analysis

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -18,8 +18,10 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
@@ -43,10 +45,27 @@ import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 import org.openmrs.module.chartsearchai.api.AuditLogService;
 import org.openmrs.module.chartsearchai.api.PatientAccessCheck;
+import org.openmrs.module.chartsearchai.api.conversation.ConversationService;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
 import org.openmrs.module.chartsearchai.api.impl.PrewarmBootstrapService;
 import org.openmrs.module.chartsearchai.api.impl.PrewarmStatus;
 import org.openmrs.module.chartsearchai.api.impl.WarmupExecutor;
+import org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope;
+import org.openmrs.module.chartsearchai.api.provider.CancellationSignal;
+import org.openmrs.module.chartsearchai.api.provider.ClinicalAnswerProvider;
+import org.openmrs.module.chartsearchai.api.provider.ClinicalAnswerProviderRegistry;
+import org.openmrs.module.chartsearchai.api.provider.HubClinicalAnswerProvider;
+import org.openmrs.module.chartsearchai.api.provider.ProviderCapability;
+import org.openmrs.module.chartsearchai.api.provider.ProviderDescriptor;
+import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
+import org.openmrs.module.chartsearchai.api.provider.ProviderUnavailableException;
+import org.openmrs.module.chartsearchai.api.provider.TurnEvent;
+import org.openmrs.module.chartsearchai.api.provider.TurnEventType;
+import org.openmrs.module.chartsearchai.api.provider.TurnRequest;
+import org.openmrs.module.chartsearchai.api.provider.TurnResult;
 import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
 import org.openmrs.module.chartsearchai.reference.SafetyWarning;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -123,6 +142,55 @@ public class ChartSearchAiRestController {
 	@Autowired
 	@Qualifier("chartSearchAi.prewarmBootstrapService")
 	private PrewarmBootstrapService prewarmBootstrapService;
+
+	@Autowired
+	@Qualifier("chartSearchAi.clinicalAnswerProviderRegistry")
+	private ClinicalAnswerProviderRegistry providerRegistry;
+
+	@Autowired
+	@Qualifier("chartSearchAi.conversationService")
+	private ConversationService conversationService;
+
+	/**
+	 * Provider discovery for the ESM picker. Fresh installs return only bundled with
+	 * {@code pickerVisible=false}; an enabled-but-unready hub stays listed with its reason.
+	 */
+	@RequestMapping(value = "/providers", method = RequestMethod.GET)
+	@ResponseBody
+	public ResponseEntity<Object> listProviders() {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+		return new ResponseEntity<Object>(
+				providersResponse(providerRegistry.descriptors(), providerRegistry.isPickerVisible(),
+						providerRegistry.getDefaultProviderId()),
+				HttpStatus.OK);
+	}
+
+	/**
+	 * Builds the {@code GET /providers} JSON body. Package-private for unit tests.
+	 */
+	static Map<String, Object> providersResponse(List<ProviderDescriptor> descriptors,
+			boolean pickerVisible, String defaultProviderId) {
+		List<Map<String, Object>> providers = new ArrayList<Map<String, Object>>();
+		for (ProviderDescriptor descriptor : descriptors) {
+			Map<String, Object> entry = new LinkedHashMap<String, Object>();
+			entry.put("id", descriptor.getId());
+			entry.put("label", descriptor.getLabel());
+			entry.put("enabled", descriptor.isEnabled());
+			entry.put("ready", descriptor.isReady());
+			entry.put("default", descriptor.isDefault());
+			entry.put("modes", descriptor.getModes().stream().map(ProviderMode::getWireName)
+					.collect(Collectors.toList()));
+			entry.put("capabilities", descriptor.getCapabilities().stream()
+					.map(ProviderCapability::getWireName).collect(Collectors.toList()));
+			entry.put("unavailableReason", descriptor.getUnavailableReason());
+			providers.add(entry);
+		}
+		Map<String, Object> response = new LinkedHashMap<String, Object>();
+		response.put("defaultProvider", defaultProviderId);
+		response.put("pickerVisible", pickerVisible);
+		response.put("providers", providers);
+		return response;
+	}
 
 	@RequestMapping(value = "/search", method = RequestMethod.POST)
 	@ResponseBody
@@ -626,6 +694,322 @@ public class ChartSearchAiRestController {
 	/** Test seam: production wires {@link AuditLogService} via {@code Autowired}. */
 	void setAuditLogService(AuditLogService auditLogService) {
 		this.auditLogService = auditLogService;
+	}
+
+	/** Test seam: production wires {@link ClinicalAnswerProviderRegistry} via {@code Autowired}. */
+	void setProviderRegistry(ClinicalAnswerProviderRegistry providerRegistry) {
+		this.providerRegistry = providerRegistry;
+	}
+
+	/** Test seam: production wires {@link ConversationService} via {@code Autowired}. */
+	void setConversationService(ConversationService conversationService) {
+		this.conversationService = conversationService;
+	}
+
+	/**
+	 * Close the active conversation for the selected provider/mode and open a fresh one.
+	 *
+	 * <pre>
+	 * POST /ws/rest/v1/chartsearchai/chat/new
+	 * { "patient": "...", "provider": "bundled|hub", "mode": "query_scoped?" }
+	 * </pre>
+	 */
+	@RequestMapping(value = "/chat/new", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Object> chatNew(@RequestBody Map<String, String> body) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+		PatientResolution resolved = resolvePatient(body == null ? null : body.get("patient"));
+		if (resolved.hasError()) {
+			return new ResponseEntity<Object>(errorResponse(resolved.errorMessage), resolved.errorStatus);
+		}
+		String providerId = resolveProviderId(body);
+		ProviderMode mode = resolveMode(body);
+		try {
+			providerRegistry.require(providerId);
+		}
+		catch (ProviderUnavailableException e) {
+			Map<String, Object> error = new LinkedHashMap<String, Object>();
+			error.put("error", e.getMessage());
+			error.put("problemCode", e.getProblemCode());
+			return new ResponseEntity<Object>(error, HttpStatus.BAD_REQUEST);
+		}
+		ClinicalConversation conversation = conversationService.startNew(resolved.patient, providerId,
+				mode);
+		Map<String, Object> response = new LinkedHashMap<String, Object>();
+		response.put("session", conversation.getUuid());
+		response.put("provider", conversation.getProviderId());
+		response.put("mode", conversation.getProviderMode());
+		response.put("messages", Collections.emptyList());
+		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	/**
+	 * Reload an existing conversation's turns for the authenticated user.
+	 *
+	 * <pre>
+	 * GET /ws/rest/v1/chartsearchai/chat?patient=...&amp;session=...
+	 * </pre>
+	 */
+	@RequestMapping(value = "/chat", method = RequestMethod.GET)
+	@ResponseBody
+	public ResponseEntity<Object> getChat(
+			@RequestParam(value = "patient", required = true) String patientUuid,
+			@RequestParam(value = "session", required = true) String sessionUuid) {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+		PatientResolution resolved = resolvePatient(patientUuid);
+		if (resolved.hasError()) {
+			return new ResponseEntity<Object>(errorResponse(resolved.errorMessage), resolved.errorStatus);
+		}
+		ClinicalConversation conversation = conversationService.getByUuid(sessionUuid);
+		if (conversation == null || !resolved.patient.equals(conversation.getPatient())) {
+			return new ResponseEntity<Object>(errorResponse("Conversation not found"), HttpStatus.NOT_FOUND);
+		}
+		List<Map<String, Object>> messages = new ArrayList<Map<String, Object>>();
+		for (ClinicalConversationTurn turn : conversationService.getTurns(conversation)) {
+			Map<String, Object> user = new LinkedHashMap<String, Object>();
+			user.put("role", "user");
+			user.put("content", turn.getQuestion());
+			user.put("requestId", turn.getRequestId());
+			messages.add(user);
+			if (turn.getAnswerText() != null) {
+				Map<String, Object> assistant = new LinkedHashMap<String, Object>();
+				assistant.put("role", "assistant");
+				assistant.put("content", turn.getAnswerText());
+				assistant.put("messageId", turn.getUuid());
+				assistant.put("terminalState", turn.getTerminalState());
+				messages.add(assistant);
+			}
+		}
+		Map<String, Object> response = new LinkedHashMap<String, Object>();
+		response.put("session", conversation.getUuid());
+		response.put("provider", conversation.getProviderId());
+		response.put("mode", conversation.getProviderMode());
+		response.put("messages", messages);
+		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	/**
+	 * Provider-neutral streaming chat turn. Emits canonical lifecycle SSE event names
+	 * ({@code turn_started}, {@code answer_delta}, {@code answer_done}, …). Bundled
+	 * {@code /search/stream} remains available for the legacy token/thinking/done wire.
+	 *
+	 * <pre>
+	 * POST /ws/rest/v1/chartsearchai/chat/stream
+	 * { "patient": "...", "question": "...", "provider": "bundled|hub",
+	 *   "mode": "query_scoped?", "profile": "hub-profile?", "session": "uuid?" }
+	 * </pre>
+	 */
+	@RequestMapping(value = "/chat/stream", method = RequestMethod.POST)
+	public void chatStream(@RequestBody Map<String, String> body, HttpServletResponse response)
+			throws IOException {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+
+		String patientUuid = body == null ? null : body.get("patient");
+		String question = body == null ? null : body.get("question");
+		if (patientUuid == null || patientUuid.trim().isEmpty()) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "patient is required");
+			return;
+		}
+		if (question == null || question.trim().isEmpty()) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "question is required");
+			return;
+		}
+		if (question.length() > MAX_QUESTION_LENGTH) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST,
+					"question exceeds maximum length of " + MAX_QUESTION_LENGTH + " characters");
+			return;
+		}
+		String sanitizedQuestion = CONTROL_CHARS.matcher(question).replaceAll("");
+		if (sanitizedQuestion.trim().isEmpty()) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, "question is required");
+			return;
+		}
+		String sanitizationError = validateQuestion(sanitizedQuestion);
+		if (sanitizationError != null) {
+			writeJsonError(response, HttpServletResponse.SC_BAD_REQUEST, sanitizationError);
+			return;
+		}
+
+		PatientResolution resolved = resolvePatient(patientUuid);
+		if (resolved.hasError()) {
+			writeJsonError(response, resolved.errorStatus.value(), resolved.errorMessage);
+			return;
+		}
+		User user = Context.getAuthenticatedUser();
+		ResponseEntity<Object> rateLimitError = checkRateLimit(user);
+		if (rateLimitError != null) {
+			writeJsonError(response, 429, "Rate limit exceeded");
+			return;
+		}
+
+		String providerId = resolveProviderId(body);
+		ProviderMode mode = resolveMode(body);
+		String profileId = body.get("profile");
+		String sessionUuid = body.get("session");
+
+		HttpServletResponse unwrapped = response;
+		while (unwrapped instanceof HttpServletResponseWrapper) {
+			javax.servlet.ServletResponse inner = ((HttpServletResponseWrapper) unwrapped).getResponse();
+			if (inner instanceof HttpServletResponse) {
+				unwrapped = (HttpServletResponse) inner;
+			} else {
+				break;
+			}
+		}
+		response.setContentType("text/event-stream");
+		response.setCharacterEncoding("UTF-8");
+		response.setHeader("Cache-Control", "no-cache");
+		response.setHeader("X-Accel-Buffering", "no");
+		response.setHeader("Connection", "keep-alive");
+		unwrapped.setBufferSize(0);
+		final OutputStream out = unwrapped.getOutputStream();
+		unwrapped.flushBuffer();
+
+		streamProviderTurn(out, resolved.patient, sanitizedQuestion, providerId, mode, profileId,
+				sessionUuid);
+	}
+
+	/**
+	 * Orchestrates one provider turn: resolve provider (no silent fallback), open/reuse a
+	 * provider-bound conversation, execute, persist, and relay canonical SSE events.
+	 * Package-private for unit tests.
+	 */
+	void streamProviderTurn(OutputStream out, Patient patient, String question, String providerId,
+			ProviderMode mode, String profileId, String conversationUuid) {
+		try {
+			ClinicalAnswerProvider provider;
+			try {
+				provider = providerRegistry.require(providerId);
+			}
+			catch (ProviderUnavailableException e) {
+				writeSseEvent(out, TurnEventType.TURN_STARTED.getWireName(), "{}");
+				writeSseEvent(out, TurnEventType.TURN_ERROR.getWireName(),
+						problemCodeJson(e.getProblemCode()));
+				return;
+			}
+			if (HubClinicalAnswerProvider.PROVIDER_ID.equals(providerId)
+					&& (profileId == null || profileId.trim().isEmpty())) {
+				writeSseEvent(out, TurnEventType.TURN_STARTED.getWireName(), "{}");
+				writeSseEvent(out, TurnEventType.TURN_ERROR.getWireName(),
+						problemCodeJson("profile_required"));
+				return;
+			}
+
+			ProviderMode resolvedMode = mode != null ? mode
+					: (provider.modes().isEmpty() ? ProviderMode.QUERY_SCOPED : provider.modes().get(0));
+			ClinicalConversation conversation = resolveConversation(patient, providerId, resolvedMode,
+					conversationUuid);
+			String requestId = UUID.randomUUID().toString();
+			ClinicalConversationTurn turn = conversationService.startTurn(conversation, requestId,
+					question);
+			List<PriorClinicalTurn> prior = conversationService.priorClinicalTurns(conversation);
+			TurnRequest request = new TurnRequest(patient, question, conversation.getUuid(), requestId,
+					resolvedMode, profileId, prior);
+
+			long startNs = System.nanoTime();
+			TurnResult result = provider
+					.execute(request, event -> writeTurnEventOrThrow(out, event, conversation, turn),
+							CancellationSignal.NONE)
+					.toCompletableFuture().get();
+			long responseTimeMs = (System.nanoTime() - startNs) / 1_000_000L;
+			conversationService.finishTurn(turn, result, responseTimeMs);
+		}
+		catch (Exception e) {
+			if (e.getCause() instanceof IOException) {
+				log.debug("Provider chat stream ended due to client disconnect");
+				return;
+			}
+			log.error("Provider chat stream failed for patient [id={}]", patient.getPatientId(), e);
+			try {
+				writeSseEvent(out, TurnEventType.TURN_ERROR.getWireName(),
+						problemCodeJson("provider_failure"));
+			}
+			catch (IOException ignored) {
+				log.debug("Could not send turn_error after provider failure");
+			}
+		}
+	}
+
+	private ClinicalConversation resolveConversation(Patient patient, String providerId,
+			ProviderMode mode, String conversationUuid) {
+		if (conversationUuid != null && !conversationUuid.trim().isEmpty()) {
+			ClinicalConversation existing = conversationService.getByUuid(conversationUuid.trim());
+			if (existing != null && patient.equals(existing.getPatient())
+					&& providerId.equals(existing.getProviderId())
+					&& ClinicalConversation.STATUS_ACTIVE.equals(existing.getStatus())
+					&& (mode == null || mode.getWireName().equals(existing.getProviderMode()))) {
+				return existing;
+			}
+		}
+		return conversationService.openOrCreate(patient, providerId, mode);
+	}
+
+	private void writeTurnEventOrThrow(OutputStream out, TurnEvent event,
+			ClinicalConversation conversation, ClinicalConversationTurn turn) {
+		try {
+			writeTurnEvent(out, event, conversation, turn);
+		}
+		catch (IOException e) {
+			log.debug("Client disconnected during provider turn event {}", event.getType());
+			throw new RuntimeException("Client disconnected", e);
+		}
+	}
+
+	private void writeTurnEvent(OutputStream out, TurnEvent event, ClinicalConversation conversation,
+			ClinicalConversationTurn turn) throws IOException {
+		TurnEventType type = event.getType();
+		String wire = type.getWireName();
+		if (type == TurnEventType.ANSWER_DELTA || type == TurnEventType.REASONING_DELTA) {
+			writeSseEvent(out, wire, event.getTextDelta() == null ? "" : event.getTextDelta());
+			return;
+		}
+		if (type == TurnEventType.TURN_ERROR) {
+			writeSseEvent(out, wire, problemCodeJson(event.getProblemCode()));
+			return;
+		}
+		if (type == TurnEventType.TURN_STARTED || type == TurnEventType.TURN_DONE) {
+			Map<String, Object> payload = new LinkedHashMap<String, Object>();
+			payload.put("session", conversation.getUuid());
+			payload.put("messageId", turn.getUuid());
+			payload.put("provider", event.getProviderId());
+			writeSseEvent(out, wire, new ObjectMapper().writeValueAsString(payload));
+			return;
+		}
+		Map<String, Object> payload = new LinkedHashMap<String, Object>();
+		AnswerEnvelope answer = event.getAnswer();
+		if (answer != null) {
+			payload.putAll(answer.getPayload());
+		}
+		payload.put("session", conversation.getUuid());
+		payload.put("messageId", turn.getUuid());
+		payload.put("provider", event.getProviderId());
+		payload.put("disclaimer", DISCLAIMER);
+		if (turn.getAuditLog() != null && turn.getAuditLog().getAuditLogId() != null) {
+			payload.put("auditLogId", turn.getAuditLog().getAuditLogId());
+		}
+		writeSseEvent(out, wire, new ObjectMapper().writeValueAsString(payload));
+	}
+
+	private static String problemCodeJson(String problemCode) throws IOException {
+		Map<String, Object> payload = new LinkedHashMap<String, Object>();
+		payload.put("problemCode", problemCode);
+		return new ObjectMapper().writeValueAsString(payload);
+	}
+
+	private String resolveProviderId(Map<String, String> body) {
+		String providerId = body == null ? null : body.get("provider");
+		if (providerId == null || providerId.trim().isEmpty()) {
+			return providerRegistry.getDefaultProviderId();
+		}
+		return providerId.trim();
+	}
+
+	private ProviderMode resolveMode(Map<String, String> body) {
+		String mode = body == null ? null : body.get("mode");
+		if (mode == null || mode.trim().isEmpty()) {
+			return ProviderMode.QUERY_SCOPED;
+		}
+		return ProviderMode.fromWireName(mode.trim());
 	}
 
 	@RequestMapping(value = "/auditlog", method = RequestMethod.GET)

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -1028,10 +1028,21 @@ public class ChartSearchAiRestController {
 		return providerId.trim();
 	}
 
-	private ProviderMode resolveMode(Map<String, String> body) {
+	/**
+	 * The caller's EXPLICIT mode override, or {@code null} when unspecified. Mode is a deployment
+	 * setting ({@code chartsearchai.chartMode}), not something callers normally send — {@code null}
+	 * here lets {@link #streamProviderTurn}'s {@code resolvedMode} fallback
+	 * ({@code provider.modes().get(0)}, sourced from the provider's live-configured mode) take
+	 * over. Hardcoding a literal default here previously pinned every conversation to
+	 * {@code query_scoped} regardless of the configured mode, and made
+	 * {@code chartsearchai.chartMode=fullChart} fail every turn with {@code unsupported_mode} (the
+	 * request's forced default never matched the provider's actual mode). Package-private for
+	 * {@code ProviderRestContractTest}.
+	 */
+	ProviderMode resolveMode(Map<String, String> body) {
 		String mode = body == null ? null : body.get("mode");
 		if (mode == null || mode.trim().isEmpty()) {
-			return ProviderMode.QUERY_SCOPED;
+			return null;
 		}
 		return ProviderMode.fromWireName(mode.trim());
 	}

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -1097,6 +1097,11 @@ public class ChartSearchAiRestController {
 	private void writeTurnEvent(OutputStream out, TurnEvent event, ClinicalConversation conversation,
 			ClinicalConversationTurn turn) throws IOException {
 		TurnEventType type = event.getType();
+		if (type == TurnEventType.ANSWER_VALIDATION && event.getAnswer() != null) {
+			// The composer becomes available after review while In-Depth may still run. Persist only
+			// the already checked/edited envelope so a follow-up sees safe prior context immediately.
+			conversationService.recordCheckedAnswer(turn, event.getAnswer());
+		}
 		String wire = type.getWireName();
 		if (type == TurnEventType.ANSWER_DELTA || type == TurnEventType.REASONING_DELTA) {
 			writeSseEvent(out, wire, event.getTextDelta() == null ? "" : event.getTextDelta());

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -1067,7 +1067,9 @@ public class ChartSearchAiRestController {
 		}
 	}
 
-	private ClinicalConversation resolveConversation(Patient patient, String providerId,
+	/** Package-private test seam — {@code ResolveConversationTest} exercises this directly rather
+	 *  than through the full SSE streaming path. */
+	ClinicalConversation resolveConversation(Patient patient, String providerId,
 			ProviderMode mode, String conversationUuid) {
 		if (conversationUuid != null && !conversationUuid.trim().isEmpty()) {
 			ClinicalConversation existing = conversationService.getByUuid(conversationUuid.trim());

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -337,6 +337,7 @@ public class ChartSearchAiRestController {
 		}
 		response.put("references", refs);
 		response.put("safetyWarnings", serializeSafetyWarnings(chartAnswer.getSafetyWarnings()));
+		response.put("safetyStatus", chartAnswer.getSafetyStatus());
 		if (auditLog.getAuditLogId() != null) {
 			response.put("questionId", String.valueOf(auditLog.getAuditLogId()));
 		}
@@ -624,6 +625,7 @@ public class ChartSearchAiRestController {
 				Map<String, Object> groundedData = new HashMap<String, Object>();
 				groundedData.put("references", serializeReferences(chartAnswer.getReferences()));
 				groundedData.put("safetyWarnings", serializeSafetyWarnings(chartAnswer.getSafetyWarnings()));
+				groundedData.put("safetyStatus", chartAnswer.getSafetyStatus());
 				if (earlyQuestionId[0] != null) {
 					groundedData.put("questionId", earlyQuestionId[0]);
 				}
@@ -712,6 +714,7 @@ public class ChartSearchAiRestController {
 		doneData.put("disclaimer", DISCLAIMER);
 		doneData.put("references", serializeReferences(answer.getReferences()));
 		doneData.put("safetyWarnings", serializeSafetyWarnings(answer.getSafetyWarnings()));
+		doneData.put("safetyStatus", answer.getSafetyStatus());
 		if (questionId != null) {
 			doneData.put("questionId", questionId);
 		}

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -151,6 +151,10 @@ public class ChartSearchAiRestController {
 	@Qualifier("chartSearchAi.conversationService")
 	private ConversationService conversationService;
 
+	@Autowired
+	@Qualifier("chartSearchAi.hubProfileService")
+	private org.openmrs.module.chartsearchai.api.impl.HubProfileService hubProfileService;
+
 	/**
 	 * Provider discovery for the ESM picker. Fresh installs return only bundled with
 	 * {@code pickerVisible=false}; an enabled-but-unready hub stays listed with its reason.
@@ -163,6 +167,26 @@ public class ChartSearchAiRestController {
 				providersResponse(providerRegistry.descriptors(), providerRegistry.isPickerVisible(),
 						providerRegistry.getDefaultProviderId()),
 				HttpStatus.OK);
+	}
+
+	/**
+	 * Relay med-agent-hub's authoritative product-profile metadata for the ESM profile picker.
+	 * ChartSearchAI does not merge, curate, or reinterpret the list; labels, availability,
+	 * capabilities, and the default marker all come from the hub.
+	 */
+	@RequestMapping(value = "/models", method = RequestMethod.GET)
+	@ResponseBody
+	public ResponseEntity<Object> listModels() {
+		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
+		try {
+			return new ResponseEntity<Object>(hubProfileService.listProfiles(), HttpStatus.OK);
+		}
+		catch (Exception e) {
+			log.warn("Failed to list hub profiles: {}", e.getMessage());
+			return new ResponseEntity<Object>(
+					errorResponse("Hub profile discovery is unavailable."),
+					HttpStatus.SERVICE_UNAVAILABLE);
+		}
 	}
 
 	/**

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -42,6 +42,7 @@ import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
 import org.openmrs.module.chartsearchai.util.DateFormatUtil;
 import org.openmrs.module.chartsearchai.api.ChartSearchService;
 import org.openmrs.module.chartsearchai.api.ChartTooLargeException;
+import org.openmrs.module.chartsearchai.api.InsufficientContextException;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 import org.openmrs.module.chartsearchai.api.AuditLogService;
@@ -279,6 +280,15 @@ public class ChartSearchAiRestController {
 			long startTime = System.currentTimeMillis();
 			chartAnswer = chartSearchService.search(patient, question);
 			responseTimeMs = System.currentTimeMillis() - startTime;
+		}
+		catch (InsufficientContextException e) {
+			log.warn("Mandatory clinical evidence exceeded the LLM input budget for patient [id={}]: {}",
+					patient.getPatientId(), e.getMessage());
+			return new ResponseEntity<Object>(
+					errorResponse("This patient's mandatory clinical evidence (demographics, allergies, "
+							+ "active conditions) exceeds the LLM's input budget. Contact your "
+							+ "administrator to increase the LLM context size."),
+					HttpStatus.UNPROCESSABLE_ENTITY);
 		}
 		catch (ChartTooLargeException e) {
 			log.warn("Chart too large for LLM context for patient [id={}]: {}",
@@ -630,6 +640,19 @@ public class ChartSearchAiRestController {
 					groundedData.put("questionId", earlyQuestionId[0]);
 				}
 				writeSseEvent(out, "grounded", new ObjectMapper().writeValueAsString(groundedData));
+			}
+		}
+		catch (InsufficientContextException e) {
+			log.warn("Mandatory clinical evidence exceeded the LLM input budget during streaming for "
+					+ "patient [id={}]: {}", patient.getPatientId(), e.getMessage());
+			try {
+				writeSseEvent(out, "error",
+						"This patient's mandatory clinical evidence (demographics, allergies, active "
+								+ "conditions) exceeds the LLM's input budget. Contact your administrator "
+								+ "to increase the LLM context size.");
+			}
+			catch (IOException ioe) {
+				log.debug("Could not send insufficient-context error event, client likely disconnected");
 			}
 		}
 		catch (ChartTooLargeException e) {

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -787,8 +787,9 @@ public class ChartSearchAiRestController {
 		}
 		String providerId = resolveProviderId(body);
 		ProviderMode mode = resolveMode(body);
+		ClinicalConversation conversation;
 		try {
-			providerRegistry.require(providerId);
+			conversation = startNewConversation(resolved.patient, providerId, mode);
 		}
 		catch (ProviderUnavailableException e) {
 			Map<String, Object> error = new LinkedHashMap<String, Object>();
@@ -796,8 +797,6 @@ public class ChartSearchAiRestController {
 			error.put("problemCode", e.getProblemCode());
 			return new ResponseEntity<Object>(error, HttpStatus.BAD_REQUEST);
 		}
-		ClinicalConversation conversation = conversationService.startNew(resolved.patient, providerId,
-				mode);
 		Map<String, Object> response = new LinkedHashMap<String, Object>();
 		response.put("session", conversation.getUuid());
 		response.put("provider", conversation.getProviderId());
@@ -1009,8 +1008,7 @@ public class ChartSearchAiRestController {
 				return;
 			}
 
-			ProviderMode resolvedMode = mode != null ? mode
-					: (provider.modes().isEmpty() ? ProviderMode.QUERY_SCOPED : provider.modes().get(0));
+			ProviderMode resolvedMode = resolveProviderMode(provider, mode);
 			conversation = resolveConversation(patient, providerId, resolvedMode, conversationUuid);
 			final ClinicalConversation activeConversation = conversation;
 			String requestId = UUID.randomUUID().toString();
@@ -1081,6 +1079,22 @@ public class ChartSearchAiRestController {
 			}
 		}
 		return conversationService.openOrCreate(patient, providerId, mode);
+	}
+
+	/** Resolve and persist a new provider-bound conversation with the same mode semantics as chat. */
+	ClinicalConversation startNewConversation(Patient patient, String providerId,
+			ProviderMode requestedMode) {
+		ClinicalAnswerProvider provider = providerRegistry.require(providerId);
+		return conversationService.startNew(patient, providerId,
+				resolveProviderMode(provider, requestedMode));
+	}
+
+	private ProviderMode resolveProviderMode(ClinicalAnswerProvider provider,
+			ProviderMode requestedMode) {
+		if (requestedMode != null) {
+			return requestedMode;
+		}
+		return provider.modes().isEmpty() ? ProviderMode.QUERY_SCOPED : provider.modes().get(0);
 	}
 
 	private void writeTurnEventOrThrow(OutputStream out, TurnEvent event,

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.openmrs.Patient;
@@ -51,7 +52,6 @@ import org.openmrs.module.chartsearchai.api.impl.PrewarmBootstrapService;
 import org.openmrs.module.chartsearchai.api.impl.PrewarmStatus;
 import org.openmrs.module.chartsearchai.api.impl.WarmupExecutor;
 import org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope;
-import org.openmrs.module.chartsearchai.api.provider.CancellationSignal;
 import org.openmrs.module.chartsearchai.api.provider.ClinicalAnswerProvider;
 import org.openmrs.module.chartsearchai.api.provider.ClinicalAnswerProviderRegistry;
 import org.openmrs.module.chartsearchai.api.provider.HubClinicalAnswerProvider;
@@ -61,6 +61,8 @@ import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
 import org.openmrs.module.chartsearchai.api.provider.ProviderUnavailableException;
 import org.openmrs.module.chartsearchai.api.provider.TurnEvent;
 import org.openmrs.module.chartsearchai.api.provider.TurnEventType;
+import org.openmrs.module.chartsearchai.api.provider.TurnCancellation;
+import org.openmrs.module.chartsearchai.api.provider.TurnPreemptionRegistry;
 import org.openmrs.module.chartsearchai.api.provider.TurnRequest;
 import org.openmrs.module.chartsearchai.api.provider.TurnResult;
 import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
@@ -154,6 +156,12 @@ public class ChartSearchAiRestController {
 	@Autowired
 	@Qualifier("chartSearchAi.hubProfileService")
 	private org.openmrs.module.chartsearchai.api.impl.HubProfileService hubProfileService;
+
+	// A conversation has at most one turn in flight at a time — a new turn starting for the same
+	// conversation always supersedes whatever came before it. This controller is a singleton bean
+	// (default Spring MVC @Controller scope), so one registry instance safely tracks preemption
+	// across every concurrent request.
+	private TurnPreemptionRegistry preemptionRegistry = new TurnPreemptionRegistry();
 
 	/**
 	 * Provider discovery for the ESM picker. Fresh installs return only bundled with
@@ -730,6 +738,11 @@ public class ChartSearchAiRestController {
 		this.conversationService = conversationService;
 	}
 
+	/** Test seam: production uses the default instance constructed above. */
+	void setPreemptionRegistry(TurnPreemptionRegistry preemptionRegistry) {
+		this.preemptionRegistry = preemptionRegistry;
+	}
+
 	/**
 	 * Close the active conversation for the selected provider/mode and open a fresh one.
 	 *
@@ -768,25 +781,55 @@ public class ChartSearchAiRestController {
 	}
 
 	/**
-	 * Reload an existing conversation's turns for the authenticated user.
+	 * Reload an existing conversation's turns for the authenticated user. {@code session} is
+	 * optional: a fresh page load has no client-side session to send, only the patient it's
+	 * looking at, so an omitted session falls back to the caller's own latest active conversation
+	 * for that patient (see {@link #buildChatHistoryResponse}).
 	 *
 	 * <pre>
-	 * GET /ws/rest/v1/chartsearchai/chat?patient=...&amp;session=...
+	 * GET /ws/rest/v1/chartsearchai/chat?patient=...&amp;session=...?
 	 * </pre>
 	 */
 	@RequestMapping(value = "/chat", method = RequestMethod.GET)
 	@ResponseBody
 	public ResponseEntity<Object> getChat(
 			@RequestParam(value = "patient", required = true) String patientUuid,
-			@RequestParam(value = "session", required = true) String sessionUuid) {
+			@RequestParam(value = "session", required = false) String sessionUuid) {
 		Context.requirePrivilege(ChartSearchAiConstants.PRIV_QUERY_PATIENT_DATA);
 		PatientResolution resolved = resolvePatient(patientUuid);
 		if (resolved.hasError()) {
 			return new ResponseEntity<Object>(errorResponse(resolved.errorMessage), resolved.errorStatus);
 		}
-		ClinicalConversation conversation = conversationService.getByUuid(sessionUuid);
-		if (conversation == null || !resolved.patient.equals(conversation.getPatient())) {
-			return new ResponseEntity<Object>(errorResponse("Conversation not found"), HttpStatus.NOT_FOUND);
+		return buildChatHistoryResponse(resolved.patient, sessionUuid);
+	}
+
+	/**
+	 * Resolves which conversation to show — by explicit session, or the caller's latest active
+	 * conversation for this patient when session is omitted — and serializes its turns, including
+	 * each assistant turn's full persisted answer envelope (references, blocks, safety warnings,
+	 * confidence, answer validation, In-Depth) so a reload restores exactly what was on screen
+	 * before it, not just the bare answer text. Package-private for unit tests.
+	 */
+	ResponseEntity<Object> buildChatHistoryResponse(Patient patient, String sessionUuid) {
+		ClinicalConversation conversation;
+		if (sessionUuid != null && !sessionUuid.trim().isEmpty()) {
+			conversation = conversationService.getByUuid(sessionUuid.trim());
+			if (conversation == null || !patient.equals(conversation.getPatient())) {
+				return new ResponseEntity<Object>(errorResponse("Conversation not found"), HttpStatus.NOT_FOUND);
+			}
+		}
+		else {
+			conversation = conversationService.getLatestActiveConversation(patient);
+			if (conversation == null) {
+				// Nobody has asked anything yet for this patient — a normal empty state, not an
+				// error (the caller has no session to have gotten wrong).
+				Map<String, Object> empty = new LinkedHashMap<String, Object>();
+				empty.put("session", null);
+				empty.put("provider", null);
+				empty.put("mode", null);
+				empty.put("messages", Collections.emptyList());
+				return new ResponseEntity<Object>(empty, HttpStatus.OK);
+			}
 		}
 		List<Map<String, Object>> messages = new ArrayList<Map<String, Object>>();
 		for (ClinicalConversationTurn turn : conversationService.getTurns(conversation)) {
@@ -797,10 +840,16 @@ public class ChartSearchAiRestController {
 			messages.add(user);
 			if (turn.getAnswerText() != null) {
 				Map<String, Object> assistant = new LinkedHashMap<String, Object>();
+				Map<String, Object> payload = parseProviderPayload(turn.getProviderPayload());
+				if (payload != null) {
+					assistant.putAll(payload);
+				}
 				assistant.put("role", "assistant");
 				assistant.put("content", turn.getAnswerText());
 				assistant.put("messageId", turn.getUuid());
-				assistant.put("terminalState", turn.getTerminalState());
+				if (turn.getAuditLog() != null) {
+					assistant.put("auditLogId", turn.getAuditLog().getAuditLogId());
+				}
 				messages.add(assistant);
 			}
 		}
@@ -810,6 +859,19 @@ public class ChartSearchAiRestController {
 		response.put("mode", conversation.getProviderMode());
 		response.put("messages", messages);
 		return new ResponseEntity<Object>(response, HttpStatus.OK);
+	}
+
+	private Map<String, Object> parseProviderPayload(String json) {
+		if (json == null || json.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return new ObjectMapper().readValue(json, new TypeReference<Map<String, Object>>() {});
+		}
+		catch (IOException e) {
+			log.warn("Could not parse a persisted turn's provider payload; restoring bare content only", e);
+			return null;
+		}
 	}
 
 	/**
@@ -900,6 +962,8 @@ public class ChartSearchAiRestController {
 	 */
 	void streamProviderTurn(OutputStream out, Patient patient, String question, String providerId,
 			ProviderMode mode, String profileId, String conversationUuid) {
+		ClinicalConversation conversation = null;
+		TurnCancellation cancellation = null;
 		try {
 			ClinicalAnswerProvider provider;
 			try {
@@ -921,19 +985,37 @@ public class ChartSearchAiRestController {
 
 			ProviderMode resolvedMode = mode != null ? mode
 					: (provider.modes().isEmpty() ? ProviderMode.QUERY_SCOPED : provider.modes().get(0));
-			ClinicalConversation conversation = resolveConversation(patient, providerId, resolvedMode,
-					conversationUuid);
+			conversation = resolveConversation(patient, providerId, resolvedMode, conversationUuid);
+			final ClinicalConversation activeConversation = conversation;
 			String requestId = UUID.randomUUID().toString();
-			ClinicalConversationTurn turn = conversationService.startTurn(conversation, requestId,
+			ClinicalConversationTurn turn = conversationService.startTurn(activeConversation, requestId,
 					question);
-			List<PriorClinicalTurn> prior = conversationService.priorClinicalTurns(conversation);
-			TurnRequest request = new TurnRequest(patient, question, conversation.getUuid(), requestId,
-					resolvedMode, profileId, prior);
+			List<PriorClinicalTurn> prior = conversationService.priorClinicalTurns(activeConversation);
+			TurnRequest request = new TurnRequest(patient, question, activeConversation.getUuid(),
+					requestId, resolvedMode, profileId, prior);
+
+			// A new turn starting for this conversation IS the preempt signal — it cancels
+			// whichever turn currently holds that conversation's slot (see TurnPreemptionRegistry),
+			// forcibly closing that turn's open hub connection instead of letting it run to the
+			// hub's own completion after the browser has already moved on.
+			cancellation = preemptionRegistry.begin(activeConversation.getUuid());
+			final TurnCancellation activeCancellation = cancellation;
 
 			long startNs = System.nanoTime();
 			TurnResult result = provider
-					.execute(request, event -> writeTurnEventOrThrow(out, event, conversation, turn),
-							CancellationSignal.NONE)
+					.execute(request,
+							event -> {
+								// Once THIS turn is the one being cancelled, its browser connection is
+								// already gone by definition — that is what cancellation means. Writing
+								// to it would only throw and abort execute() before it can return a
+								// result to persist (see HubClinicalAnswerProvider's partial-answer
+								// completion), so drop silently rather than propagate.
+								if (activeCancellation.isCancelled()) {
+									return;
+								}
+								writeTurnEventOrThrow(out, event, activeConversation, turn);
+							},
+							cancellation)
 					.toCompletableFuture().get();
 			long responseTimeMs = (System.nanoTime() - startNs) / 1_000_000L;
 			conversationService.finishTurn(turn, result, responseTimeMs);
@@ -950,6 +1032,11 @@ public class ChartSearchAiRestController {
 			}
 			catch (IOException ignored) {
 				log.debug("Could not send turn_error after provider failure");
+			}
+		}
+		finally {
+			if (conversation != null && cancellation != null) {
+				preemptionRegistry.end(conversation.getUuid(), cancellation);
 			}
 		}
 	}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -23,6 +23,8 @@
 	<!-- Hibernate Mappings -->
 	<mappingFiles>
 		ChartSearchAuditLog.hbm.xml
+		ClinicalConversation.hbm.xml
+		ClinicalConversationTurn.hbm.xml
 	</mappingFiles>
 
 	<!-- Privileges -->

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChatHistoryEndpointTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChatHistoryEndpointTest.java
@@ -202,6 +202,12 @@ public class ChatHistoryEndpointTest {
 		}
 
 		@Override
+		public boolean recordCheckedAnswer(ClinicalConversationTurn turn,
+				org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope answer) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation) {
 			throw new UnsupportedOperationException();
 		}

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChatHistoryEndpointTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ChatHistoryEndpointTest.java
@@ -1,0 +1,209 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.web.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.conversation.ConversationService;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
+import org.openmrs.module.chartsearchai.api.provider.TurnResult;
+import org.openmrs.module.chartsearchai.model.ChartSearchAuditLog;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * {@code GET /chat} reload/history recovery. A fresh page load has no client-side session to
+ * send — only the patient it's looking at — so {@code session} must be optional, falling back to
+ * the caller's own active conversation, and each restored assistant turn must carry its full
+ * persisted answer envelope (references, In-Depth, etc.), not just bare text — otherwise a reload
+ * silently drops the evidence and validation state that was on screen a moment before.
+ */
+public class ChatHistoryEndpointTest {
+
+	private static Patient patient() {
+		Patient patient = new Patient();
+		patient.setUuid("patient-1");
+		patient.setPatientId(1);
+		return patient;
+	}
+
+	private static ClinicalConversation conversation(String uuid, Patient patient) {
+		ClinicalConversation conversation = new ClinicalConversation();
+		conversation.setUuid(uuid);
+		conversation.setPatient(patient);
+		conversation.setProviderId("hub");
+		conversation.setProviderMode("query_scoped");
+		conversation.setStatus(ClinicalConversation.STATUS_ACTIVE);
+		return conversation;
+	}
+
+	@Test
+	public void withNoSessionAndNoActiveConversationReturnsAnEmptyHistoryNotAnError() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		controller.setConversationService(new StubConversationService());
+
+		ResponseEntity<Object> response = controller.buildChatHistoryResponse(patient(), null);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		@SuppressWarnings("unchecked")
+		Map<String, Object> body = (Map<String, Object>) response.getBody();
+		assertNull(body.get("session"));
+		assertEquals(Collections.emptyList(), body.get("messages"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void withNoSessionRecoversTheCallersActiveConversation() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		ClinicalConversation active = conversation("conversation-uuid-1", patient());
+		conversations.activeConversation = active;
+		controller.setConversationService(conversations);
+
+		ResponseEntity<Object> response = controller.buildChatHistoryResponse(patient(), null);
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		Map<String, Object> body = (Map<String, Object>) response.getBody();
+		assertEquals("conversation-uuid-1", body.get("session"));
+		assertEquals("hub", body.get("provider"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void restoresTheFullAnswerEnvelopeFromThePersistedPayloadNotJustBareText() {
+		// The whole point of surviving reload: citations, safety warnings, and the In-Depth
+		// verdict must come back exactly as they were, not collapse to plain text.
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		ClinicalConversation active = conversation("conversation-uuid-1", patient());
+		conversations.activeConversation = active;
+
+		ClinicalConversationTurn turn = new ClinicalConversationTurn();
+		turn.setUuid("turn-uuid-1");
+		turn.setQuestion("What medications is this patient on?");
+		turn.setRequestId("request-1");
+		turn.setAnswerText("Aspirin 81mg [1].");
+		turn.setProviderPayload("{\"answer\":\"Aspirin 81mg [1].\","
+				+ "\"references\":[{\"index\":1,\"resourceType\":\"drugOrder\"}],"
+				+ "\"answerValidation\":{\"status\":\"checked\"},"
+				+ "\"inDepth\":{\"status\":\"needs_review\"}}");
+		ChartSearchAuditLog audit = new ChartSearchAuditLog();
+		audit.setAuditLogId(42);
+		turn.setAuditLog(audit);
+		conversations.turns.put("conversation-uuid-1", Collections.singletonList(turn));
+		controller.setConversationService(conversations);
+
+		ResponseEntity<Object> response = controller.buildChatHistoryResponse(patient(), null);
+
+		Map<String, Object> body = (Map<String, Object>) response.getBody();
+		List<Map<String, Object>> messages = (List<Map<String, Object>>) body.get("messages");
+		assertEquals(2, messages.size());
+		Map<String, Object> assistant = messages.get(1);
+		assertEquals("assistant", assistant.get("role"));
+		assertEquals("Aspirin 81mg [1].", assistant.get("content"));
+		assertEquals(42, assistant.get("auditLogId"));
+		assertTrue(assistant.get("references") instanceof List, "references must survive reload");
+		assertEquals(1, ((List<?>) assistant.get("references")).size());
+		Map<String, Object> validation = (Map<String, Object>) assistant.get("answerValidation");
+		assertEquals("checked", validation.get("status"));
+		Map<String, Object> inDepth = (Map<String, Object>) assistant.get("inDepth");
+		assertEquals("needs_review", inDepth.get("status"));
+	}
+
+	@Test
+	public void anExplicitSessionIsPreferredOverTheCallersActiveConversation() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		conversations.activeConversation = conversation("active-but-not-requested", patient());
+		ClinicalConversation requested = conversation("explicitly-requested", patient());
+		conversations.byUuid.put("explicitly-requested", requested);
+		controller.setConversationService(conversations);
+
+		ResponseEntity<Object> response = controller.buildChatHistoryResponse(patient(), "explicitly-requested");
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> body = (Map<String, Object>) response.getBody();
+		assertEquals("explicitly-requested", body.get("session"));
+	}
+
+	@Test
+	public void anExplicitSessionThatDoesNotExistIs404() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		controller.setConversationService(new StubConversationService());
+
+		ResponseEntity<Object> response = controller.buildChatHistoryResponse(patient(), "does-not-exist");
+
+		assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+	}
+
+	private static final class StubConversationService implements ConversationService {
+
+		ClinicalConversation activeConversation;
+
+		final Map<String, ClinicalConversation> byUuid = new HashMap<>();
+
+		final Map<String, List<ClinicalConversationTurn>> turns = new HashMap<>();
+
+		@Override
+		public ClinicalConversation openOrCreate(Patient patient, String providerId, ProviderMode mode) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ClinicalConversation startNew(Patient patient, String providerId, ProviderMode mode) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ClinicalConversation getByUuid(String uuid) {
+			return byUuid.get(uuid);
+		}
+
+		@Override
+		public ClinicalConversation getLatestActiveConversation(Patient patient) {
+			return activeConversation;
+		}
+
+		@Override
+		public List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation) {
+			return turns.getOrDefault(conversation.getUuid(), new ArrayList<ClinicalConversationTurn>());
+		}
+
+		@Override
+		public ClinicalConversationTurn startTurn(ClinicalConversation conversation, String requestId,
+				String question) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ClinicalConversationTurn finishTurn(ClinicalConversationTurn turn, TurnResult result,
+				long responseTimeMs) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
@@ -1,0 +1,344 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.web.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.conversation.ConversationService;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+import org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope;
+import org.openmrs.module.chartsearchai.api.provider.CancellationSignal;
+import org.openmrs.module.chartsearchai.api.provider.ClinicalAnswerProvider;
+import org.openmrs.module.chartsearchai.api.provider.ClinicalAnswerProviderRegistry;
+import org.openmrs.module.chartsearchai.api.provider.ProviderCapability;
+import org.openmrs.module.chartsearchai.api.provider.ProviderDescriptor;
+import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
+import org.openmrs.module.chartsearchai.api.provider.TurnEvent;
+import org.openmrs.module.chartsearchai.api.provider.TurnEventSink;
+import org.openmrs.module.chartsearchai.api.provider.TurnEventType;
+import org.openmrs.module.chartsearchai.api.provider.TurnRequest;
+import org.openmrs.module.chartsearchai.api.provider.TurnResult;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * REST contract for provider discovery and provider-neutral chat streaming. Driven through the
+ * controller's package-private orchestration seams with stubbed registry/conversation services —
+ * same style as {@link ChartSearchAiStreamEventOrderTest}.
+ */
+public class ProviderRestContractTest {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void providersPayloadExposesPickerVisibilityDefaultAndUnavailableHub() {
+		ProviderDescriptor bundled = new ProviderDescriptor("bundled", "ChartSearchAI (bundled)", true,
+				true, true, Collections.singletonList(ProviderMode.QUERY_SCOPED),
+				EnumSet.of(ProviderCapability.ANSWER, ProviderCapability.TOKEN_STREAMING), null);
+		ProviderDescriptor hub = new ProviderDescriptor("hub", "med-agent-hub", true, false, false,
+				Collections.singletonList(ProviderMode.QUERY_SCOPED),
+				EnumSet.of(ProviderCapability.ANSWER, ProviderCapability.INDEPTH),
+				"chartsearchai.hub.endpointUrl is not set");
+
+		Map<String, Object> payload = ChartSearchAiRestController.providersResponse(
+				Arrays.asList(bundled, hub), true, "bundled");
+
+		assertEquals("bundled", payload.get("defaultProvider"));
+		assertEquals(Boolean.TRUE, payload.get("pickerVisible"));
+		List<Map<String, Object>> providers = (List<Map<String, Object>>) payload.get("providers");
+		assertEquals(2, providers.size());
+		assertEquals("bundled", providers.get(0).get("id"));
+		assertEquals(Boolean.TRUE, providers.get(0).get("default"));
+		assertEquals(Boolean.TRUE, providers.get(0).get("ready"));
+		assertEquals(Arrays.asList("query_scoped"), providers.get(0).get("modes"));
+		assertTrue(((List<?>) providers.get(0).get("capabilities")).contains("answer"));
+		assertEquals("hub", providers.get(1).get("id"));
+		assertEquals(Boolean.FALSE, providers.get(1).get("ready"));
+		assertEquals("chartsearchai.hub.endpointUrl is not set",
+				providers.get(1).get("unavailableReason"));
+		assertFalse((Boolean) providers.get(1).get("default"));
+	}
+
+	@Test
+	public void chatStreamMapsCanonicalTurnEventsAndPersistsThroughConversationService()
+			throws Exception {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider provider = new ScriptedProvider("bundled", true);
+		provider.events = Arrays.asList(
+				TurnEvent.of(TurnEventType.TURN_STARTED, 0, "bundled"),
+				TurnEvent.delta(TurnEventType.ANSWER_DELTA, 1, "bundled", "Aspirin "),
+				TurnEvent.withAnswer(TurnEventType.ANSWER_DONE, 2, "bundled",
+						AnswerEnvelope.fromPayload(answerPayload("Aspirin 81mg."))),
+				TurnEvent.of(TurnEventType.TURN_DONE, 3, "bundled"));
+		provider.result = TurnResult.done("bundled", ProviderMode.QUERY_SCOPED,
+				AnswerEnvelope.fromPayload(answerPayload("Aspirin 81mg.")));
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(provider));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		controller.streamProviderTurn(out, patient(), "What meds?", "bundled",
+				ProviderMode.QUERY_SCOPED, null, null);
+
+		List<String> types = sseTypes(out);
+		assertEquals(Arrays.asList("turn_started", "answer_delta", "answer_done", "turn_done"),
+				types);
+		assertEquals(1, conversations.started);
+		assertEquals(1, conversations.finished);
+		assertEquals("Aspirin 81mg.", conversations.lastFinishedAnswer);
+		assertEquals("conversation-uuid-1", conversations.openConversation.getUuid());
+		JsonNode answerDone = ssePayload(out, "answer_done");
+		assertEquals("Aspirin 81mg.", answerDone.get("answer").asText());
+		assertEquals("turn-uuid-1", answerDone.get("messageId").asText());
+		assertEquals("conversation-uuid-1", answerDone.get("session").asText());
+	}
+
+	@Test
+	public void chatStreamFailsWithTurnErrorWhenProviderIsUnavailableWithoutFallback()
+			throws Exception {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider bundled = new ScriptedProvider("bundled", true);
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(bundled));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		controller.streamProviderTurn(out, patient(), "What meds?", "hub",
+				ProviderMode.QUERY_SCOPED, null, null);
+
+		List<String> types = sseTypes(out);
+		assertEquals(Arrays.asList("turn_started", "turn_error"), types);
+		assertEquals(0, conversations.started);
+		assertEquals(0, conversations.finished);
+		JsonNode error = ssePayload(out, "turn_error");
+		assertEquals("unknown_provider", error.get("problemCode").asText());
+	}
+
+	@Test
+	public void chatStreamRequiresHubProfileAndNeverCallsAnUnreadyProvider() throws Exception {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider hub = new ScriptedProvider("hub", true);
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(hub));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		controller.streamProviderTurn(out, patient(), "What meds?", "hub",
+				ProviderMode.QUERY_SCOPED, null, null);
+
+		assertEquals(0, hub.calls.get());
+		assertEquals(Arrays.asList("turn_started", "turn_error"), sseTypes(out));
+		assertEquals("profile_required", ssePayload(out, "turn_error").get("problemCode").asText());
+	}
+
+	private static Patient patient() {
+		Patient patient = new Patient();
+		patient.setUuid("patient-1");
+		patient.setPatientId(1);
+		return patient;
+	}
+
+	/** Registry that enables every constructed provider without reading OpenMRS GPs. */
+	private static ClinicalAnswerProviderRegistry stubRegistry(ClinicalAnswerProvider... providers) {
+		List<ClinicalAnswerProvider> list = Arrays.asList(providers);
+		String enabled = list.stream().map(ClinicalAnswerProvider::id)
+				.collect(Collectors.joining(","));
+		return new ClinicalAnswerProviderRegistry(list) {
+			private final Map<String, String> gps = new HashMap<>();
+			{
+				gps.put(ClinicalAnswerProviderRegistry.GP_PROVIDERS_ENABLED, enabled);
+				gps.put(ClinicalAnswerProviderRegistry.GP_DEFAULT_PROVIDER, list.get(0).id());
+			}
+
+			@Override
+			protected String gp(String property, String defaultValue) {
+				return gps.containsKey(property) ? gps.get(property) : defaultValue;
+			}
+		};
+	}
+
+	private static Map<String, Object> answerPayload(String answer) {
+		Map<String, Object> payload = new LinkedHashMap<>();
+		payload.put("answer", answer);
+		payload.put("references", Collections.emptyList());
+		return payload;
+	}
+
+	private static List<String> sseTypes(ByteArrayOutputStream out) {
+		List<String> types = new ArrayList<>();
+		for (String block : new String(out.toByteArray(), StandardCharsets.UTF_8).split("\n\n")) {
+			for (String line : block.split("\n")) {
+				if (line.startsWith("event: ")) {
+					types.add(line.substring(7).trim());
+				}
+			}
+		}
+		return types;
+	}
+
+	private static JsonNode ssePayload(ByteArrayOutputStream out, String type) throws Exception {
+		String current = null;
+		StringBuilder data = new StringBuilder();
+		for (String block : new String(out.toByteArray(), StandardCharsets.UTF_8).split("\n\n")) {
+			current = null;
+			data.setLength(0);
+			for (String line : block.split("\n")) {
+				if (line.startsWith("event: ")) {
+					current = line.substring(7).trim();
+				} else if (line.startsWith("data: ")) {
+					data.append(line.substring(6));
+				}
+			}
+			if (type.equals(current)) {
+				return MAPPER.readTree(data.toString());
+			}
+		}
+		return null;
+	}
+
+	private static final class ScriptedProvider implements ClinicalAnswerProvider {
+
+		private final String id;
+
+		private final boolean ready;
+
+		private final AtomicInteger calls = new AtomicInteger();
+
+		List<TurnEvent> events = Collections.emptyList();
+
+		TurnResult result;
+
+		ScriptedProvider(String id, boolean ready) {
+			this.id = id;
+			this.ready = ready;
+		}
+
+		@Override
+		public String id() {
+			return id;
+		}
+
+		@Override
+		public ProviderDescriptor descriptor() {
+			return new ProviderDescriptor(id, id, true, ready, "bundled".equals(id),
+					Collections.singletonList(ProviderMode.QUERY_SCOPED),
+					EnumSet.of(ProviderCapability.ANSWER, ProviderCapability.TOKEN_STREAMING),
+					ready ? null : "not ready");
+		}
+
+		@Override
+		public CompletionStage<TurnResult> execute(TurnRequest request, TurnEventSink sink,
+				CancellationSignal cancellation) {
+			calls.incrementAndGet();
+			if (request.getProfileId() == null && "hub".equals(id)) {
+				sink.accept(TurnEvent.of(TurnEventType.TURN_STARTED, 0, id));
+				sink.accept(TurnEvent.error(1, id, "profile_required"));
+				return CompletableFuture.completedFuture(
+						TurnResult.error(id, request.getMode(), "profile_required"));
+			}
+			for (TurnEvent event : events) {
+				sink.accept(event);
+			}
+			return CompletableFuture.completedFuture(result);
+		}
+	}
+
+	private static final class RecordingConversationService implements ConversationService {
+
+		ClinicalConversation openConversation;
+
+		int started;
+
+		int finished;
+
+		String lastFinishedAnswer;
+
+		RecordingConversationService() {
+			openConversation = new ClinicalConversation();
+			openConversation.setUuid("conversation-uuid-1");
+			openConversation.setProviderId("bundled");
+			openConversation.setProviderMode(ProviderMode.QUERY_SCOPED.getWireName());
+			openConversation.setStatus(ClinicalConversation.STATUS_ACTIVE);
+		}
+
+		@Override
+		public ClinicalConversation openOrCreate(Patient patient, String providerId,
+				ProviderMode mode) {
+			openConversation.setPatient(patient);
+			openConversation.setProviderId(providerId);
+			openConversation.setProviderMode(mode == null ? null : mode.getWireName());
+			return openConversation;
+		}
+
+		@Override
+		public ClinicalConversation startNew(Patient patient, String providerId,
+				ProviderMode mode) {
+			return openOrCreate(patient, providerId, mode);
+		}
+
+		@Override
+		public ClinicalConversation getByUuid(String uuid) {
+			return openConversation.getUuid().equals(uuid) ? openConversation : null;
+		}
+
+		@Override
+		public List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation) {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public ClinicalConversationTurn startTurn(ClinicalConversation conversation,
+				String requestId, String question) {
+			started++;
+			ClinicalConversationTurn turn = new ClinicalConversationTurn();
+			turn.setUuid("turn-uuid-1");
+			turn.setConversation(conversation);
+			turn.setQuestion(question);
+			turn.setRequestId(requestId);
+			return turn;
+		}
+
+		@Override
+		public ClinicalConversationTurn finishTurn(ClinicalConversationTurn turn,
+				TurnResult result, long responseTimeMs) {
+			finished++;
+			lastFinishedAnswer = result.getAnswer() == null ? null : result.getAnswer().getText();
+			return turn;
+		}
+
+		@Override
+		public List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation) {
+			return Collections.emptyList();
+		}
+	}
+}

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
@@ -318,6 +318,21 @@ public class ProviderRestContractTest {
 	}
 
 	@Test
+	public void newConversationUsesTheProvidersLiveModeWhenTheRequestOmitsMode() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider hub = new ScriptedProvider("hub", true);
+		hub.mode = ProviderMode.FULL_CHART_STABLE;
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(hub));
+
+		ClinicalConversation created = controller.startNewConversation(patient(), "hub", null);
+
+		assertEquals("hub", created.getProviderId());
+		assertEquals(ProviderMode.FULL_CHART_STABLE.getWireName(), created.getProviderMode());
+	}
+
+	@Test
 	public void chatStreamWithNoExplicitModeUsesTheProvidersLiveConfiguredMode() throws Exception {
 		// Regression: chartsearchai.chartMode=fullChart previously failed EVERY turn with
 		// unsupported_mode, because resolveMode's hardcoded query_scoped default never matched

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
@@ -128,6 +128,33 @@ public class ProviderRestContractTest {
 	}
 
 	@Test
+	public void checkedAnswerIsRecordedBeforeItsInDepthTailCompletes() throws Exception {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider provider = new ScriptedProvider("hub", true);
+		Map<String, Object> checked = answerPayload("2026-01-26");
+		checked.put("answerValidation", Collections.singletonMap("status", "checked"));
+		checked.put("inDepth", Collections.singletonMap("status", "pending"));
+		provider.events = Arrays.asList(
+				TurnEvent.of(TurnEventType.TURN_STARTED, 0, "hub"),
+				TurnEvent.withAnswer(TurnEventType.ANSWER_VALIDATION, 1, "hub",
+						AnswerEnvelope.fromPayload(checked)),
+				TurnEvent.of(TurnEventType.INDEPTH_PENDING, 2, "hub"),
+				TurnEvent.of(TurnEventType.TURN_DONE, 3, "hub"));
+		provider.result = TurnResult.done("hub", ProviderMode.QUERY_SCOPED,
+				AnswerEnvelope.fromPayload(checked));
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(provider));
+
+		controller.streamProviderTurn(new ByteArrayOutputStream(), patient(), "What was the visit date?",
+				"hub", ProviderMode.QUERY_SCOPED, "single-e4b-checked", null);
+
+		assertEquals(1, conversations.recordedCheckedAnswers,
+				"checked answer must persist before an optional In-Depth tail completes");
+		assertEquals("2026-01-26", conversations.lastRecordedCheckedAnswer);
+	}
+
+	@Test
 	public void aNewTurnOnTheSameConversationCancelsThePriorInFlightTurn() throws Exception {
 		// G18: starting a new turn while a prior one on the same conversation is still running
 		// (e.g. its In-Depth is still generating) must cancel that prior turn instead of letting
@@ -459,7 +486,11 @@ public class ProviderRestContractTest {
 
 		int finished;
 
+		int recordedCheckedAnswers;
+
 		String lastFinishedAnswer;
+
+		String lastRecordedCheckedAnswer;
 
 		RecordingConversationService() {
 			openConversation = new ClinicalConversation();
@@ -518,6 +549,13 @@ public class ProviderRestContractTest {
 			finished++;
 			lastFinishedAnswer = result.getAnswer() == null ? null : result.getAnswer().getText();
 			return turn;
+		}
+
+		@Override
+		public boolean recordCheckedAnswer(ClinicalConversationTurn turn, AnswerEnvelope answer) {
+			recordedCheckedAnswers++;
+			lastRecordedCheckedAnswer = answer.getText();
+			return true;
 		}
 
 		@Override

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -121,6 +125,106 @@ public class ProviderRestContractTest {
 		assertEquals("Aspirin 81mg.", answerDone.get("answer").asText());
 		assertEquals("turn-uuid-1", answerDone.get("messageId").asText());
 		assertEquals("conversation-uuid-1", answerDone.get("session").asText());
+	}
+
+	@Test
+	public void aNewTurnOnTheSameConversationCancelsThePriorInFlightTurn() throws Exception {
+		// G18: starting a new turn while a prior one on the same conversation is still running
+		// (e.g. its In-Depth is still generating) must cancel that prior turn instead of letting
+		// it run to its provider's own natural completion — otherwise a preempted hub turn keeps
+		// occupying the router slot the whole point of preempting was meant to free.
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider provider = new ScriptedProvider("bundled", true);
+		provider.events = Arrays.asList(TurnEvent.of(TurnEventType.TURN_STARTED, 0, "bundled"),
+				TurnEvent.of(TurnEventType.TURN_DONE, 1, "bundled"));
+		provider.result = TurnResult.done("bundled", ProviderMode.QUERY_SCOPED,
+				AnswerEnvelope.fromPayload(answerPayload("first turn's answer")));
+		provider.blockFirstCallUntilReleased = new CountDownLatch(1);
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(provider));
+
+		Thread firstTurn = new Thread(() -> controller.streamProviderTurn(new ByteArrayOutputStream(),
+				patient(), "First question", "bundled", ProviderMode.QUERY_SCOPED, null,
+				"conversation-uuid-1"));
+		firstTurn.start();
+		// Deterministic handoff: wait for the first turn to actually be inside execute() and have
+		// registered its cancellation signal, rather than racing it with a fixed sleep.
+		long deadline = System.currentTimeMillis() + 2000;
+		while (provider.capturedCancellations.isEmpty() && System.currentTimeMillis() < deadline) {
+			Thread.sleep(5);
+		}
+		assertEquals(1, provider.capturedCancellations.size());
+		CancellationSignal firstCancellation = provider.capturedCancellations.get(0);
+		assertFalse(firstCancellation.isCancelled(), "not cancelled yet — no second turn has started");
+
+		controller.streamProviderTurn(new ByteArrayOutputStream(), patient(), "Second question",
+				"bundled", ProviderMode.QUERY_SCOPED, null, "conversation-uuid-1");
+
+		assertTrue(firstCancellation.isCancelled(),
+				"starting a new turn on the same conversation must cancel the prior in-flight turn");
+		assertEquals(2, provider.capturedCancellations.size());
+		assertFalse(provider.capturedCancellations.get(1).isCancelled(), "the new turn is not cancelled");
+
+		provider.blockFirstCallUntilReleased.countDown();
+		firstTurn.join(5000);
+		assertFalse(firstTurn.isAlive(), "first turn's thread should have unblocked and finished");
+	}
+
+	@Test
+	public void aPreemptedTurnsTrailingEventIsSwallowedSoItsAnswerStillPersists() throws Exception {
+		// Mirrors HubClinicalAnswerProvider's cancelled-with-partial-answer completion: once a
+		// turn is known to be cancelled, writing its trailing event must not throw even though
+		// the browser connection is already dead — otherwise execute() never returns a result and
+		// finishTurn is skipped, silently dropping an answer that had already completed before
+		// preemption.
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider provider = new ScriptedProvider("bundled", true);
+		provider.blockFirstCallUntilReleased = new CountDownLatch(1);
+		provider.events = Collections.singletonList(TurnEvent.of(TurnEventType.TURN_DONE, 0, "bundled"));
+		provider.result = TurnResult.done("bundled", ProviderMode.QUERY_SCOPED,
+				AnswerEnvelope.fromPayload(answerPayload("answer before preempt")));
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(provider));
+
+		ThrowingOutputStream deadConnection = new ThrowingOutputStream();
+		Thread firstTurn = new Thread(() -> controller.streamProviderTurn(deadConnection, patient(),
+				"First question", "bundled", ProviderMode.QUERY_SCOPED, null, "conversation-uuid-1"));
+		firstTurn.start();
+		long deadline = System.currentTimeMillis() + 2000;
+		while (provider.capturedCancellations.isEmpty() && System.currentTimeMillis() < deadline) {
+			Thread.sleep(5);
+		}
+		assertEquals(1, provider.capturedCancellations.size());
+
+		// The second turn on the same conversation preempts (cancels) the first.
+		controller.streamProviderTurn(new ByteArrayOutputStream(), patient(), "Second question",
+				"bundled", ProviderMode.QUERY_SCOPED, null, "conversation-uuid-1");
+		assertTrue(provider.capturedCancellations.get(0).isCancelled());
+
+		// Only now does the first turn's provider emit its trailing event and return — the
+		// connection is dead (deadConnection throws on every write), but that write must be
+		// skipped rather than aborting execute() before it can hand back a persistable result.
+		provider.blockFirstCallUntilReleased.countDown();
+		firstTurn.join(5000);
+
+		assertFalse(firstTurn.isAlive(), "first turn's thread should have unblocked and finished");
+		assertEquals(0, deadConnection.writeAttempts, "a cancelled turn must not attempt to write at all");
+		assertEquals(2, conversations.finished,
+				"both turns should be persisted — the first turn's answer must not vanish just "
+						+ "because its browser connection was already gone when it completed");
+	}
+
+	private static final class ThrowingOutputStream extends java.io.OutputStream {
+
+		int writeAttempts;
+
+		@Override
+		public void write(int b) throws IOException {
+			writeAttempts++;
+			throw new IOException("connection reset by peer");
+		}
 	}
 
 	@Test
@@ -298,6 +402,11 @@ public class ProviderRestContractTest {
 
 		TurnResult result;
 
+		/** Set to make the FIRST call block until released — simulates a turn still in flight. */
+		CountDownLatch blockFirstCallUntilReleased;
+
+		final CopyOnWriteArrayList<CancellationSignal> capturedCancellations = new CopyOnWriteArrayList<>();
+
 		ScriptedProvider(String id, boolean ready) {
 			this.id = id;
 			this.ready = ready;
@@ -319,7 +428,16 @@ public class ProviderRestContractTest {
 		@Override
 		public CompletionStage<TurnResult> execute(TurnRequest request, TurnEventSink sink,
 				CancellationSignal cancellation) {
-			calls.incrementAndGet();
+			int callNumber = calls.incrementAndGet();
+			capturedCancellations.add(cancellation);
+			if (callNumber == 1 && blockFirstCallUntilReleased != null) {
+				try {
+					blockFirstCallUntilReleased.await(5, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+			}
 			if (request.getProfileId() == null && "hub".equals(id)) {
 				sink.accept(TurnEvent.of(TurnEventType.TURN_STARTED, 0, id));
 				sink.accept(TurnEvent.error(1, id, "profile_required"));
@@ -369,6 +487,12 @@ public class ProviderRestContractTest {
 		@Override
 		public ClinicalConversation getByUuid(String uuid) {
 			return openConversation.getUuid().equals(uuid) ? openConversation : null;
+		}
+
+		@Override
+		public ClinicalConversation getLatestActiveConversation(Patient patient) {
+			return ClinicalConversation.STATUS_ACTIVE.equals(openConversation.getStatus())
+					&& patient.equals(openConversation.getPatient()) ? openConversation : null;
 		}
 
 		@Override

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ProviderRestContractTest.java
@@ -161,6 +161,64 @@ public class ProviderRestContractTest {
 		assertEquals("profile_required", ssePayload(out, "turn_error").get("problemCode").asText());
 	}
 
+	@Test
+	public void resolveModeReturnsNullWhenTheRequestOmitsMode() {
+		// Mode is a DEPLOYMENT setting (chartsearchai.chartMode), never something callers are
+		// expected to send. resolveMode must return null (not a hardcoded default) so
+		// streamProviderTurn's own fallback — provider.modes().get(0), sourced from the
+		// provider's LIVE configured mode — decides. A hardcoded default here silently
+		// overrides whatever chartMode is actually configured to.
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+
+		assertEquals(null, controller.resolveMode(new HashMap<String, String>()));
+		assertEquals(null, controller.resolveMode(null));
+		Map<String, String> blank = new HashMap<String, String>();
+		blank.put("mode", "   ");
+		assertEquals(null, controller.resolveMode(blank));
+	}
+
+	@Test
+	public void resolveModeHonorsAnExplicitOverride() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		Map<String, String> body = new HashMap<String, String>();
+		body.put("mode", "full_chart_stable");
+
+		assertEquals(ProviderMode.FULL_CHART_STABLE, controller.resolveMode(body));
+	}
+
+	@Test
+	public void chatStreamWithNoExplicitModeUsesTheProvidersLiveConfiguredMode() throws Exception {
+		// Regression: chartsearchai.chartMode=fullChart previously failed EVERY turn with
+		// unsupported_mode, because resolveMode's hardcoded query_scoped default never matched
+		// the provider's actual configured mode (full_chart_stable) — a mismatch the provider's
+		// own no-silent-fallback guard correctly rejects. With mode UNSPECIFIED (the normal,
+		// only-ever-used-in-practice case — no caller sends "mode"), the turn must succeed using
+		// whatever mode the provider is actually configured for.
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		RecordingConversationService conversations = new RecordingConversationService();
+		ScriptedProvider bundled = new ScriptedProvider("bundled", true);
+		bundled.mode = ProviderMode.FULL_CHART_STABLE;
+		bundled.events = Arrays.asList(
+				TurnEvent.of(TurnEventType.TURN_STARTED, 0, "bundled"),
+				TurnEvent.withAnswer(TurnEventType.ANSWER_DONE, 1, "bundled",
+						AnswerEnvelope.fromPayload(answerPayload("Full chart summary."))),
+				TurnEvent.of(TurnEventType.TURN_DONE, 2, "bundled"));
+		bundled.result = TurnResult.done("bundled", ProviderMode.FULL_CHART_STABLE,
+				AnswerEnvelope.fromPayload(answerPayload("Full chart summary.")));
+		controller.setConversationService(conversations);
+		controller.setProviderRegistry(stubRegistry(bundled));
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		Map<String, String> body = new HashMap<String, String>();
+		// No "mode" key — the only shape any real caller sends.
+		ProviderMode resolved = controller.resolveMode(body);
+		controller.streamProviderTurn(out, patient(), "Summarize the chart", "bundled",
+				resolved, null, null);
+
+		assertEquals(Arrays.asList("turn_started", "answer_done", "turn_done"), sseTypes(out));
+		assertEquals("Full chart summary.", ssePayload(out, "answer_done").get("answer").asText());
+	}
+
 	private static Patient patient() {
 		Patient patient = new Patient();
 		patient.setUuid("patient-1");
@@ -232,6 +290,8 @@ public class ProviderRestContractTest {
 
 		private final boolean ready;
 
+		ProviderMode mode = ProviderMode.QUERY_SCOPED;
+
 		private final AtomicInteger calls = new AtomicInteger();
 
 		List<TurnEvent> events = Collections.emptyList();
@@ -251,7 +311,7 @@ public class ProviderRestContractTest {
 		@Override
 		public ProviderDescriptor descriptor() {
 			return new ProviderDescriptor(id, id, true, ready, "bundled".equals(id),
-					Collections.singletonList(ProviderMode.QUERY_SCOPED),
+					Collections.singletonList(mode),
 					EnumSet.of(ProviderCapability.ANSWER, ProviderCapability.TOKEN_STREAMING),
 					ready ? null : "not ready");
 		}

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ResolveConversationTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ResolveConversationTest.java
@@ -225,6 +225,12 @@ public class ResolveConversationTest {
 		}
 
 		@Override
+		public boolean recordCheckedAnswer(ClinicalConversationTurn turn,
+				org.openmrs.module.chartsearchai.api.provider.AnswerEnvelope answer) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation) {
 			throw new UnsupportedOperationException();
 		}

--- a/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ResolveConversationTest.java
+++ b/omod/src/test/java/org/openmrs/module/chartsearchai/web/rest/ResolveConversationTest.java
@@ -1,0 +1,232 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.web.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.conversation.ConversationService;
+import org.openmrs.module.chartsearchai.api.conversation.PriorClinicalTurn;
+import org.openmrs.module.chartsearchai.api.provider.ProviderMode;
+import org.openmrs.module.chartsearchai.api.provider.TurnResult;
+import org.openmrs.module.chartsearchai.model.ClinicalConversation;
+import org.openmrs.module.chartsearchai.model.ClinicalConversationTurn;
+
+/**
+ * {@code ChartSearchAiRestController#resolveConversation} — the REST-layer half of "changing
+ * providerId creates a new conversation" (the service-layer half,
+ * {@code ConversationServiceImpl.openOrCreate}, is covered by
+ * {@code ConversationServicePersistenceTest#reusesOnlyAnActiveConversationWithTheSameProviderAndMode}).
+ * Live-observed gap this closes: a client that submits a turn with a provider different from the
+ * one bound to its client-supplied session must never have that turn silently written into the
+ * old conversation — the caller (openOrCreate, delegated to on any mismatch) closes the old one
+ * and opens a new one, and the caller must see a DIFFERENT conversation uuid back so it can stop
+ * displaying the old conversation's turns as part of the same thread.
+ */
+public class ResolveConversationTest {
+
+	private static Patient patient() {
+		Patient patient = new Patient();
+		patient.setUuid("patient-1");
+		patient.setPatientId(1);
+		return patient;
+	}
+
+	private static ClinicalConversation conversation(String uuid, Patient patient, String providerId,
+			String mode, String status) {
+		ClinicalConversation conversation = new ClinicalConversation();
+		conversation.setUuid(uuid);
+		conversation.setPatient(patient);
+		conversation.setProviderId(providerId);
+		conversation.setProviderMode(mode);
+		conversation.setStatus(status);
+		return conversation;
+	}
+
+	@Test
+	public void reusesTheClientSuppliedSessionWhenProviderAndModeMatch() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		Patient patient = patient();
+		ClinicalConversation existing = conversation("conversation-1", patient, "bundled", "query_scoped",
+				ClinicalConversation.STATUS_ACTIVE);
+		conversations.byUuid.put("conversation-1", existing);
+		controller.setConversationService(conversations);
+
+		ClinicalConversation resolved = controller.resolveConversation(patient, "bundled",
+				ProviderMode.QUERY_SCOPED, "conversation-1");
+
+		assertSame(existing, resolved);
+		assertEquals(0, conversations.openOrCreateCalls, "a matching session never falls through to openOrCreate");
+	}
+
+	@Test
+	public void aProviderMismatchNeverReusesTheClientSuppliedSession() {
+		// The exact live-observed scenario: a stale client session bound to "bundled" (e.g. from a
+		// picker that didn't sync to a restored conversation's real provider) is submitted
+		// alongside provider=hub. The old conversation must never receive a hub-answered turn.
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		Patient patient = patient();
+		ClinicalConversation staleBundled = conversation("conversation-old-bundled", patient, "bundled",
+				"query_scoped", ClinicalConversation.STATUS_ACTIVE);
+		conversations.byUuid.put("conversation-old-bundled", staleBundled);
+		ClinicalConversation freshHub = conversation("conversation-new-hub", patient, "hub", "query_scoped",
+				ClinicalConversation.STATUS_ACTIVE);
+		conversations.openOrCreateResult = freshHub;
+		controller.setConversationService(conversations);
+
+		ClinicalConversation resolved = controller.resolveConversation(patient, "hub", ProviderMode.QUERY_SCOPED,
+				"conversation-old-bundled");
+
+		assertSame(freshHub, resolved);
+		assertNotEquals(staleBundled.getUuid(), resolved.getUuid(),
+				"a provider-mismatched session must never be reused for the new provider's turn");
+		assertEquals(1, conversations.openOrCreateCalls);
+		assertEquals("hub", conversations.lastOpenOrCreateProviderId);
+	}
+
+	@Test
+	public void aModeMismatchAlsoFallsThroughToOpenOrCreate() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		Patient patient = patient();
+		ClinicalConversation queryScoped = conversation("conversation-1", patient, "bundled", "query_scoped",
+				ClinicalConversation.STATUS_ACTIVE);
+		conversations.byUuid.put("conversation-1", queryScoped);
+		ClinicalConversation fullChart = conversation("conversation-2", patient, "bundled", "full_chart_stable",
+				ClinicalConversation.STATUS_ACTIVE);
+		conversations.openOrCreateResult = fullChart;
+		controller.setConversationService(conversations);
+
+		ClinicalConversation resolved = controller.resolveConversation(patient, "bundled",
+				ProviderMode.FULL_CHART_STABLE, "conversation-1");
+
+		assertSame(fullChart, resolved);
+		assertEquals(1, conversations.openOrCreateCalls);
+	}
+
+	@Test
+	public void aClosedConversationIsNeverReusedEvenWithAMatchingProviderAndMode() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		Patient patient = patient();
+		ClinicalConversation closed = conversation("conversation-1", patient, "bundled", "query_scoped",
+				ClinicalConversation.STATUS_CLOSED);
+		conversations.byUuid.put("conversation-1", closed);
+		ClinicalConversation fresh = conversation("conversation-2", patient, "bundled", "query_scoped",
+				ClinicalConversation.STATUS_ACTIVE);
+		conversations.openOrCreateResult = fresh;
+		controller.setConversationService(conversations);
+
+		ClinicalConversation resolved = controller.resolveConversation(patient, "bundled",
+				ProviderMode.QUERY_SCOPED, "conversation-1");
+
+		assertSame(fresh, resolved);
+		assertEquals(1, conversations.openOrCreateCalls);
+	}
+
+	@Test
+	public void anUnknownConversationUuidFallsThroughToOpenOrCreate() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		Patient patient = patient();
+		ClinicalConversation fresh = conversation("conversation-new", patient, "bundled", "query_scoped",
+				ClinicalConversation.STATUS_ACTIVE);
+		conversations.openOrCreateResult = fresh;
+		controller.setConversationService(conversations);
+
+		ClinicalConversation resolved = controller.resolveConversation(patient, "bundled",
+				ProviderMode.QUERY_SCOPED, "does-not-exist");
+
+		assertSame(fresh, resolved);
+		assertEquals(1, conversations.openOrCreateCalls);
+	}
+
+	@Test
+	public void aBlankConversationUuidGoesStraightToOpenOrCreate() {
+		ChartSearchAiRestController controller = new ChartSearchAiRestController();
+		StubConversationService conversations = new StubConversationService();
+		Patient patient = patient();
+		ClinicalConversation fresh = conversation("conversation-new", patient, "bundled", "query_scoped",
+				ClinicalConversation.STATUS_ACTIVE);
+		conversations.openOrCreateResult = fresh;
+		controller.setConversationService(conversations);
+
+		ClinicalConversation resolved = controller.resolveConversation(patient, "bundled", ProviderMode.QUERY_SCOPED,
+				null);
+
+		assertSame(fresh, resolved);
+		assertEquals(1, conversations.openOrCreateCalls);
+	}
+
+	private static final class StubConversationService implements ConversationService {
+
+		final Map<String, ClinicalConversation> byUuid = new HashMap<>();
+
+		ClinicalConversation openOrCreateResult;
+
+		int openOrCreateCalls;
+
+		String lastOpenOrCreateProviderId;
+
+		@Override
+		public ClinicalConversation openOrCreate(Patient patient, String providerId, ProviderMode mode) {
+			openOrCreateCalls++;
+			lastOpenOrCreateProviderId = providerId;
+			return openOrCreateResult;
+		}
+
+		@Override
+		public ClinicalConversation startNew(Patient patient, String providerId, ProviderMode mode) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ClinicalConversation getByUuid(String uuid) {
+			return byUuid.get(uuid);
+		}
+
+		@Override
+		public ClinicalConversation getLatestActiveConversation(Patient patient) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<ClinicalConversationTurn> getTurns(ClinicalConversation conversation) {
+			return new ArrayList<ClinicalConversationTurn>();
+		}
+
+		@Override
+		public ClinicalConversationTurn startTurn(ClinicalConversation conversation, String requestId,
+				String question) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public ClinicalConversationTurn finishTurn(ClinicalConversationTurn turn, TurnResult result,
+				long responseTimeMs) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<PriorClinicalTurn> priorClinicalTurns(ClinicalConversation conversation) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
## Purpose

Rebuilds ChartSearchAI around a provider-neutral clinical-chat boundary while preserving the
bundled provider. med-agent-hub is a separately configured provider; there is no silent
cross-provider fallback.

## What is here

- `ClinicalAnswerProvider` boundary with bundled and hub adapters, a canonical turn lifecycle,
  provider-neutral conversation/audit persistence, and configuration-driven provider discovery.
- Bundled behavior remains intact: local/remote engines, context modes, warming, caching,
  grounding, medication checks, and legacy `/search` routes continue behind the bundled adapter.
- Hub requests are one profile stream through `HubClinicalAnswerProvider`; checked/edited Answers
  are available as safe prior context while an earlier In-Depth tail is still running.
- Both providers consume QueryStore's tiered context slice. QueryStore owns deterministic
  selection and optional question interpretation; ChartSearchAI owns prompt assembly and
  module-contributed resource scopes.
- Explicit context-overflow and provider-readiness behavior, with no implicit provider fallback.

## Cross-repository dependency

This branch imports `ContextSlice`, `ContextSliceRecord`, and `ContextSliceRequest` from
[QueryStore #63](https://github.com/openmrs/openmrs-module-querystore/pull/63). The exact source
pair was built locally on 2026-07-29: QueryStore `e2cb359` completed `mvn -q -B clean install`,
then this branch at `209e7cb` completed `mvn -q -B clean package` against that artifact.

The public Java 11/17/21 failures are expected until #63 merges and the upstream build publishes
`querystore-api:1.0.0-SNAPSHOT` containing those classes. Do not add a duplicate compatibility
copy. After publication the required sequence is: verify the Maven artifact independently, fetch
current upstream, record dispositions for any new commits, re-cut this branch, then rerun public
CI and the source-pair, live product, and browser evidence.

## Verification

- Full Maven package passes for the exact source pair above.
- Live current-head evidence has covered provider isolation, profile relay lifecycle, answer
  validation, final evidence state, multi-turn checked-answer history during an In-Depth tail, and
  preemption. It must be regenerated after the QueryStore publication/re-cut sequence before
  release evidence is claimed.
