### PR TITLE
feat(guard): opt-in deterministic verdict guard for lab-only "Yes" answers

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -266,6 +266,24 @@ public class ChartSearchAiConstants {
 	public static final boolean DEFAULT_GROUNDING_ENABLED = false;
 
 	/**
+	 * When {@code true}, a yes/no answer that leads "Yes" but cites ONLY measurement records
+	 * (observations / test orders — no diagnosis, condition, allergy, enrollment, or medication order
+	 * that explicitly names the asked problem) has its leading verdict clause deterministically
+	 * rewritten to a NO-family verdict. Citations are not altered, so the evidence and the reference
+	 * set are unchanged; only the unsupported affirmative verdict is corrected. See
+	 * {@code LlmInferenceService#applyVerdictGuard}.
+	 *
+	 * <p><strong>Opt-in — default {@code false}.</strong> The guard is question-blind: it assumes
+	 * every yes/no question asks whether the patient HAS a named problem. It therefore mis-fires on
+	 * <em>existence/order</em> questions ("was a creatinine test ordered?", "was blood pressure
+	 * measured?"), where a correct "Yes" cited by a test order or observation would be wrongly
+	 * negated — a failure the current diagnosis-presence eval set cannot detect. Enable only for a
+	 * deployment whose yes/no traffic is predominantly diagnosis-presence, and only until
+	 * question-intent gating is added.
+	 */
+	public static final String GP_VERDICT_GUARD_ENABLED = "chartsearchai.verdictGuard.enabled";
+
+	/**
 	 * Minimum cosine similarity between a cited record's text and the answer
 	 * sentence that cites it for the citation to count as grounded. This Tier-1
 	 * check catches grossly off-topic citations (a blood-pressure record cited
@@ -464,6 +482,8 @@ public class ChartSearchAiConstants {
 	public static final String RESOURCE_TYPE_DIAGNOSIS = "diagnosis";
 
 	public static final String RESOURCE_TYPE_ORDER = "order";
+
+	public static final String RESOURCE_TYPE_TEST_ORDER = "test_order";
 
 	public static final String RESOURCE_TYPE_PROGRAM = "program";
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -10,15 +10,18 @@
 package org.openmrs.module.chartsearchai.api.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.openmrs.Patient;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
@@ -127,12 +130,16 @@ public class LlmInferenceService implements ChartSearchService {
 			inputTokens = response.getInputTokens();
 			cachedTokens = response.getCachedTokens();
 
-			List<RecordReference> references = groundReferences(response.getAnswer(),
-					extractCitedReferences(response.getAnswer(), response.getCitations(),
-							chart.getMappings()),
-					chart.getMappings());
-			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(response.getAnswer(), question, patient);
-			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
+			List<RecordReference> cited = extractCitedReferences(response.getAnswer(),
+					response.getCitations(), chart.getMappings());
+			// Correct an unsupported affirmative verdict (leads "Yes" but cites only measurements) to
+			// a NO-family verdict before grounding and return. Citations are untouched — see
+			// applyVerdictGuard.
+			String guardedAnswer = resolveVerdictGuardEnabled()
+					? applyVerdictGuard(response.getAnswer(), cited) : response.getAnswer();
+			List<RecordReference> references = groundReferences(guardedAnswer, cited, chart.getMappings());
+			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(guardedAnswer, question, patient);
+			ChartAnswer answer = new ChartAnswer(guardedAnswer, references,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens(), safetyWarnings);
 			outcome = "ok";
@@ -397,21 +404,28 @@ public class LlmInferenceService implements ChartSearchService {
 					response.getCitations(), chart.getMappings());
 			citationsConsumer.accept(cited);
 
+			// Verdict guard applies to the FINALIZED answer only: the raw verdict has already been
+			// streamed token-by-token to the client above, so an unsupported "Yes" is corrected in
+			// the completed answer the REST layer keeps (audit row, "done" payload) and returns, not
+			// in the live token stream. Citations are untouched — see applyVerdictGuard.
+			String guardedAnswer = resolveVerdictGuardEnabled()
+					? applyVerdictGuard(response.getAnswer(), cited) : response.getAnswer();
+
 			// The answer is complete: hand the whole (not yet grounding-verified) result to the
 			// caller before the grounding pass, so the REST layer can finish the user-visible
 			// response (emit "done", persist the audit row) without waiting out the Tier-2 tail.
 			// Fires regardless of whether grounding is enabled — see the interface contract.
-			ungroundedAnswerConsumer.accept(new ChartAnswer(response.getAnswer(), cited,
+			ungroundedAnswerConsumer.accept(new ChartAnswer(guardedAnswer, cited,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens()));
 
 			long groundStart = System.currentTimeMillis();
-			List<RecordReference> references = groundReferences(response.getAnswer(), cited,
+			List<RecordReference> references = groundReferences(guardedAnswer, cited,
 					chart.getMappings());
 			groundMs = System.currentTimeMillis() - groundStart;
 
-			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(response.getAnswer(), question, patient);
-			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
+			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(guardedAnswer, question, patient);
+			ChartAnswer answer = new ChartAnswer(guardedAnswer, references,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens(), safetyWarnings);
 			outcome = "ok";
@@ -453,6 +467,97 @@ public class LlmInferenceService implements ChartSearchService {
 			return references;
 		}
 		return citationGroundingVerifier.verify(answer, references, mappings);
+	}
+
+	// ---- Verdict guard ----
+
+	/** Test seam wrapping {@link #isVerdictGuardEnabled()}; production delegates, tests override to
+	 *  exercise the guard path without an OpenMRS context. */
+	protected boolean resolveVerdictGuardEnabled() {
+		return isVerdictGuardEnabled();
+	}
+
+	static boolean isVerdictGuardEnabled() {
+		try {
+			String value = org.openmrs.api.context.Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_VERDICT_GUARD_ENABLED, "false");
+			return "true".equalsIgnoreCase(value.trim());
+		}
+		catch (RuntimeException e) {
+			// No admin service (e.g. context not started) — leave the answer unmodified rather than
+			// break the search path. Mirrors ChartSearchAiUtils.isGroundingEnabled's safe fallback.
+			return false;
+		}
+	}
+
+	/** Leading "Yes" plus its trailing connector punctuation — whitespace and any of {@code — , : . ; -}
+	 *  (— is the em dash) — e.g. "Yes — ", "Yes, ", "Yes: ", "Yes. ". Doubles as the "leads with Yes"
+	 *  gate (the trailing class is zero-or-more, so a bare "Yes" matches). The class stops before "[",
+	 *  so this can never consume an inline citation marker. */
+	private static final Pattern GUARD_YES_CLAUSE =
+			Pattern.compile("^\\s*yes\\b[\\s\\u2014:,.;-]*", Pattern.CASE_INSENSITIVE);
+
+	/** A standalone re-affirming opener the model sometimes places after "Yes" ("there are records
+	 *  of kidney issues."). Removed so the rewritten NO lead is not immediately contradicted. The
+	 *  {@code [^.:\[]} class refuses to span a "[", so a clause carrying a citation never matches and
+	 *  no inline marker can be dropped — the guard stays citation-neutral. */
+	private static final Pattern GUARD_REAFFIRM =
+			Pattern.compile("^there (is|are)\\b[^.:\\[]*[.:]\\s*", Pattern.CASE_INSENSITIVE);
+
+	/** Measurement resource types — a lab/observation or a diagnostic order. Neither NAMES a
+	 *  problem, so a "Yes" whose citations are ALL of these is unsupported per the naming rule in
+	 *  {@code LlmProvider.DEFAULT_SYSTEM_PROMPT} and is the case the guard corrects. The guard fires
+	 *  only when EVERY citation is one of these (a whitelist trigger): any other cited type — a
+	 *  condition/diagnosis/allergy/program, a medication order, an injected {@code drug_reference},
+	 *  a referral/encounter/visit/patient record — leaves the "Yes" untouched, so the guard can never
+	 *  negate a verdict backed by a record it does not positively recognise as a pure measurement. */
+	private static final Set<String> GUARD_MEASUREMENT_TYPES = Collections.unmodifiableSet(new HashSet<String>(
+			Arrays.asList(ChartSearchAiConstants.RESOURCE_TYPE_OBS, ChartSearchAiConstants.RESOURCE_TYPE_TEST_ORDER)));
+
+	/**
+	 * Deterministic verdict guard for the yes/no over-affirmation failure. When an answer leads
+	 * "Yes" but every cited record is a measurement (an {@code obs}/{@code test_order} — none is a
+	 * diagnosis, condition, allergy, enrollment, or medication order that explicitly NAMES the asked
+	 * problem), the affirmative verdict is unsupported per the naming rule the system prompt states.
+	 * This rewrites <em>only</em> the leading verdict clause to a NO-family verdict, preserving the
+	 * evidence and every inline {@code [N]} citation marker — so the reference set, and therefore the
+	 * recall/drift/abstention the metrics measure, are unchanged by construction. The correction is
+	 * for the pure lab-only "Yes"; a "Yes" backed by any naming/order record is left untouched (the
+	 * borderline "is this condition actually kidney disease?" calls are not the guard's job).
+	 *
+	 * <p><strong>Limitations (why it is opt-in — see {@link ChartSearchAiConstants#GP_VERDICT_GUARD_ENABLED}).</strong>
+	 * (1) Question-blind: it assumes the yes/no question asks whether the patient HAS the problem, so
+	 * it wrongly negates a correct "Yes" to an existence/order question ("was a creatinine test
+	 * ordered?" cited by a {@code test_order}, "was blood pressure measured?" cited by an
+	 * {@code obs}). Safe general use needs question-intent gating. (2) The contradiction-avoidance
+	 * strip removes only a leading "there is/are …" clause, so a lab-only "Yes" phrased another way
+	 * ("the patient has diabetes recorded: HbA1c 9.2 [3]") can leave a clause that contradicts the
+	 * rewritten "No" lead.
+	 *
+	 * @param answer the model's answer text
+	 * @param cited the records the answer cites, carrying their resource type
+	 * @return the answer with a corrected verdict lead, or the original answer when the guard does
+	 *         not apply (not a "Yes" lead, no citations, or any non-measurement record is cited)
+	 */
+	static String applyVerdictGuard(String answer, List<RecordReference> cited) {
+		if (answer == null || cited == null || cited.isEmpty() || !GUARD_YES_CLAUSE.matcher(answer).find()) {
+			return answer;
+		}
+		for (RecordReference ref : cited) {
+			if (!GUARD_MEASUREMENT_TYPES.contains(ref.getResourceType())) {
+				// A non-measurement record is cited (a named condition/allergy/program, a medication
+				// order, a drug reference, a referral/encounter, …); the "Yes" may be legitimate —
+				// leave it. A null type is also non-measurement, so it too leaves the answer untouched.
+				return answer;
+			}
+		}
+		String rest = GUARD_YES_CLAUSE.matcher(answer).replaceFirst("");
+		rest = GUARD_REAFFIRM.matcher(rest).replaceFirst("").trim();
+		if (!rest.isEmpty()) {
+			rest = Character.toUpperCase(rest.charAt(0)) + rest.substring(1);
+		}
+		String lead = "No diagnosis explicitly naming this is recorded.";
+		return rest.isEmpty() ? lead : lead + " " + rest;
 	}
 
 	static List<RecordReference> extractCitedReferences(List<Integer> citations,

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceVerdictGuardTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceServiceVerdictGuardTest.java
@@ -1,0 +1,222 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.ChartAnswer;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * Unit tests for {@link LlmInferenceService#applyVerdictGuard}. The guard is a deterministic
+ * post-processing rule, so — like {@code extractCitedReferences} — it is exercised directly with
+ * constructed references (the codebase convention for the pure citation/answer helpers).
+ *
+ * <p>The load-bearing contract is <strong>citation neutrality</strong>: rewriting the verdict lead
+ * must never add or drop an inline {@code [N]} marker, because the downstream reference extraction
+ * and the drift/recall metrics are computed from exactly those markers.
+ */
+public class LlmInferenceServiceVerdictGuardTest {
+
+	private static RecordReference ref(int index, String type) {
+		return new RecordReference(index, type, "uuid-" + index, null);
+	}
+
+	private static final Pattern CITATION = Pattern.compile("\\[(\\d+)\\]");
+
+	private static Set<String> citations(String text) {
+		Set<String> out = new LinkedHashSet<String>();
+		Matcher m = CITATION.matcher(text);
+		while (m.find()) {
+			out.add(m.group(1));
+		}
+		return out;
+	}
+
+	@Test
+	public void applyVerdictGuard_rewritesLabOnlyYesToNoFamily() {
+		String answer = "Yes — kidney function labs are recorded: Serum creatinine 78.7 [9], "
+				+ "Blood urea nitrogen 98.7 [11].";
+		List<RecordReference> cited = Arrays.asList(ref(9, "obs"), ref(11, "obs"));
+
+		String result = LlmInferenceService.applyVerdictGuard(answer, cited);
+
+		assertTrue(result.matches("(?is)^\\s*no\\b.*"), "verdict must lead with No: " + result);
+		assertEquals(citations(answer), citations(result), "citations must be unchanged");
+		assertTrue(result.contains("[9]") && result.contains("[11]"), "evidence markers preserved");
+	}
+
+	@Test
+	public void applyVerdictGuard_leavesYesWhenANamingRecordIsCited() {
+		String answer = "Yes — kidney issues are recorded: Chronic kidney disease [30], "
+				+ "Serum creatinine 78.7 [9].";
+		// [30] is a condition — a record that explicitly NAMES the problem, so the Yes is legitimate.
+		List<RecordReference> cited = Arrays.asList(ref(30, "condition"), ref(9, "obs"));
+
+		String result = LlmInferenceService.applyVerdictGuard(answer, cited);
+
+		assertSame(answer, result, "a Yes backed by a naming record must be left unchanged");
+	}
+
+	@Test
+	public void applyVerdictGuard_leavesYesWhenCitationIsInjectedDrugReference() {
+		// A drug_reference is injected reference data, not a patient measurement; the guard must NOT
+		// fire on a "Yes" citing one (e.g. a drug-interaction answer), or it would negate a valid
+		// verdict AND stamp a nonsensical "No diagnosis…" lead on it.
+		String answer = "Yes — drug A and drug B interact [1].";
+		List<RecordReference> cited = Arrays.asList(ref(1, "drug_reference"));
+
+		assertSame(answer, LlmInferenceService.applyVerdictGuard(answer, cited));
+	}
+
+	@Test
+	public void applyVerdictGuard_leavesYesWhenAnyCitationIsNonMeasurement() {
+		// The guard fires only when EVERY citation is a measurement (obs/test_order). A referral
+		// order mixed in with labs is a non-measurement, so the "Yes" is left untouched.
+		String answer = "Yes — creatinine 78.7 [1] and a nephrology referral [2].";
+		List<RecordReference> cited = Arrays.asList(ref(1, "obs"), ref(2, "referral_order"));
+
+		assertSame(answer, LlmInferenceService.applyVerdictGuard(answer, cited));
+	}
+
+	@Test
+	public void applyVerdictGuard_leavesNonYesAnswer() {
+		String answer = "No hypertension diagnosis is recorded. Blood pressure 145 mmHg [2].";
+		List<RecordReference> cited = Arrays.asList(ref(2, "obs"));
+
+		assertSame(answer, LlmInferenceService.applyVerdictGuard(answer, cited));
+	}
+
+	@Test
+	public void applyVerdictGuard_leavesYesWithNoCitations() {
+		String answer = "Yes.";
+		assertSame(answer, LlmInferenceService.applyVerdictGuard(answer, Collections.<RecordReference>emptyList()));
+	}
+
+	@Test
+	public void applyVerdictGuard_isCitationNeutralWhenReaffirmClauseCarriesAMarker() {
+		// The re-affirming opener the guard strips to avoid a "No … there are records" contradiction
+		// MUST NOT be stripped when it carries a citation, or an inline [7] would be silently dropped.
+		String answer = "Yes, there are records of kidney issues [7]. Urine test [3].";
+		List<RecordReference> cited = Arrays.asList(ref(7, "obs"), ref(3, "obs"));
+
+		String result = LlmInferenceService.applyVerdictGuard(answer, cited);
+
+		assertTrue(result.matches("(?is)^\\s*no\\b.*"), "verdict must lead with No: " + result);
+		assertEquals(citations(answer), citations(result),
+		    "no inline citation may be dropped by the rewrite: " + result);
+	}
+
+	@Test
+	public void applyVerdictGuard_stripsReaffirmContradictionWhenNoMarker() {
+		String answer = "Yes, there are records of kidney issues. Urine test [3].";
+		List<RecordReference> cited = Arrays.asList(ref(3, "obs"));
+
+		String result = LlmInferenceService.applyVerdictGuard(answer, cited);
+
+		assertTrue(result.matches("(?is)^\\s*no\\b.*"));
+		assertTrue(!result.toLowerCase().contains("there are records of kidney issues"),
+		    "the re-affirming clause that contradicts the No lead should be removed: " + result);
+		assertEquals(citations(answer), citations(result));
+	}
+
+	/**
+	 * Builds a {@link LlmInferenceService} with all collaborators stubbed and the LLM returning a
+	 * fixed lab-only "Yes" citing one {@code obs} record, so the {@code search} path can be exercised
+	 * without an OpenMRS context. {@code guardEnabled} drives the {@code resolveVerdictGuardEnabled}
+	 * seam; grounding is forced off to skip its context read.
+	 */
+	private static LlmInferenceService stubbedServiceReturningLabOnlyYes(boolean guardEnabled) {
+		java.util.List<RecordMapping> mappings = Arrays.asList(new RecordMapping(1, "obs", "uuid-1", null));
+		PatientChart chart = new PatientChart("records", mappings);
+
+		LlmInferenceService service = new LlmInferenceService() {
+
+			@Override
+			protected boolean resolveVerdictGuardEnabled() {
+				return guardEnabled;
+			}
+
+			@Override
+			protected boolean resolveGroundingEnabled() {
+				return false;
+			}
+		};
+		service.setChartBuildingStrategy(new ChartBuildingStrategy() {
+
+			@Override
+			PatientChart buildChart(Patient patient, String question) {
+				return chart;
+			}
+		});
+		service.setDrugReferenceInjector(new org.openmrs.module.chartsearchai.reference.DrugReferenceInjector() {
+
+			@Override
+			public PatientChart inject(PatientChart chart, Patient patient, String question) {
+				return chart;
+			}
+		});
+		service.setDrugSafetyValidator(new org.openmrs.module.chartsearchai.reference.DrugSafetyValidator() {
+
+			@Override
+			public java.util.List<org.openmrs.module.chartsearchai.reference.SafetyWarning> validate(
+					String answer, String question, Patient patient) {
+				return java.util.Collections.emptyList();
+			}
+		});
+		service.setLlmProvider(new LlmProvider() {
+
+			@Override
+			public LlmResponse search(String numberedRecords, java.util.List<Integer> focusIndices,
+					String question) {
+				return new LlmResponse("Yes — kidney function labs are recorded: creatinine 78.7 [1].",
+						Arrays.asList(1));
+			}
+		});
+		return service;
+	}
+
+	/**
+	 * Wiring test: proves the production {@code search} path actually applies the guard (the
+	 * pure-function tests prove the transform; this proves it is invoked). The lab-only "Yes" must
+	 * come back as a NO-family verdict, with the evidence citation preserved.
+	 */
+	@Test
+	public void search_appliesVerdictGuardToLabOnlyYesAnswer() {
+		ChartAnswer answer = stubbedServiceReturningLabOnlyYes(true).search(new Patient(), "any kidney issues");
+
+		assertTrue(answer.getAnswer().matches("(?is)^\\s*no\\b.*"),
+		    "search must apply the guard and lead with No: " + answer.getAnswer());
+		assertTrue(answer.getAnswer().contains("[1]"), "the evidence citation must be preserved");
+	}
+
+	/** With the GP off, the guard is skipped and the raw model verdict is returned unchanged. */
+	@Test
+	public void search_leavesAnswerUnchangedWhenGuardDisabled() {
+		ChartAnswer answer = stubbedServiceReturningLabOnlyYes(false).search(new Patient(), "any kidney issues");
+
+		assertTrue(answer.getAnswer().matches("(?is)^\\s*yes\\b.*"),
+		    "with the guard disabled the raw Yes must be preserved: " + answer.getAnswer());
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
+++ b/omod/src/main/java/org/openmrs/module/chartsearchai/web/rest/ChartSearchAiRestController.java
@@ -321,7 +321,12 @@ public class ChartSearchAiRestController {
 	 *       preview can be wrong until the committed full-chart pass corrects it</li>
 	 *   <li>{@code thinking} — a chunk of the model's reasoning (chain-of-thought), emitted
 	 *       before the answer; render distinctly (e.g. a collapsible panel), not as the answer</li>
-	 *   <li>{@code token} — a chunk of the answer text</li>
+	 *   <li>{@code token} — a chunk of the answer text. NOTE: the concatenated tokens are the
+	 *       model's raw answer; the authoritative answer is the one in {@code done}, which may
+	 *       differ — the verdict guard ({@code chartsearchai.verdictGuard.enabled}) can correct an
+	 *       unsupported "Yes" lead to a "No" verdict on the finalized answer, after the raw tokens
+	 *       have already streamed. Clients should render the final answer from {@code done}, not
+	 *       from the accumulated tokens</li>
 	 *   <li>{@code references} — the answer's citations the moment the answer is complete,
 	 *       before grounding verdicts exist; render as unverified until verdicts arrive</li>
 	 *   <li>{@code done} — final JSON with answer, references, questionId, and disclaimer.


### PR DESCRIPTION
## Summary

Adds an opt-in deterministic **verdict guard** that corrects the model's yes/no over-affirmation. When an answer leads "Yes" but cites **only measurement records** (observations / test orders — no diagnosis, condition, allergy, enrollment, or medication order that explicitly names the asked problem), the leading verdict clause is rewritten to a NO-family verdict. Citations are left untouched.

Example — "any kidney issues?":
- before: `Yes — kidney function labs are recorded: creatinine 78.7 [9], BUN 98.7 [11].`
- after: `No diagnosis explicitly naming this is recorded. Kidney function labs are recorded: creatinine 78.7 [9], BUN 98.7 [11].`

## Why a post-processor, not a prompt/decoding change

A prior investigation gated ~14 prompt / decoding / retrieval / serialization levers against this same over-affirmation failure. Every LLM-side fix coupled the verdict gain to a citation-recall or drift loss — a model made conservative enough to stop over-affirming also cites differently. A deterministic post-processor edits only the verdict word, so **recall / drift / abstention are unchanged by construction** — the one approach that improved the target axis with no regression.

## Behavior & safety

- **Opt-in, default OFF** (`chartsearchai.verdictGuard.enabled`), mirroring the grounding feature; safe no-Context fallback.
- **Citation-neutral by construction** — the strip regexes never span a `[`, so no inline `[N]` marker is added or dropped; the reference set (and the drift/recall metrics) are unchanged.
- **Whitelist trigger** — fires only when *every* cited record is a measurement (`obs`/`test_order`). A "Yes" backed by any naming record, medication order, injected `drug_reference`, referral/encounter/visit, or a null type is left untouched.
- Applied to **both** the non-streaming and streaming search paths; streaming corrects the finalized answer (the live token stream is unchanged — documented in the SSE contract, since clients finalize from `done`).

## Known limitations (why it is opt-in)

1. **Question-blind.** It assumes every yes/no question asks whether the patient *has* a problem, so it would wrongly negate a correct "Yes" to an **existence/order** question ("was a creatinine test ordered?" cited by a `test_order`). Enable only for diagnosis-presence-dominant traffic **until question-intent gating is added**. The current eval cannot detect this — its gold has only diagnosis-presence questions.
2. The contradiction-avoidance strip handles only a leading "there is/are …" clause; other lab-only phrasings can leave a clause that reads against the rewritten "No" lead.

Both are documented on `GP_VERDICT_GUARD_ENABLED` and `applyVerdictGuard`.

## Validation

- **Gate (yes/no drift-metric, diagnosis-presence):** directness 0.989 (=), verdict-accuracy 0.869 → 0.881 (2 lab-only "Yes" cells corrected, 0 broken), meanF1 / abstention / drift unchanged, 0 unsafe-YES.
- **Tests:** new `LlmInferenceServiceVerdictGuardTest` (10) covers the transform, citation-neutrality both ways, the `drug_reference` / `referral_order` non-fire regressions, and both search-path + GP branches. Full `api` suite green (623 run, 0 failures/errors, 34 skipped live-LLM).

## Follow-ups (not in this PR)

- Question-intent gating to make the guard safe default-on for the general question space, validated against a **widened** eval that includes existence/order questions.
- Broader contradiction handling for non-"there is/are" phrasings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRqyvPYbHP3vCeg22Jy8s3
