### PR TITLE
feat(verdict): intent-aware entailment-arbitrated yes/no verdict (opt-in, 2-call)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -310,6 +310,32 @@ public class ChartSearchAiConstants {
 	public static final boolean DEFAULT_GROUNDING_ENTAILMENT_ENABLED = false;
 
 	/**
+	 * When {@code true}, the yes/no verdict lead is arbitrated by a Tier-2 entailment check instead
+	 * of trusting the model's free-form chart synthesis. When an answer leads "Yes" but NONE of its
+	 * cited records entail a <em>diagnosis</em> of what the question asks about (verified via
+	 * {@link org.openmrs.module.chartsearchai.api.impl.LlmProvider#entailsBatch} against a statement
+	 * derived from the question), the affirmation is unsupported and the verdict lead is rewritten to
+	 * a NO-family lead — leaving every inline {@code [N]} citation marker untouched, so the reference
+	 * set (and the recall/drift/abstention the metrics measure) is unchanged by construction.
+	 *
+	 * <p>This is the semantic, question-aware successor to {@code chartsearchai.verdictGuard.enabled}:
+	 * the guard fired on a blind {@code resourceType} whitelist (obs/test_order) and so missed a
+	 * "Yes" cited by a non-matching <em>condition</em> (e.g. "peripheral vascular disease" cited for a
+	 * heart-problems question) and could not tell an existence/order question from a diagnosis-presence
+	 * one. The entailment check keys off the clinical meaning of each cited record against the actual
+	 * question, so it catches the condition-typed over-affirmations the guard could not and does not
+	 * negate a "Yes" whose cited records genuinely name the asked problem.
+	 *
+	 * <p>Opt-in and default {@code false}: it costs one batched LLM round-trip per yes/no answer, and
+	 * v1 corrects only the over-affirmation ("Yes" → "No") direction — the under-recognition
+	 * ("No" → "Yes") direction, which must surface previously-uncited evidence, is deliberately out of
+	 * scope here. Certified by the yes/no verdict gate in {@code eval/drift-metric/} before enabling.
+	 */
+	public static final String GP_VERDICT_ENTAILMENT_ENABLED = "chartsearchai.verdictEntailment.enabled";
+
+	public static final boolean DEFAULT_VERDICT_ENTAILMENT_ENABLED = false;
+
+	/**
 	 * When set, citation grounding is clause-scoped: a sentence citing multiple records checks each
 	 * citation against the answer text up to and including its own {@code [N]} marker, not the whole
 	 * compound sentence. This grounds a citation that supports its own clause but not a later clause

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmInferenceService.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 
 import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
 import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
 import org.openmrs.module.chartsearchai.api.ChartSearchService;
@@ -67,6 +68,9 @@ public class LlmInferenceService implements ChartSearchService {
 	private CitationGroundingVerifier citationGroundingVerifier;
 
 	@Autowired
+	private VerdictEntailmentArbiter verdictEntailmentArbiter;
+
+	@Autowired
 	private DrugReferenceInjector drugReferenceInjector;
 
 	@Autowired
@@ -75,6 +79,11 @@ public class LlmInferenceService implements ChartSearchService {
 	/** Test seam: production wires {@link CitationGroundingVerifier} via {@link Autowired}. */
 	void setCitationGroundingVerifier(CitationGroundingVerifier citationGroundingVerifier) {
 		this.citationGroundingVerifier = citationGroundingVerifier;
+	}
+
+	/** Test seam: production wires {@link VerdictEntailmentArbiter} via {@link Autowired}. */
+	void setVerdictEntailmentArbiter(VerdictEntailmentArbiter verdictEntailmentArbiter) {
+		this.verdictEntailmentArbiter = verdictEntailmentArbiter;
 	}
 
 	/** Test seam: production wires {@link DrugReferenceInjector} via {@link Autowired}. */
@@ -127,12 +136,16 @@ public class LlmInferenceService implements ChartSearchService {
 			inputTokens = response.getInputTokens();
 			cachedTokens = response.getCachedTokens();
 
-			List<RecordReference> references = groundReferences(response.getAnswer(),
-					extractCitedReferences(response.getAnswer(), response.getCitations(),
-							chart.getMappings()),
+			List<RecordReference> cited = extractCitedReferences(response.getAnswer(),
+					response.getCitations(), chart.getMappings());
+			// Verdict entailment (opt-in) may rewrite the leading "Yes" to a NO-family lead when no
+			// cited record entails a diagnosis of the asked problem. The rewrite is citation-neutral,
+			// so `cited` stays valid and grounding runs against the corrected answer text.
+			String finalAnswer = arbitrateVerdict(response.getAnswer(), question, cited,
 					chart.getMappings());
-			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(response.getAnswer(), question, patient);
-			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
+			List<RecordReference> references = groundReferences(finalAnswer, cited, chart.getMappings());
+			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(finalAnswer, question, patient);
+			ChartAnswer answer = new ChartAnswer(finalAnswer, references,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens(), safetyWarnings);
 			outcome = "ok";
@@ -194,6 +207,40 @@ public class LlmInferenceService implements ChartSearchService {
 	 *  delegates, tests override to exercise the grounding path without an OpenMRS context. */
 	protected boolean resolveGroundingEnabled() {
 		return ChartSearchAiUtils.isGroundingEnabled();
+	}
+
+	/** Overridable test seam for the verdict-entailment kill switch. */
+	protected boolean resolveVerdictEntailmentEnabled() {
+		return isVerdictEntailmentEnabled();
+	}
+
+	/**
+	 * Reads the {@code chartsearchai.verdictEntailment.enabled} global property (default off). A
+	 * {@link RuntimeException} — e.g. no OpenMRS context in a unit test — degrades to {@code false}
+	 * so the arbiter is simply skipped, exactly as if the flag were unset.
+	 */
+	static boolean isVerdictEntailmentEnabled() {
+		try {
+			String value = Context.getAdministrationService()
+					.getGlobalProperty(ChartSearchAiConstants.GP_VERDICT_ENTAILMENT_ENABLED, "false");
+			return "true".equalsIgnoreCase(value == null ? "" : value.trim());
+		}
+		catch (RuntimeException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Arbitrates the answer's yes/no verdict lead via {@link VerdictEntailmentArbiter} when the
+	 * feature is enabled, otherwise returns the answer unchanged. The rewrite (when it fires) is
+	 * citation-neutral, so the {@code cited} references stay valid for the returned answer.
+	 */
+	private String arbitrateVerdict(String answer, String question, List<RecordReference> cited,
+			List<RecordMapping> mappings) {
+		if (!resolveVerdictEntailmentEnabled()) {
+			return answer;
+		}
+		return verdictEntailmentArbiter.arbitrate(answer, question, cited, mappings);
 	}
 
 	/**
@@ -397,21 +444,29 @@ public class LlmInferenceService implements ChartSearchService {
 					response.getCitations(), chart.getMappings());
 			citationsConsumer.accept(cited);
 
+			// Verdict entailment (opt-in) may rewrite a lab-only "Yes" lead to a NO-family lead. It is
+			// applied to the finalized answer BEFORE the "done" hand-off so the committed answer (and
+			// the audit row) carry the corrected verdict — the streamed `token`s already emitted the
+			// raw lead, so the finalized done.answer can differ from the concatenated stream (the REST
+			// SSE contract notes this). The rewrite is citation-neutral, so `cited` stays valid.
+			String finalAnswer = arbitrateVerdict(response.getAnswer(), question, cited,
+					chart.getMappings());
+
 			// The answer is complete: hand the whole (not yet grounding-verified) result to the
 			// caller before the grounding pass, so the REST layer can finish the user-visible
 			// response (emit "done", persist the audit row) without waiting out the Tier-2 tail.
 			// Fires regardless of whether grounding is enabled — see the interface contract.
-			ungroundedAnswerConsumer.accept(new ChartAnswer(response.getAnswer(), cited,
+			ungroundedAnswerConsumer.accept(new ChartAnswer(finalAnswer, cited,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens()));
 
 			long groundStart = System.currentTimeMillis();
-			List<RecordReference> references = groundReferences(response.getAnswer(), cited,
+			List<RecordReference> references = groundReferences(finalAnswer, cited,
 					chart.getMappings());
 			groundMs = System.currentTimeMillis() - groundStart;
 
-			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(response.getAnswer(), question, patient);
-			ChartAnswer answer = new ChartAnswer(response.getAnswer(), references,
+			List<SafetyWarning> safetyWarnings = drugSafetyValidator.validate(finalAnswer, question, patient);
+			ChartAnswer answer = new ChartAnswer(finalAnswer, references,
 					response.getInputTokens(), response.getOutputTokens(),
 					response.getCachedTokens(), safetyWarnings);
 			outcome = "ok";

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/LlmProvider.java
@@ -453,6 +453,38 @@ public class LlmProvider {
 		return parseEntailmentVerdict(result == null ? null : result.getText());
 	}
 
+	/** Intent classifier for the verdict arbiter: is a yes/no question asking whether the patient HAS
+	 *  a diagnosed condition/disease/disorder — the only intent for which a finding-vs-diagnosis
+	 *  over-affirmation downgrade is appropriate. Written generally (a problem/disorder of any body
+	 *  part or organ system counts), NOT as a per-topic list, so it transfers to questions the eval
+	 *  never contains. Validated on held-out systems (liver, skin, thyroid, lung, anemia) as well as
+	 *  the eval topics, and correctly excludes enrollment/allergy/medication/test-performed/value
+	 *  questions. */
+	static final String CONDITION_INTENT_SYSTEM_PROMPT = "You classify a clinician's yes/no question "
+			+ "by what kind of record would make the answer YES. Answer YES if the question asks "
+			+ "whether the patient HAS a medical condition, disease, disorder, or diagnosis — INCLUDING "
+			+ "any problem, issue, or disorder affecting a body part or organ system (e.g. 'any liver "
+			+ "issues', 'heart problems', 'eye disease'). Answer NO if it asks about anything else: a "
+			+ "program or treatment enrollment, an allergy, a medication, whether a test/measurement "
+			+ "was performed, or a specific numeric value. Briefly reason, then put YES or NO in the "
+			+ "\"answer\" field with an empty \"citations\" array.";
+
+	/**
+	 * Classifies whether {@code question} asks about the presence of a diagnosed condition/disease.
+	 * Uses the same reason-then-verdict path (and {@link #parseEntailmentVerdict}) as {@link
+	 * #entails}. Returns {@code TRUE}/{@code FALSE} on a parseable YES/NO, {@code null} when the
+	 * answer is empty or unparseable — the arbiter treats {@code null} as "do not act", so a failed
+	 * classification degrades safely to leaving the model's verdict untouched.
+	 */
+	public Boolean isConditionPresenceQuestion(String question) {
+		if (question == null || question.trim().isEmpty()) {
+			return null;
+		}
+		LlmEngine.InferenceResult result = getActiveEngine().infer(
+				CONDITION_INTENT_SYSTEM_PROMPT, "Question: " + question.trim(), getTimeoutSeconds());
+		return parseEntailmentVerdict(result == null ? null : result.getText());
+	}
+
 	static final String ENTAILMENT_BATCH_SYSTEM_PROMPT = "You are a strict clinical fact-checker. "
 			+ "For EACH numbered pair you are given a SOURCE record and a STATEMENT. A SOURCE "
 			+ "supports its STATEMENT only if it explicitly states it. It does NOT support the "

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/VerdictEntailmentArbiter.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/VerdictEntailmentArbiter.java
@@ -1,0 +1,257 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Arbitrates the yes/no verdict lead of an answer with a Tier-2 entailment check, instead of
+ * trusting the small local model's free-form chart synthesis to decide it.
+ *
+ * <p><strong>The failure it fixes.</strong> Asked "any kidney problems?", Gemma&nbsp;E4B tends to
+ * answer "Yes" whenever a topically-related record exists — a creatinine lab, a urine test, a
+ * symptom like "difficulty in urination" — even though none of those is a recorded <em>diagnosis</em>
+ * of kidney disease. Measured on the yes/no gold set this over-affirmation is the dominant verdict
+ * error, and it is a <em>confident</em> error: resampling the same free-generation task does not fix
+ * it (self-consistency N=7 agreed with the greedy miss). But the error is task-specific, not
+ * model-wide: posed the narrow, verdict-only question "does THIS record explicitly state a diagnosis
+ * of X?", the same model answers correctly. This arbiter routes the verdict through that narrow
+ * task.
+ *
+ * <p><strong>How.</strong> When an answer leads "Yes", the arbiter first checks — via {@link
+ * LlmProvider#isConditionPresenceQuestion} — that the question actually asks whether the patient HAS
+ * a diagnosed condition/disease. Only then does it entail each cited record (in one batched call,
+ * {@link LlmProvider#entailsBatch}) against a diagnosis-presence STATEMENT derived from the question
+ * ("The patient has a recorded diagnosis, condition, or problem of &lt;topic&gt;."). If NO cited
+ * record entails it — with positive evidence (at least one definitive NO and zero YES) — the "Yes"
+ * is unsupported and the leading verdict clause is rewritten to a NO-family lead. Every inline
+ * {@code [N]} citation marker is preserved, so the reference set — and therefore the recall / drift /
+ * abstention the metrics measure — is unchanged by construction. This is why the correction cannot
+ * regress recall the way answer-regenerating approaches (two-pass, self-critique) do.
+ *
+ * <p><strong>Why the intent gate.</strong> An intent-blind first cut applied the diagnosis-presence
+ * standard to <em>every</em> yes/no question. It fixed the condition over-affirmations but wrongly
+ * negated program-enrollment answers ("Yes — enrolled in the PMTCT program" &rarr; "No diagnosis
+ * …"), because a "diagnosis of X" yardstick is simply wrong for a non-diagnosis question — a net
+ * wash on the gate. The gate ({@link LlmProvider#CONDITION_INTENT_SYSTEM_PROMPT}) restricts the
+ * downgrade to condition/disease-presence questions, so enrollment, allergy, medication,
+ * test-performed, and value questions are left to the model. It is written generally (any body-part
+ * / organ-system problem counts) and validated on held-out systems, not fitted to the eval topics.
+ *
+ * <p><strong>Why it supersedes the {@code resourceType} guard.</strong> The earlier
+ * {@code applyVerdictGuard} fired only when every citation was an {@code obs}/{@code test_order} — a
+ * blind type whitelist. It therefore missed a "Yes" cited by a non-matching <em>condition</em>
+ * ("peripheral vascular disease" for a heart-problems question) and, being type-only, could not
+ * distinguish a diagnosis-presence question from an existence/order one. The entailment keys off the
+ * clinical meaning of each record against the actual question, catching the condition-typed
+ * over-affirmations the guard could not while leaving a genuinely-named diagnosis ("essential
+ * hypertension" cited for "is the patient hypertensive?") untouched.
+ *
+ * <p><strong>Scope (v1).</strong> Only the over-affirmation direction ("Yes" &rarr; "No"). The
+ * mirror direction ("No" &rarr; "Yes" for an under-recognised diagnosis) must surface previously
+ * uncited evidence and change the citation set, so it is deliberately out of scope here. Gated by
+ * {@code chartsearchai.verdictEntailment.enabled} (default off) and certified by the yes/no verdict
+ * gate in {@code eval/drift-metric/} before enabling.
+ */
+@Component("chartSearchAi.verdictEntailmentArbiter")
+public class VerdictEntailmentArbiter {
+
+	private static final Logger log = LoggerFactory.getLogger(VerdictEntailmentArbiter.class);
+
+	/** Leading "Yes" verdict clause, ported verbatim from the resourceType guard: the trailing
+	 *  class (em dash, colon, comma, etc.) is zero-or-more so a bare "Yes" matches, and it stops
+	 *  before "[" so it can never consume an inline citation marker. */
+	static final Pattern YES_CLAUSE =
+			Pattern.compile("^\\s*yes\\b[\\s\\u2014:,.;-]*", Pattern.CASE_INSENSITIVE);
+
+	/** A standalone re-affirming opener the model sometimes places after "Yes" ("there are records
+	 *  of kidney issues."). Removed so the rewritten NO lead is not immediately contradicted. The
+	 *  {@code [^.:\[]} class refuses to span a "[", so a clause carrying a citation never matches and
+	 *  no inline marker is dropped — the rewrite stays citation-neutral. */
+	static final Pattern REAFFIRM =
+			Pattern.compile("^there (is|are)\\b[^.:\\[]*[.:]\\s*", Pattern.CASE_INSENSITIVE);
+
+	/** Yes/no interrogative framings stripped to recover the clinical topic. Longest/most-specific
+	 *  first so "any history of" wins over "any". Kept general (not a per-topic table) so the
+	 *  statement derivation does not encode the eval's specific question set. */
+	private static final String[] QUESTION_PREFIXES = {
+			"does the patient have any ", "does the patient have ", "is the patient ",
+			"has the patient ", "do they have ", "are there any ", "is there any ",
+			"any known history of ", "any history of ", "history of ", "any known ", "any ",
+	};
+
+	static final String NO_LEAD = "No diagnosis explicitly naming this is recorded.";
+
+	@Autowired
+	private LlmProvider llmProvider;
+
+	/** Test seam: production wires {@link LlmProvider} via {@link Autowired}. */
+	void setLlmProvider(LlmProvider llmProvider) {
+		this.llmProvider = llmProvider;
+	}
+
+	/** The batched (source, statement) &rarr; verdict primitive, isolated as a seam so the decision
+	 *  logic is unit-testable without a live llama-server. Production binds {@code entailsBatch}. */
+	interface BatchEntailer {
+		List<Boolean> entails(List<String> sources, List<String> statements);
+	}
+
+	/** Question-intent gate: does this yes/no question ask about the presence of a diagnosed
+	 *  condition/disease? Isolated as a seam for the same reason as {@link BatchEntailer}. Production
+	 *  binds {@code isConditionPresenceQuestion}. */
+	interface IntentClassifier {
+		Boolean isConditionPresenceQuestion(String question);
+	}
+
+	/**
+	 * Production entry point: arbitrates the verdict lead using the real batched entailment call.
+	 *
+	 * @param answer the model's answer text
+	 * @param question the clinician's yes/no question
+	 * @param cited the records the answer cites
+	 * @param mappings the record mappings carrying each cited index's source text
+	 * @return the answer with a corrected verdict lead, or the original answer when the arbiter does
+	 *         not apply (not a "Yes" lead, no citations, unresolved text, or a cited record entails
+	 *         the diagnosis)
+	 */
+	public String arbitrate(String answer, String question, List<RecordReference> cited,
+			List<RecordMapping> mappings) {
+		return arbitrate(answer, question, cited, mappings,
+				llmProvider::isConditionPresenceQuestion, llmProvider::entailsBatch);
+	}
+
+	/**
+	 * Seam overload: decision logic against injected {@link IntentClassifier} and {@link
+	 * BatchEntailer}. Package-private so unit tests exercise the full transform (trigger, intent
+	 * gate, statement derivation, verdict aggregation, citation-neutral rewrite) without an OpenMRS
+	 * context or a llama-server.
+	 */
+	String arbitrate(String answer, String question, List<RecordReference> cited,
+			List<RecordMapping> mappings, IntentClassifier classifier, BatchEntailer entailer) {
+		// V1 acts only on an over-affirming "Yes" lead. A NO/NONE lead is left untouched.
+		if (answer == null || cited == null || cited.isEmpty() || !YES_CLAUSE.matcher(answer).find()) {
+			return answer;
+		}
+
+		// Intent gate: the finding-vs-diagnosis downgrade is only sound for a "does the patient HAVE a
+		// condition/disease" question. For an enrollment ("any programs"), allergy, medication,
+		// test-performed, or value question, a "Yes" is affirmed by a non-diagnosis record and must
+		// not be negated by a diagnosis-presence standard — that was the wash that sank the
+		// intent-blind v1 (it fixed condition over-affirmations but broke program-enrollment cells).
+		// A null/unknown classification degrades to "do not act".
+		if (!Boolean.TRUE.equals(classifier.isConditionPresenceQuestion(question))) {
+			return answer;
+		}
+
+		Map<Integer, String> textByIndex = new HashMap<Integer, String>();
+		if (mappings != null) {
+			for (RecordMapping mapping : mappings) {
+				textByIndex.put(mapping.getIndex(), mapping.getText());
+			}
+		}
+		List<String> sources = new ArrayList<String>();
+		for (RecordReference ref : cited) {
+			String text = textByIndex.get(ref.getIndex());
+			if (text != null && !text.trim().isEmpty()) {
+				sources.add(text);
+			}
+		}
+		// No resolvable cited text — cannot check; leave the model's verdict alone.
+		if (sources.isEmpty()) {
+			return answer;
+		}
+
+		String statement = buildStatement(question);
+		List<Boolean> verdicts = entailer.entails(sources,
+				Collections.nCopies(sources.size(), statement));
+		if (verdicts == null) {
+			return answer;
+		}
+
+		boolean anyDiagnosis = false;
+		boolean anyDefiniteNo = false;
+		for (Boolean v : verdicts) {
+			if (Boolean.TRUE.equals(v)) {
+				anyDiagnosis = true;
+			} else if (Boolean.FALSE.equals(v)) {
+				anyDefiniteNo = true;
+			}
+		}
+		// Keep the "Yes" when any cited record entails the diagnosis. Downgrade ONLY on positive
+		// evidence of absence: at least one definitive NO and zero YES. An all-null verdict
+		// (unparseable/unavailable) is treated as "could not verify" and leaves the answer intact —
+		// the arbiter never negates a verdict it could not check.
+		if (anyDiagnosis || !anyDefiniteNo) {
+			return answer;
+		}
+
+		String corrected = downgradeToNoLead(answer);
+		if (log.isDebugEnabled()) {
+			log.debug("Verdict entailment downgraded a 'Yes' lead: {} cited record(s), none entailed \"{}\"",
+					sources.size(), statement);
+		}
+		return corrected;
+	}
+
+	/**
+	 * Rewrites only the leading verdict clause of a "Yes" answer to a NO-family lead, preserving the
+	 * evidence and every inline {@code [N]} citation marker. Identical rewrite to the retired
+	 * resourceType guard, so its citation-neutrality carries over unchanged.
+	 */
+	static String downgradeToNoLead(String answer) {
+		String rest = YES_CLAUSE.matcher(answer).replaceFirst("");
+		rest = REAFFIRM.matcher(rest).replaceFirst("").trim();
+		if (!rest.isEmpty()) {
+			rest = Character.toUpperCase(rest.charAt(0)) + rest.substring(1);
+		}
+		return rest.isEmpty() ? NO_LEAD : NO_LEAD + " " + rest;
+	}
+
+	/** Builds the diagnosis-presence statement entailed against each cited record. */
+	static String buildStatement(String question) {
+		return "The patient has a recorded diagnosis, condition, or problem of " + deriveTopic(question)
+				+ ".";
+	}
+
+	/**
+	 * Recovers the clinical topic from a yes/no question by stripping its interrogative framing.
+	 * General (not a per-topic lookup): "any kidney problems?" &rarr; "kidney problems"; "is the
+	 * patient hypertensive" &rarr; "hypertensive". A question with no recognised framing is used
+	 * verbatim (minus trailing punctuation), which the entailment tolerates.
+	 */
+	static String deriveTopic(String question) {
+		if (question == null) {
+			return "";
+		}
+		String t = question.trim();
+		while (t.endsWith("?") || t.endsWith(".") || t.endsWith("!")) {
+			t = t.substring(0, t.length() - 1).trim();
+		}
+		String lower = t.toLowerCase();
+		for (String prefix : QUESTION_PREFIXES) {
+			if (lower.startsWith(prefix)) {
+				return t.substring(prefix.length()).trim();
+			}
+		}
+		return t;
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/VerdictEntailmentArbiterTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/VerdictEntailmentArbiterTest.java
@@ -1,0 +1,271 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * Unit tests for {@link VerdictEntailmentArbiter}: the trigger, statement derivation, verdict
+ * aggregation, and citation-neutral rewrite are exercised against a stubbed {@link
+ * VerdictEntailmentArbiter.BatchEntailer} so no llama-server is needed. The end-to-end behaviour on
+ * real patient data is covered by the yes/no verdict gate in {@code eval/drift-metric/}.
+ */
+public class VerdictEntailmentArbiterTest {
+
+	private static final String KIDNEY_Q = "any kidney problems";
+
+	/** A condition-presence question (kidney/heart/…): the intent gate opens, the arbiter runs. */
+	private static final VerdictEntailmentArbiter.IntentClassifier CONDITION = q -> Boolean.TRUE;
+
+	/** A non-condition question (programs/allergies/value/…): the intent gate keeps it shut. */
+	private static final VerdictEntailmentArbiter.IntentClassifier NOT_CONDITION = q -> Boolean.FALSE;
+
+	/** Classifier could not decide — the arbiter must degrade to leaving the verdict untouched. */
+	private static final VerdictEntailmentArbiter.IntentClassifier UNKNOWN_INTENT = q -> null;
+
+	private final VerdictEntailmentArbiter arbiter = new VerdictEntailmentArbiter();
+
+	/** Records what the arbiter asked, and replies with a preset verdict list. */
+	private static final class CapturingEntailer implements VerdictEntailmentArbiter.BatchEntailer {
+
+		List<String> lastSources;
+
+		List<String> lastStatements;
+
+		int calls;
+
+		private final List<Boolean> reply;
+
+		CapturingEntailer(List<Boolean> reply) {
+			this.reply = reply;
+		}
+
+		@Override
+		public List<Boolean> entails(List<String> sources, List<String> statements) {
+			this.calls++;
+			this.lastSources = sources;
+			this.lastStatements = statements;
+			return reply;
+		}
+	}
+
+	private static RecordReference ref(int index) {
+		return new RecordReference(index, "obs", "uuid-" + index, null);
+	}
+
+	private static RecordMapping mapping(int index, String text) {
+		return new RecordMapping(index, "obs", "uuid-" + index, null, text);
+	}
+
+	// ---- trigger ----
+
+	@Test
+	public void nonYesLead_isLeftUntouched_andSkipsEntailment() {
+		String answer = "No fractures are recorded.";
+		CapturingEntailer entailer = new CapturingEntailer(Collections.<Boolean> emptyList());
+		String out = arbiter.arbitrate(answer, "any fractures", Arrays.asList(ref(1)),
+				Arrays.asList(mapping(1, "Traumatic amputation")), CONDITION, entailer);
+		assertSame(answer, out, "a NO-lead answer must be returned unchanged");
+		assertEquals(0, entailer.calls, "no entailment call for a non-Yes lead");
+	}
+
+	@Test
+	public void emptyCitations_areLeftUntouched() {
+		String answer = "Yes — kidney problems are recorded.";
+		CapturingEntailer entailer = new CapturingEntailer(Collections.<Boolean> emptyList());
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Collections.<RecordReference> emptyList(),
+				Collections.<RecordMapping> emptyList(), CONDITION, entailer);
+		assertSame(answer, out);
+		assertEquals(0, entailer.calls);
+	}
+
+	// ---- downgrade path ----
+
+	@Test
+	public void labOnlyYes_withNoEntailedDiagnosis_isDowngraded() {
+		String answer = "Yes — kidney function labs are recorded: Serum creatinine 93.1 [3].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.FALSE));
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(3)),
+				Arrays.asList(mapping(3, "Serum creatinine (umol/L): 93.1 umol/L")), CONDITION, entailer);
+		assertFalse(out.toLowerCase().startsWith("yes"), "the 'Yes' lead must be removed");
+		assertTrue(out.startsWith(VerdictEntailmentArbiter.NO_LEAD), "a NO-family lead is prepended");
+		assertTrue(out.contains("[3]"), "the inline citation marker must be preserved");
+	}
+
+	@Test
+	public void downgrade_firesOnAnyDefiniteNo_withZeroYes() {
+		// one definite NO, one unverifiable (null) → positive evidence of absence, still downgrades.
+		String answer = "Yes — kidney issues: creatinine [3], urine test [4].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.FALSE, null));
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(3), ref(4)),
+				Arrays.asList(mapping(3, "Serum creatinine 93.1"), mapping(4, "Urine glucose test")),
+				CONDITION, entailer);
+		assertTrue(out.startsWith(VerdictEntailmentArbiter.NO_LEAD));
+		assertTrue(out.contains("[3]") && out.contains("[4]"), "both markers preserved");
+	}
+
+	// ---- keep path ----
+
+	@Test
+	public void yes_backedByAnEntailedDiagnosis_isKept() {
+		String answer = "Yes — chronic kidney disease is recorded [2].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.TRUE));
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(2)),
+				Arrays.asList(mapping(2, "Chronic kidney disease")), CONDITION, entailer);
+		assertSame(answer, out, "a Yes whose cited record entails the diagnosis is untouched");
+	}
+
+	@Test
+	public void yes_withMixedVerdicts_isKept_whenAnyRecordEntails() {
+		String answer = "Yes — CKD [2] and creatinine [3].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.TRUE, Boolean.FALSE));
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(2), ref(3)),
+				Arrays.asList(mapping(2, "Chronic kidney disease"), mapping(3, "Serum creatinine 93.1")),
+				CONDITION, entailer);
+		assertSame(answer, out, "any single entailed diagnosis keeps the Yes");
+	}
+
+	@Test
+	public void allNullVerdicts_neverNegate() {
+		String answer = "Yes — kidney problems [3].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList((Boolean) null, (Boolean) null));
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(3), ref(4)),
+				Arrays.asList(mapping(3, "Serum creatinine 93.1"), mapping(4, "Urine test")), CONDITION, entailer);
+		assertSame(answer, out, "an unverifiable (all-null) result must never negate the verdict");
+	}
+
+	@Test
+	public void nullVerdictList_neverNegate() {
+		String answer = "Yes — kidney problems [3].";
+		VerdictEntailmentArbiter.BatchEntailer entailer = (s, st) -> null;
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(3)),
+				Arrays.asList(mapping(3, "Serum creatinine 93.1")), CONDITION, entailer);
+		assertSame(answer, out);
+	}
+
+	@Test
+	public void citedRecordWithNoResolvableText_isLeftUntouched() {
+		String answer = "Yes — kidney problems [9].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.FALSE));
+		// cited index 9 has no mapping (and thus no text) — nothing to entail.
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(9)),
+				Arrays.asList(mapping(3, "unrelated")), CONDITION, entailer);
+		assertSame(answer, out);
+		assertEquals(0, entailer.calls, "no entailment call when no cited text resolves");
+	}
+
+	// ---- what the entailer is asked ----
+
+	@Test
+	public void entailer_receivesCitedRecordText_andOneStatementPerSource() {
+		String answer = "Yes — kidney issues: creatinine [3], BUN [4].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.FALSE, Boolean.FALSE));
+		arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(3), ref(4)),
+				Arrays.asList(mapping(3, "Serum creatinine 93.1"), mapping(4, "Blood urea nitrogen 82.9")),
+				CONDITION, entailer);
+		assertEquals(Arrays.asList("Serum creatinine 93.1", "Blood urea nitrogen 82.9"),
+				entailer.lastSources, "sources are the cited records' text, by index");
+		assertEquals(2, entailer.lastStatements.size(), "one statement per source");
+		assertEquals(entailer.lastStatements.get(0), entailer.lastStatements.get(1),
+				"the same diagnosis-presence statement is used for every pair");
+		assertTrue(entailer.lastStatements.get(0).contains("kidney problems"),
+				"the statement carries the question topic: " + entailer.lastStatements.get(0));
+	}
+
+	// ---- statement derivation ----
+
+	@Test
+	public void deriveTopic_stripsInterrogativeFraming() {
+		assertEquals("kidney problems", VerdictEntailmentArbiter.deriveTopic("any kidney problems?"));
+		assertEquals("hypertensive", VerdictEntailmentArbiter.deriveTopic("is the patient hypertensive"));
+		assertEquals("allergies",
+				VerdictEntailmentArbiter.deriveTopic("Does the patient have any allergies?"));
+		assertEquals("psychiatric illness",
+				VerdictEntailmentArbiter.deriveTopic("any history of psychiatric illness"));
+	}
+
+	@Test
+	public void deriveTopic_withNoKnownFraming_usesQuestionVerbatimMinusPunctuation() {
+		assertEquals("fractures on the left femur",
+				VerdictEntailmentArbiter.deriveTopic("fractures on the left femur?"));
+	}
+
+	@Test
+	public void buildStatement_isADiagnosisPresenceClaim() {
+		String s = VerdictEntailmentArbiter.buildStatement("any kidney problems?");
+		assertTrue(s.startsWith("The patient has a recorded diagnosis, condition, or problem of "), s);
+		assertTrue(s.endsWith("kidney problems."), s);
+	}
+
+	@Test
+	public void downgradeToNoLead_isCitationNeutral() {
+		String answer = "Yes — there are records of kidney issues: creatinine [3], urine [7].";
+		String out = VerdictEntailmentArbiter.downgradeToNoLead(answer);
+		assertTrue(out.startsWith(VerdictEntailmentArbiter.NO_LEAD), out);
+		assertTrue(out.contains("[3]") && out.contains("[7]"), "all inline markers preserved: " + out);
+		assertFalse(out.toLowerCase().contains("there are records of kidney issues"),
+				"the contradicting re-affirming clause is removed");
+	}
+
+	@Test
+	public void nullAnswer_isReturnedUnchanged() {
+		assertNull(arbiter.arbitrate(null, KIDNEY_Q, Arrays.asList(ref(1)),
+				new ArrayList<RecordMapping>(), CONDITION, new CapturingEntailer(null)));
+	}
+
+	// ---- intent gate ----
+
+	@Test
+	public void nonConditionQuestion_isSkipped_beforeAnyEntailment() {
+		// "any programs?" is a non-diagnosis question: a program-enrollment "Yes" must NOT be
+		// negated by a diagnosis-presence standard. The gate keeps it shut; the entailer never runs.
+		String answer = "Yes — the patient is enrolled in the PMTCT program [4].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.FALSE));
+		String out = arbiter.arbitrate(answer, "any programs", Arrays.asList(ref(4)),
+				Arrays.asList(mapping(4, "Enrolled in PMTCT Program")), NOT_CONDITION, entailer);
+		assertSame(answer, out, "a non-condition question's Yes must be left untouched");
+		assertEquals(0, entailer.calls, "the intent gate must short-circuit before entailment");
+	}
+
+	@Test
+	public void unknownIntent_isSkipped() {
+		String answer = "Yes — kidney problems are recorded: creatinine [3].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.FALSE));
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(3)),
+				Arrays.asList(mapping(3, "Serum creatinine 93.1")), UNKNOWN_INTENT, entailer);
+		assertSame(answer, out, "an undecided intent must degrade to leaving the verdict untouched");
+		assertEquals(0, entailer.calls);
+	}
+
+	@Test
+	public void conditionQuestion_opensTheGate_andDowngrades() {
+		// Same lab-only Yes as the downgrade test, but routed through the intent gate: a condition
+		// question opens it, so the unsupported "Yes" is still corrected.
+		String answer = "Yes — kidney function labs are recorded: creatinine 93.1 [3].";
+		CapturingEntailer entailer = new CapturingEntailer(Arrays.asList(Boolean.FALSE));
+		String out = arbiter.arbitrate(answer, KIDNEY_Q, Arrays.asList(ref(3)),
+				Arrays.asList(mapping(3, "Serum creatinine 93.1")), CONDITION, entailer);
+		assertTrue(out.startsWith(VerdictEntailmentArbiter.NO_LEAD));
+		assertEquals(1, entailer.calls, "a condition question runs the entailment");
+	}
+}


### PR DESCRIPTION
## What

Decides the **yes/no verdict lead** with a narrow, verdict-only **entailment** check instead of the small local model's free-form chart synthesis — which confidently over-affirms (e.g. answers *"Yes, kidney problems"* from a creatinine lab value alone, with no kidney diagnosis on record).

Opened as a **draft for evaluation** (per request). Opt-in, default **off** (`chartsearchai.verdictEntailment.enabled`).

## How it works

On a `"Yes"`-leading answer:
1. **Intent gate** — `LlmProvider.isConditionPresenceQuestion(question)` classifies whether the question asks *does the patient have a diagnosed condition/disease?* (general classifier — validated on held-out body systems like liver/skin/thyroid/lung, **not** fitted to the eval's topics). Enrollment / allergy / medication / test / value questions are left to the model.
2. **Entailment** — each cited record is entailed (one batched call, reusing the existing `LlmProvider.entailsBatch`) against a diagnosis-presence statement derived from the question.
3. **Rewrite** — if no cited record entails a diagnosis, the leading verdict clause is rewritten to a NO-family lead. The answer body and **every inline `[N]` citation marker are untouched**, so recall / drift / abstention are unchanged by construction.

## Why two LLM calls

The verdict correction must **not** touch the answer-generation call (doing so couples to recall — see the intent-blind and single-call kind-guard experiments that netted zero / regressed). The extra signal therefore comes from a *separate, isolated* judgment: an intent-classify call + one batched entailment call, both short verdict-only round-trips, only on condition `"Yes"` answers. This is the deliberate cost that buys the semantic, question-aware correction. If a single-call solution is required, the deterministic resourceType guard (#91) is the recall-neutral alternative at a lower ceiling.

## Gate results (`eval/drift-metric`, yes/no verdict gate)

| metric | v7 baseline | resourceType guard (#91) | **this PR** |
|---|---|---|---|
| verdict-acc | 0.869 | 0.881 | **0.903** (159/176) |
| directness | 0.989 | 0.989 | **0.989** |
| meanF1 (recall) | 0.742 | — | **0.743** |
| abstention acc | 0.94 | — | **0.94** |
| drift (off-topic citations) | 70 | — | **69** |
| Tier-B safety violations | 0 | 0 | **0** |

First lever to beat the guard **and** pass the full gate with no recall/abstention/drift regression. It fixes condition-typed over-affirmations the resourceType guard structurally cannot (e.g. a symptom stored as a `condition`, or a real-but-off-topic diagnosis).

## Scope / limits

- **v1 corrects over-affirmation only** (`"Yes"` → `"No"`). Under-recognition (`"No"` → `"Yes"`) needs surfacing previously-uncited evidence and is out of scope.
- Adds up to **2 short verdict-only LLM calls** per condition `"Yes"` answer → opt-in, default off. Intent classification depends only on the question and can be cached before any on-by-default use.
- Supersedes the resourceType guard (#91) when a second call is acceptable; the two are mutually exclusive in practice.

## Tests

- `VerdictEntailmentArbiterTest` — trigger, intent gate, statement derivation, verdict aggregation, citation-neutral rewrite (stubbed classifier/entailer; no llama-server needed).
- End-to-end behaviour covered by the yes/no verdict gate above (real pipeline, real datasets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)