### PR TITLE
fix(drug-safety): check question-named drugs against each other, not only against the chart — closes #114

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -690,18 +690,6 @@ public class DrugSafetyValidator {
 	 */
 	static final int MAX_QUESTION_PAIR_CHIPS = 10;
 
-	/**
-	 * @return {@link #severityRank} with an UNRATED rule raised above {@code major}: every curated
-	 *         hand-authored rule is unrated and {@link #clearsSeverityFloor} already treats unrated as
-	 *         exempt rather than low — unrated is not low-rated, so wherever a most-severe-first choice
-	 *         is made it must not be the one dropped. Matches the ordering
-	 *         {@code DrugReferenceInjector}'s promoted notes apply to the same rows.
-	 */
-	static int severityPriority(String severity) {
-		int rank = severityRank(severity);
-		return rank < 0 ? Integer.MAX_VALUE : rank;
-	}
-
 	/** Orders candidate pair chips most-severe first; see {@link #severityPriority}. */
 	private static final Comparator<PairFinding> PAIR_SEVERITY_DESCENDING = new Comparator<PairFinding>() {
 
@@ -913,6 +901,16 @@ public class DrugSafetyValidator {
 	 * {@code rxnorm_name}s, and all 6 are one substance family (the trastuzumab conjugates, isosorbide
 	 * and its mononitrate, the COVID-19 vaccines), so a pair genuinely worth reporting is not among them.
 	 *
+	 * <p>The name comes from {@link #partnerLabel}, the same coalesce the chart arm's own grouping keys
+	 * on, so the two arms that now group chips in this class agree by construction about what naming a
+	 * partner means. They cannot fight over a pair: both consult {@code hasActiveDrug}, and they take
+	 * opposite branches of it. Whenever any rule joining a pair names an active order, this arm records
+	 * the pair as the chart's and raises nothing, while {@link #bestRulePerPartner} raises exactly one
+	 * chip for that partner label — grouping only merges chips sharing a label, so a chip for the
+	 * deferred pair always survives it, at that partner's most severe row. Whenever no joining rule
+	 * names an active order, the chart arm raises nothing for the pair and this arm reports it. So one
+	 * clinical pair yields one chip from one arm, never two chips and never none.
+	 *
 	 * @return each drug mapped to the reference data's own name for it: the match token (or, for a rule
 	 *         carrying only a code, the ATC code) of the first above-floor rule any OTHER drug in
 	 *         {@code drugs} uses to name it. Falls back to its generic name, else its display name, when
@@ -929,7 +927,7 @@ public class DrugSafetyValidator {
 				}
 				List<DrugReference.Interaction> naming = aboveFloorRulesAgainst(other, drug, floor);
 				if (!naming.isEmpty()) {
-					name = ChartSearchAiUtils.firstNonBlank(naming.get(0).getToken(), naming.get(0).getAtc());
+					name = partnerLabel(naming.get(0));
 					break;
 				}
 			}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -655,8 +655,14 @@ public class DrugSafetyValidator {
 		if (!reportedPairs.add(unorderedPairKey(matchTokenFor(first, reverse), matchTokenFor(second, forward)))) {
 			return;
 		}
-		// Whichever side carries the rule owns the sentence; with symmetric data both do and the
-		// earlier question drug leads.
+		// Whichever side carries the rule owns the sentence; with symmetric data both do, and the tie
+		// goes to whichever entry the DATASET lists first — not whichever the question names first,
+		// because questionDrugs comes from findByQuery, which walks getAll() and so returns dataset
+		// order. Measured on the 3.7.1 standalone: "does voxelotor interact with dexamethasone?" and
+		// "can dexamethasone be given with voxelotor?" both chip with Voxelotor as the subject, its
+		// entry sitting at index 1055 against dexamethasone's 1744. Stable either way, which is what
+		// the chip needs; a rule that followed the question's word order would need the drug's offset
+		// in the question, which findByQuery does not report.
 		boolean fromFirst = !forward.isEmpty();
 		DrugReference subject = fromFirst ? first : second;
 		DrugReference partner = fromFirst ? second : first;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -53,7 +53,9 @@ import org.springframework.stereotype.Service;
  *       {@link CrossReactivityGroup} (cross-branch family overlap). The rule arm raises one
  *       warning per (drug, matched partner): several rules can name one partner — DDInter's
  *       route variants of a drug all publish the same match token — and they collapse to the
- *       most severe row, see {@link #bestRulePerPartner}.</li>
+ *       most severe row, see {@link #bestRulePerPartner}. It also interacts with
+ *       ANOTHER DRUG THE QUESTION NAMED — see {@link #addQuestionPairInteractions}, the arm that
+ *       answers "does A interact with B?" for a patient on neither.</li>
  *   <li><b>Contraindications</b> — the drug is contraindicated by an active allergy or
  *       condition: by a hand-authored rule, by being the same drug as — or sharing an ATC
  *       chemical subgroup with — a recorded allergy (cross-reactivity reasoning), or —
@@ -248,6 +250,11 @@ public class DrugSafetyValidator {
 			if (warnDose) {
 				addOverdose(warnings, ref, context, lower, all);
 			}
+		}
+		// LAST, so the patient's own findings lead: a chip about their allergy or their active order
+		// is a fact about them, and outranks a reference lookup about a pair they may not be on.
+		if (warnInteractions) {
+			addQuestionPairInteractions(warnings, questionDrugs, context, severityFloor);
 		}
 		if (!warnings.isEmpty()) {
 			log.info("Drug-safety validator raised {} warning(s)", warnings.size());
@@ -558,6 +565,127 @@ public class DrugSafetyValidator {
 	 */
 	private static int noteLength(DrugReference.Interaction interaction) {
 		return interaction.getNote() == null ? 0 : interaction.getNote().trim().length();
+	}
+
+	/**
+	 * The question-named PAIR arm (issue #114): the drugs the question resolved to, checked against
+	 * EACH OTHER rather than only against the chart.
+	 *
+	 * <p>Every other interaction arm joins one drug to the patient's own data, so a question naming
+	 * two drugs was silently reduced to two independent one-drug questions: asked "does warfarin
+	 * interact with aspirin?" about a patient on neither, the module reported no information about a
+	 * pair its own KB rates Major (measured on the 3.7.1 standalone, 2026-08-04 — it also raised an
+	 * unrequested Minor chip about the one drug that WAS on the chart, which reads as an answer to
+	 * the question asked). The pair is a plain reference lookup: it needs no patient data at all, and
+	 * withholding it because the patient happens not to be on either drug answers a question nobody
+	 * asked.
+	 *
+	 * <p>Deliberately scoped to the QUESTION's drugs, not to all of {@code inPlay}. The
+	 * answer-named additions are the LLM's word choice, and two drugs it names are as often
+	 * alternatives ("ibuprofen, or paracetamol if …") as a proposed combination, so pairing them
+	 * would assert a co-administration risk nobody proposed — the same over-reach echo scoping
+	 * exists to prevent (issue #105). It also keeps the chips aligned with the injected findings:
+	 * {@link DrugReferenceInjector#preAnswerFindings} runs this same validate with an EMPTY answer,
+	 * so an answer-side pair could produce a chip with no record behind it.
+	 *
+	 * <p>The floor is the shared {@code severityFloor} the chart arm is given, so this cannot become
+	 * a route around a decision the chip path enforces; and a pair either of whose drugs is an
+	 * active order is left to {@link #addInteractions}, whose chip states a fact about THIS patient
+	 * — the stronger statement, and reporting both would say one finding in two voices.
+	 */
+	private void addQuestionPairInteractions(List<SafetyWarning> warnings, Set<DrugReference> questionDrugs,
+			PatientClinicalContext context, int severityFloor) {
+		if (questionDrugs.size() < 2) {
+			return;
+		}
+		// Indexed so each UNORDERED pair is visited once: DDInter rows are symmetric and the parser
+		// writes every pair into both drugs' entries, so walking ordered pairs would report each
+		// interaction twice, once from each side.
+		List<DrugReference> drugs = new ArrayList<DrugReference>(questionDrugs);
+		for (int i = 0; i < drugs.size() - 1; i++) {
+			for (int j = i + 1; j < drugs.size(); j++) {
+				addQuestionPairInteraction(warnings, drugs.get(i), drugs.get(j), context, severityFloor);
+			}
+		}
+	}
+
+	/** One question-named pair: at most one chip, from whichever side carries the rule. */
+	private void addQuestionPairInteraction(List<SafetyWarning> warnings, DrugReference first,
+			DrugReference second, PatientClinicalContext context, int severityFloor) {
+		DrugReference.Interaction forward = aboveFloorRuleAgainst(first, second, severityFloor);
+		DrugReference.Interaction reverse = aboveFloorRuleAgainst(second, first, severityFloor);
+		if (forward == null && reverse == null) {
+			return;
+		}
+		if (coveredByActiveOrderArm(forward, context) || coveredByActiveOrderArm(reverse, context)) {
+			return;
+		}
+		// Whichever side carries the rule owns the sentence; with symmetric data both do and the
+		// earlier question drug leads.
+		DrugReference subject = forward != null ? first : second;
+		DrugReference partner = forward != null ? second : first;
+		DrugReference.Interaction rule = forward != null ? forward : reverse;
+		// "named in the question" is what keeps this distinguishable from the active-order chip, and
+		// it is a claim about the QUESTION, so it stays true whatever the chart holds. Wording it as
+		// "neither drug is on the chart" instead would be false for the one-sided-data case that
+		// reaches here — the patient IS on one of the pair, but only that drug's entry carries the
+		// rule, so no active-order chip fires from either side — and stating the patient's
+		// medications wrongly is the defect in #86.
+		String detail = subject.displayLabel() + " interacts with "
+				+ ChartSearchAiUtils.firstNonBlank(partner.displayLabel(), rule.getToken(), rule.getAtc())
+				+ ", also named in the question";
+		if (rule.getNote() != null && !rule.getNote().isEmpty()) {
+			detail += " — " + rule.getNote();
+		}
+		warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, subject.displayLabel(), detail));
+	}
+
+	/**
+	 * @return {@code subject}'s first interaction rule that names {@code other} AND clears
+	 *         {@code floor}, or null when it carries none. First rather than every: a pair of
+	 *         reference entries is one clinical fact however many rows join them (route variants
+	 *         sharing a match token can produce several), and the chart arm's one-chip-per-rule
+	 *         behaviour is not extended here.
+	 */
+	private static DrugReference.Interaction aboveFloorRuleAgainst(DrugReference subject, DrugReference other,
+			int floor) {
+		for (DrugReference.Interaction i : subject.getInteractions()) {
+			if (clearsSeverityFloor(i, floor) && identifies(i, other)) {
+				return i;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @return true when interaction rule {@code i} names reference entry {@code other} — the
+	 *         reference-side counterpart of {@link PatientClinicalContext#hasActiveDrug}: the same
+	 *         two arms, the rule's name token and its ATC code, resolved against a loaded entry's
+	 *         aliases and normalized codes instead of against the chart's active orders. Alias
+	 *         matching goes through the shared {@link DrugReference#matchesText} — the same matcher
+	 *         {@code findByQuery}/{@code lookupByToken} use to bind free text to an entry — so
+	 *         "this rule points at that drug" is decided one way throughout.
+	 */
+	private static boolean identifies(DrugReference.Interaction i, DrugReference other) {
+		String token = i.getToken();
+		if (token != null && !token.trim().isEmpty()
+				&& other.matchesText(token.trim().toLowerCase(Locale.ROOT))) {
+			return true;
+		}
+		String atc = DrugReference.normalizeAtcToken(i.getAtc());
+		return atc != null && other.normalizedAtcCodes().contains(atc);
+	}
+
+	/**
+	 * @return true when {@code rule} points at one of the patient's active orders, i.e.
+	 *         {@link #addInteractions} already raises this pair as a fact about the patient. Asked
+	 *         of both sides of a pair by the caller, so it covers "the partner is on the chart" and
+	 *         "the subject is on the chart" alike. Uses the very predicate that arm uses, so the two
+	 *         cannot disagree about which pairs the chart already owns.
+	 */
+	private static boolean coveredByActiveOrderArm(DrugReference.Interaction rule,
+			PatientClinicalContext context) {
+		return rule != null && context != null && context.hasActiveDrug(rule.getToken(), rule.getAtc());
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -642,6 +642,16 @@ public class DrugSafetyValidator {
 		// being the KB's own canonical name for a drug, and precisely what the variants share. Which
 		// variant's row then supplies the severity is #115's open half; the dataset's first is kept,
 		// as the chart arm keeps its first.
+		//   De-duplicating inside a safety net can only be done where nothing actionable is lost, and
+		// two entries collapse here only when the reference data gives them the SAME name. In the
+		// shape this exists for, one rule then identifies both, so the surviving chip carries that
+		// very rule's severity and mechanism and all that is dropped is a second spelling of the
+		// partner. Entries the data can tell apart are named by different tokens and keep their own
+		// chips — asserted over three drugs named in one question. The residual is a KB that gives two
+		// genuinely different drugs one token and separates them only by ATC code: the first is
+		// reported. Such a token is ambiguous in the reference data itself: the chart arm reads that
+		// same token to decide which of the patient's orders a rule names, so it cannot resolve the
+		// ambiguity either.
 		if (!reportedPairs.add(unorderedPairKey(matchTokenFor(first, reverse), matchTokenFor(second, forward)))) {
 			return;
 		}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -11,6 +11,8 @@ package org.openmrs.module.chartsearchai.reference;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -620,7 +622,7 @@ public class DrugSafetyValidator {
 		// subject of a sentence reading as a reference lookup, carrying one variant's mechanism
 		// attributed to another whose own row was sub-floor. Candidates are collected per pair key and
 		// emitted only once every entry pair has been seen.
-		Map<List<String>, SafetyWarning> candidates = new LinkedHashMap<List<String>, SafetyWarning>();
+		Map<List<String>, PairFinding> candidates = new LinkedHashMap<List<String>, PairFinding>();
 		Set<List<String>> chartOwned = new LinkedHashSet<List<String>>();
 		// Indexed so each UNORDERED pair of entries is visited once: DDInter rows are symmetric and
 		// the parser writes every pair into both drugs' entries, so walking ordered pairs would report
@@ -631,15 +633,89 @@ public class DrugSafetyValidator {
 						context, severityFloor);
 			}
 		}
-		for (Map.Entry<List<String>, SafetyWarning> candidate : candidates.entrySet()) {
+		List<PairFinding> found = new ArrayList<PairFinding>();
+		for (Map.Entry<List<String>, PairFinding> candidate : candidates.entrySet()) {
 			if (!chartOwned.contains(candidate.getKey())) {
-				warnings.add(candidate.getValue());
+				found.add(candidate.getValue());
 			}
+		}
+		// Most severe first, and bounded — see MAX_QUESTION_PAIR_CHIPS. Collections.sort is stable, so
+		// equally-rated pairs keep the dataset order the entry loop produced them in.
+		Collections.sort(found, PAIR_SEVERITY_DESCENDING);
+		int shown = Math.min(found.size(), MAX_QUESTION_PAIR_CHIPS);
+		if (shown < found.size()) {
+			// WARN, not INFO: a clinician reading the chips cannot tell a bounded list from a complete
+			// one, so an operator has to be able to see that this question outran the bound and which
+			// ratings went unshown. Silent truncation in a safety net reads as "nothing else was found".
+			List<String> withheld = new ArrayList<String>();
+			for (PairFinding finding : found.subList(shown, found.size())) {
+				withheld.add(finding.severity);
+			}
+			log.warn("Question-pair safety: {} of {} question-named drug pairs shown (cap {}); the "
+					+ "question resolved {} reference drugs, and pairs grow as N^2/2. Withheld, least "
+					+ "severe last: {}", shown, found.size(), MAX_QUESTION_PAIR_CHIPS, drugs.size(),
+					withheld);
+		}
+		for (PairFinding finding : found.subList(0, shown)) {
+			warnings.add(finding.warning);
+		}
+	}
+
+	/**
+	 * How many question-pair chips one question may raise.
+	 *
+	 * <p>Pairs grow as N²/2 in the number of reference drugs the question resolves, and every chip is
+	 * also injected as a citable pre-answer finding, so this arm is the one safety input a QUESTION
+	 * controls the size of — the others are bounded by the patient's own chart, which held findings to
+	 * 0–3. Measured on the bundled sample with the patient on nothing: one line naming its 16 drugs
+	 * raised 72 chips carrying 42,708 characters of finding text into the prompt, against a path that
+	 * caps a single reference record at {@link DrugReferenceInjector#MAX_INTERACTION_RENDER_CHARS} =
+	 * 1500 for precisely this reason.
+	 *
+	 * <p>Ten covers every pair among five named drugs, which is well past any "does A interact with B?"
+	 * question this arm exists for, and holds that worst case to roughly 6k characters of finding text.
+	 * A count rather than a character budget because a chip is a whole sentence a clinician reads: half
+	 * a chip is not a smaller chip. What is dropped is the least severe — the list is sorted
+	 * most-severe-first — and it is logged, never dropped silently.
+	 */
+	static final int MAX_QUESTION_PAIR_CHIPS = 10;
+
+	/**
+	 * @return {@link #severityRank} with an UNRATED rule raised above {@code major}: every curated
+	 *         hand-authored rule is unrated and {@link #clearsSeverityFloor} already treats unrated as
+	 *         exempt rather than low — unrated is not low-rated, so wherever a most-severe-first choice
+	 *         is made it must not be the one dropped. Matches the ordering
+	 *         {@code DrugReferenceInjector}'s promoted notes apply to the same rows.
+	 */
+	static int severityPriority(String severity) {
+		int rank = severityRank(severity);
+		return rank < 0 ? Integer.MAX_VALUE : rank;
+	}
+
+	/** Orders candidate pair chips most-severe first; see {@link #severityPriority}. */
+	private static final Comparator<PairFinding> PAIR_SEVERITY_DESCENDING = new Comparator<PairFinding>() {
+
+		@Override
+		public int compare(PairFinding a, PairFinding b) {
+			return Integer.compare(severityPriority(b.severity), severityPriority(a.severity));
+		}
+	};
+
+	/** One candidate pair chip, with the source-assigned rating that orders it. */
+	private static final class PairFinding {
+
+		final SafetyWarning warning;
+
+		final String severity;
+
+		PairFinding(SafetyWarning warning, String severity) {
+			this.warning = warning;
+			this.severity = severity;
 		}
 	}
 
 	/** One question-named pair: at most one candidate chip, from whichever side carries the rule. */
-	private void collectQuestionPairInteraction(Map<List<String>, SafetyWarning> candidates,
+	private void collectQuestionPairInteraction(Map<List<String>, PairFinding> candidates,
 			Set<List<String>> chartOwned, DrugReference first, DrugReference second,
 			Map<DrugReference, String> names, PatientClinicalContext context, int severityFloor) {
 		List<DrugReference.Interaction> forward = aboveFloorRulesAgainst(first, second, severityFloor);
@@ -687,8 +763,8 @@ public class DrugSafetyValidator {
 		if (rule.getNote() != null && !rule.getNote().isEmpty()) {
 			detail += " — " + rule.getNote();
 		}
-		candidates.put(pairKey, new SafetyWarning(SafetyWarning.TYPE_INTERACTION, subject.displayLabel(),
-				detail));
+		candidates.put(pairKey, new PairFinding(new SafetyWarning(SafetyWarning.TYPE_INTERACTION,
+				subject.displayLabel(), detail), rule.getSeverity()));
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -609,35 +609,58 @@ public class DrugSafetyValidator {
 		if (questionDrugs.size() < 2) {
 			return;
 		}
+		List<DrugReference> drugs = new ArrayList<DrugReference>(questionDrugs);
+		Map<DrugReference, String> names = pairKeyNames(drugs, severityFloor);
+		// Group first, decide second. Both the grouping and the chart-precedence verdict belong to the
+		// CLINICAL pair, and route variants make one clinical pair arrive as several entry pairs
+		// carrying different rule sets — the sub-floor sibling of an above-floor row loses that row, so
+		// its entry pair sees different tokens and can reach a different verdict. Deciding per entry
+		// pair, as an early return, therefore let a chart-owned pair leave no trace: its sibling
+		// concluded the chart did not own it and chipped, so the patient's own medication became the
+		// subject of a sentence reading as a reference lookup, carrying one variant's mechanism
+		// attributed to another whose own row was sub-floor. Candidates are collected per pair key and
+		// emitted only once every entry pair has been seen.
+		Map<List<String>, SafetyWarning> candidates = new LinkedHashMap<List<String>, SafetyWarning>();
+		Set<List<String>> chartOwned = new LinkedHashSet<List<String>>();
 		// Indexed so each UNORDERED pair of entries is visited once: DDInter rows are symmetric and
 		// the parser writes every pair into both drugs' entries, so walking ordered pairs would report
 		// each interaction twice, once from each side.
-		List<DrugReference> drugs = new ArrayList<DrugReference>(questionDrugs);
-		Set<List<String>> reportedPairs = new LinkedHashSet<List<String>>();
 		for (int i = 0; i < drugs.size() - 1; i++) {
 			for (int j = i + 1; j < drugs.size(); j++) {
-				addQuestionPairInteraction(warnings, drugs.get(i), drugs.get(j), context, severityFloor,
-						reportedPairs);
+				collectQuestionPairInteraction(candidates, chartOwned, drugs.get(i), drugs.get(j), names,
+						context, severityFloor);
+			}
+		}
+		for (Map.Entry<List<String>, SafetyWarning> candidate : candidates.entrySet()) {
+			if (!chartOwned.contains(candidate.getKey())) {
+				warnings.add(candidate.getValue());
 			}
 		}
 	}
 
-	/** One question-named pair: at most one chip, from whichever side carries the rule. */
-	private void addQuestionPairInteraction(List<SafetyWarning> warnings, DrugReference first,
-			DrugReference second, PatientClinicalContext context, int severityFloor,
-			Set<List<String>> reportedPairs) {
+	/** One question-named pair: at most one candidate chip, from whichever side carries the rule. */
+	private void collectQuestionPairInteraction(Map<List<String>, SafetyWarning> candidates,
+			Set<List<String>> chartOwned, DrugReference first, DrugReference second,
+			Map<DrugReference, String> names, PatientClinicalContext context, int severityFloor) {
 		List<DrugReference.Interaction> forward = aboveFloorRulesAgainst(first, second, severityFloor);
 		List<DrugReference.Interaction> reverse = aboveFloorRulesAgainst(second, first, severityFloor);
 		if (forward.isEmpty() && reverse.isEmpty()) {
 			return;
 		}
-		if (coveredByActiveOrderArm(forward, context) || coveredByActiveOrderArm(reverse, context)) {
+		// One chip per clinical PAIR, not per pair of ENTRIES, and nothing at all when the two entries
+		// are one drug — see pairKeyNames.
+		String firstName = names.get(first);
+		String secondName = names.get(second);
+		if (firstName.equals(secondName)) {
 			return;
 		}
-		// One chip per clinical PAIR, not per pair of ENTRIES, and nothing at all when the two entries
-		// are one drug — see pairKeyFor.
-		List<String> pairKey = pairKeyFor(first, forward, second, reverse);
-		if (pairKey == null || !reportedPairs.add(pairKey)) {
+		List<String> pairKey = unorderedPairKey(firstName, secondName);
+		if (coveredByActiveOrderArm(forward, context) || coveredByActiveOrderArm(reverse, context)) {
+			// Recorded, not returned: the sibling entry pairs of this clinical pair must see it.
+			chartOwned.add(pairKey);
+			return;
+		}
+		if (candidates.containsKey(pairKey)) {
 			return;
 		}
 		// Whichever side carries the rule owns the sentence; with symmetric data both do, and the tie
@@ -664,7 +687,8 @@ public class DrugSafetyValidator {
 		if (rule.getNote() != null && !rule.getNote().isEmpty()) {
 			detail += " — " + rule.getNote();
 		}
-		warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, subject.displayLabel(), detail));
+		candidates.put(pairKey, new SafetyWarning(SafetyWarning.TYPE_INTERACTION, subject.displayLabel(),
+				detail));
 	}
 
 	/**
@@ -772,57 +796,63 @@ public class DrugSafetyValidator {
 	 * against voxelotor is four near-identical chips, and four near-identical injected findings, for a
 	 * single clinical fact. That is issue #115's shape arriving on the question side (142
 	 * {@code rxnorm_name} values are shared by more than one entry across 332 entries of the full KB),
-	 * so the pair is keyed by the two drugs' MATCH TOKENS rather than by their entries — the token
-	 * being the reference data's own canonical name for a drug, and precisely what the variants share.
-	 * Which variant's row then supplies the severity is #115's open half; the dataset's first is kept,
-	 * as the chart arm keeps its first.
+	 * so pairs are keyed by the two drugs' MATCH TOKENS rather than by their entries — the token being
+	 * the reference data's own canonical name for a drug, and precisely what the variants share
+	 * (measured: in all 142 of those families the token is an exact alias of every member).
+	 *
+	 * <p>The name is resolved PER DRUG, once, rather than per pair, because a drug that keys two ways
+	 * gets two keys and its pair escapes the grouping. It did: the name came from the other side's rule
+	 * token where there was one and from {@link DrugReference#displayLabel} where there was not — two
+	 * vocabularies, so one entry keyed as {@code aspirin} in the pair whose partner row names it and as
+	 * {@code Acetylsalicylic acid (aspirin)} in the pair whose partner row is sub-floor, leaving nothing
+	 * to name it with. Resolving from ANY of the question's drugs' rules removes the second vocabulary
+	 * from the common case entirely, and route variants agree by construction, being named by the one
+	 * token that identifies them all.
 	 *
 	 * <p>De-duplicating inside a safety net can only be done where nothing actionable is lost, and two
-	 * entries collapse here only when the reference data gives them the SAME name. In the shape this
-	 * exists for, one rule then identifies both, so the surviving chip carries that very rule's
-	 * severity and mechanism and all that is dropped is a second spelling of the partner. Entries the
-	 * data can tell apart are named by different tokens and keep their own chips — asserted over three
-	 * drugs named in one question. The residual is a KB that gives two genuinely different drugs one
-	 * token and separates them only by ATC code: the first is reported. Such a token is ambiguous in
-	 * the reference data itself: the chart arm reads that same token to decide which of the patient's
-	 * orders a rule names, so it cannot resolve the ambiguity either.
+	 * entries share a name only when the reference data itself gives them one. The surviving chip then
+	 * carries that same rule's severity and mechanism, and all that is dropped is a second spelling of
+	 * the partner; entries the data can tell apart keep their own chips, asserted over three drugs named
+	 * in one question. Which variant's row supplies the severity is #115's open half; the dataset's
+	 * first is kept, as the chart arm keeps its first.
 	 *
-	 * <p>The degenerate case of that same rule is a pair of entries the data names IDENTICALLY, which
-	 * is one drug and not a pair at all — so it gets no key and no chip. It is reachable from a
-	 * question naming a single drug: the two-drugs guard counts ENTRIES, and one word resolves several
-	 * when the KB carries route variants of it, 33 above-floor rows in the full KB joining two entries
-	 * that share one match token (29 drug words: minoxidil, timolol, lidocaine, atropine, neomycin,
-	 * paclitaxel …). Grouping alone cannot suppress those, a self-pair's key being unique by
-	 * construction. Reporting one would assert a combination the clinician never proposed — issue
-	 * #105's over-reach — and where the variants are named after different substances it would name two
-	 * drugs the question never mentioned, the #86 failure mode this arm's wording exists to avoid. The
-	 * verdict is taken before any key is claimed, so a genuine pair keyed differently still reports.
+	 * <p>Two entries that end up with the SAME name are one drug, not a pair, and raise nothing. That is
+	 * reachable from a question naming a single drug: the two-drugs guard counts ENTRIES, and one word
+	 * resolves several when the KB carries variants of it — 33 above-floor rows in the full KB join two
+	 * entries sharing one token (29 drug words: minoxidil, timolol, lidocaine, atropine, neomycin,
+	 * paclitaxel …). Reporting one would assert a combination the clinician never proposed (issue #105's
+	 * over-reach), and where the variants are named after different substances it would name two drugs
+	 * the question never mentioned, which is #86. The measured cost of that suppression is bounded: only
+	 * 6 of the full KB's 2093 distinct tokens are an exact alias of entries with different
+	 * {@code rxnorm_name}s, and all 6 are one substance family (the trastuzumab conjugates, isosorbide
+	 * and its mononitrate, the COVID-19 vaccines), so a pair genuinely worth reporting is not among them.
 	 *
-	 * @return the key for this pair, or null when the two entries are one drug. Each drug is named by
-	 *         the rules on the OTHER side of it, so {@code first} is named by {@code reverse} and
-	 *         {@code second} by {@code forward} — the crossing is deliberate, not a transposition.
+	 * @return each drug mapped to the reference data's own name for it: the match token (or, for a rule
+	 *         carrying only a code, the ATC code) of the first above-floor rule any OTHER drug in
+	 *         {@code drugs} uses to name it. Falls back to its generic name, else its display name, when
+	 *         no rule names it at all — reachable only for the unnamed side of a one-directional pair,
+	 *         since {@code ddinter} writes every row into both entries.
 	 */
-	private static List<String> pairKeyFor(DrugReference first, List<DrugReference.Interaction> forward,
-			DrugReference second, List<DrugReference.Interaction> reverse) {
-		String firstName = pairKeyNameFor(first, reverse);
-		String secondName = pairKeyNameFor(second, forward);
-		return firstName.equals(secondName) ? null : unorderedPairKey(firstName, secondName);
-	}
-
-	/**
-	 * @return the reference data's own name for {@code drug}, lower-cased: the match token (or, for a
-	 *         rule carrying only a code, the ATC code) of {@code namingRules} — the rules on the other
-	 *         side of the pair, which are the ones that name this drug. Falls back to the entry's own
-	 *         label when no rule names it at all, so a pair with data on one side only still keys on
-	 *         something specific to that drug rather than on a shared blank. That fallback is where
-	 *         variants of one drug can key differently (each on its own label), and the direction is
-	 *         the safe one for a net — an extra chip, never a dropped one. Not a matcher: this name is
-	 *         only ever a key, which is why it may be a label.
-	 */
-	private static String pairKeyNameFor(DrugReference drug, List<DrugReference.Interaction> namingRules) {
-		String name = namingRules.isEmpty() ? drug.displayLabel()
-				: ChartSearchAiUtils.firstNonBlank(namingRules.get(0).getToken(), namingRules.get(0).getAtc());
-		return name == null ? "" : name.trim().toLowerCase(Locale.ROOT);
+	private static Map<DrugReference, String> pairKeyNames(List<DrugReference> drugs, int floor) {
+		Map<DrugReference, String> names = new LinkedHashMap<DrugReference, String>();
+		for (DrugReference drug : drugs) {
+			String name = null;
+			for (DrugReference other : drugs) {
+				if (other == drug) {
+					continue;
+				}
+				List<DrugReference.Interaction> naming = aboveFloorRulesAgainst(other, drug, floor);
+				if (!naming.isEmpty()) {
+					name = ChartSearchAiUtils.firstNonBlank(naming.get(0).getToken(), naming.get(0).getAtc());
+					break;
+				}
+			}
+			if (name == null) {
+				name = ChartSearchAiUtils.firstNonBlank(drug.getGenericName(), drug.displayLabel());
+			}
+			names.put(drug, name == null ? "" : name.trim().toLowerCase(Locale.ROOT));
+		}
+		return names;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -592,39 +592,65 @@ public class DrugSafetyValidator {
 	 * a route around a decision the chip path enforces; and a pair either of whose drugs is an
 	 * active order is left to {@link #addInteractions}, whose chip states a fact about THIS patient
 	 * — the stronger statement, and reporting both would say one finding in two voices.
+	 *
+	 * <p>{@link DrugReferenceInjector#orderedInteractionNotes} is deliberately NOT extended to match:
+	 * its documented "a partner that raises a chip is exactly a partner promoted here" is scoped to
+	 * the active-order arm, and stays exact, because a pair chip's partner is by construction not an
+	 * active order. The pair finding's prose grounding comes from elsewhere — since issue #110 the
+	 * deterministic finding is itself injected as a numbered, citable record by
+	 * {@code preAnswerFindings}, carrying this chip's string verbatim — so the promoted-note budget
+	 * and the chip/prose invariant both stay untouched.
 	 */
 	private void addQuestionPairInteractions(List<SafetyWarning> warnings, Set<DrugReference> questionDrugs,
 			PatientClinicalContext context, int severityFloor) {
 		if (questionDrugs.size() < 2) {
 			return;
 		}
-		// Indexed so each UNORDERED pair is visited once: DDInter rows are symmetric and the parser
-		// writes every pair into both drugs' entries, so walking ordered pairs would report each
-		// interaction twice, once from each side.
+		// Indexed so each UNORDERED pair of entries is visited once: DDInter rows are symmetric and
+		// the parser writes every pair into both drugs' entries, so walking ordered pairs would report
+		// each interaction twice, once from each side.
 		List<DrugReference> drugs = new ArrayList<DrugReference>(questionDrugs);
+		Set<List<String>> reportedPairs = new LinkedHashSet<List<String>>();
 		for (int i = 0; i < drugs.size() - 1; i++) {
 			for (int j = i + 1; j < drugs.size(); j++) {
-				addQuestionPairInteraction(warnings, drugs.get(i), drugs.get(j), context, severityFloor);
+				addQuestionPairInteraction(warnings, drugs.get(i), drugs.get(j), context, severityFloor,
+						reportedPairs);
 			}
 		}
 	}
 
 	/** One question-named pair: at most one chip, from whichever side carries the rule. */
 	private void addQuestionPairInteraction(List<SafetyWarning> warnings, DrugReference first,
-			DrugReference second, PatientClinicalContext context, int severityFloor) {
-		DrugReference.Interaction forward = aboveFloorRuleAgainst(first, second, severityFloor);
-		DrugReference.Interaction reverse = aboveFloorRuleAgainst(second, first, severityFloor);
-		if (forward == null && reverse == null) {
+			DrugReference second, PatientClinicalContext context, int severityFloor,
+			Set<List<String>> reportedPairs) {
+		List<DrugReference.Interaction> forward = aboveFloorRulesAgainst(first, second, severityFloor);
+		List<DrugReference.Interaction> reverse = aboveFloorRulesAgainst(second, first, severityFloor);
+		if (forward.isEmpty() && reverse.isEmpty()) {
 			return;
 		}
 		if (coveredByActiveOrderArm(forward, context) || coveredByActiveOrderArm(reverse, context)) {
 			return;
 		}
+		// One chip per clinical PAIR, not per pair of ENTRIES. DDInter carries a separate entry per
+		// route variant and every variant publishes the same rxnorm_name — which is the token its
+		// rules match on — so ONE word in the question resolves several entries (findByQuery returns
+		// every entry whose aliases match) that all pair off the same rule: four dexamethasone entries
+		// against voxelotor is four near-identical chips, and four near-identical injected findings,
+		// for a single clinical fact. That is issue #115's shape arriving on the question side (142
+		// rxnorm_name values are shared by more than one entry across 332 entries of the full KB), so
+		// the pair is keyed by the two drugs' MATCH TOKENS rather than by their entries — the token
+		// being the KB's own canonical name for a drug, and precisely what the variants share. Which
+		// variant's row then supplies the severity is #115's open half; the dataset's first is kept,
+		// as the chart arm keeps its first.
+		if (!reportedPairs.add(unorderedPairKey(matchTokenFor(first, reverse), matchTokenFor(second, forward)))) {
+			return;
+		}
 		// Whichever side carries the rule owns the sentence; with symmetric data both do and the
 		// earlier question drug leads.
-		DrugReference subject = forward != null ? first : second;
-		DrugReference partner = forward != null ? second : first;
-		DrugReference.Interaction rule = forward != null ? forward : reverse;
+		boolean fromFirst = !forward.isEmpty();
+		DrugReference subject = fromFirst ? first : second;
+		DrugReference partner = fromFirst ? second : first;
+		DrugReference.Interaction rule = fromFirst ? forward.get(0) : reverse.get(0);
 		// "named in the question" is what keeps this distinguishable from the active-order chip, and
 		// it is a claim about the QUESTION, so it stays true whatever the chart holds. Wording it as
 		// "neither drug is on the chart" instead would be false for the one-sided-data case that
@@ -641,20 +667,22 @@ public class DrugSafetyValidator {
 	}
 
 	/**
-	 * @return {@code subject}'s first interaction rule that names {@code other} AND clears
-	 *         {@code floor}, or null when it carries none. First rather than every: a pair of
-	 *         reference entries is one clinical fact however many rows join them (route variants
-	 *         sharing a match token can produce several), and the chart arm's one-chip-per-rule
-	 *         behaviour is not extended here.
+	 * @return every interaction rule of {@code subject} that names {@code other} AND clears
+	 *         {@code floor}, in dataset order — empty when it carries none. All of them, not just the
+	 *         first, because the two questions asked of them differ: the CHIP carries one row (a pair
+	 *         of reference entries is one clinical fact however many rows join them, so the chart
+	 *         arm's one-chip-per-rule behaviour is deliberately not extended here), while the
+	 *         chart-precedence check has to see them all — see {@link #coveredByActiveOrderArm}.
 	 */
-	private static DrugReference.Interaction aboveFloorRuleAgainst(DrugReference subject, DrugReference other,
-			int floor) {
+	private static List<DrugReference.Interaction> aboveFloorRulesAgainst(DrugReference subject,
+			DrugReference other, int floor) {
+		List<DrugReference.Interaction> out = new ArrayList<DrugReference.Interaction>();
 		for (DrugReference.Interaction i : subject.getInteractions()) {
 			if (clearsSeverityFloor(i, floor) && identifies(i, other)) {
-				return i;
+				out.add(i);
 			}
 		}
-		return null;
+		return out;
 	}
 
 	/**
@@ -665,6 +693,15 @@ public class DrugSafetyValidator {
 	 *         matching goes through the shared {@link DrugReference#matchesText} — the same matcher
 	 *         {@code findByQuery}/{@code lookupByToken} use to bind free text to an entry — so
 	 *         "this rule points at that drug" is decided one way throughout.
+	 *         <p>
+	 *         Deliberately that matcher and not the order-name one {@code hasActiveDrug} reaches for
+	 *         (issue #128 splits the two): both operands here are canonical reference strings — a
+	 *         rule's match token against an entry's aliases — with no localized, inflected display
+	 *         name to tolerate a trailing letter for, and the orientation is inverted, the rule's
+	 *         TOKEN being the haystack and the entry's aliases the needles. The nesting hazard
+	 *         therefore runs the other way here, and it is the symmetric word boundary that stops an
+	 *         alias nested in a longer token from matching ({@code chlorothiazide} against a
+	 *         {@code hydrochlorothiazide} rule).
 	 */
 	private static boolean identifies(DrugReference.Interaction i, DrugReference other) {
 		String token = i.getToken();
@@ -677,15 +714,55 @@ public class DrugSafetyValidator {
 	}
 
 	/**
-	 * @return true when {@code rule} points at one of the patient's active orders, i.e.
-	 *         {@link #addInteractions} already raises this pair as a fact about the patient. Asked
-	 *         of both sides of a pair by the caller, so it covers "the partner is on the chart" and
-	 *         "the subject is on the chart" alike. Uses the very predicate that arm uses, so the two
+	 * @return true when any of {@code rules} points at one of the patient's active orders, i.e.
+	 *         {@link #addInteractions} already raises this pair as a fact about the patient. ANY,
+	 *         over every rule joining the pair rather than only the one this arm would chip, because
+	 *         {@code addInteractions} walks them all: two rules can join one pair under different
+	 *         tokens — a brand-name row and an INN row — and a pair is the chart arm's as soon as one
+	 *         of them names an active order, so consulting the first alone would report that pair
+	 *         twice, once as a fact about the patient and once as a reference lookup. Asked of both
+	 *         directions by the caller, so it covers "the partner is on the chart" and "the subject
+	 *         is on the chart" alike, and it asks through the very predicate that arm uses, so the two
 	 *         cannot disagree about which pairs the chart already owns.
 	 */
-	private static boolean coveredByActiveOrderArm(DrugReference.Interaction rule,
+	private static boolean coveredByActiveOrderArm(List<DrugReference.Interaction> rules,
 			PatientClinicalContext context) {
-		return rule != null && context != null && context.hasActiveDrug(rule.getToken(), rule.getAtc());
+		if (context == null) {
+			return false;
+		}
+		for (DrugReference.Interaction rule : rules) {
+			if (context.hasActiveDrug(rule.getToken(), rule.getAtc())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @return the reference data's own name for {@code drug} in this pair, lower-cased: the match
+	 *         token (or, for a rule carrying only a code, the ATC code) of {@code namingRules} — the
+	 *         rules on the OTHER side of the pair, which are the ones that name this drug. Falls back
+	 *         to the entry's own label when no rule names it at all, so a pair with data on one side
+	 *         only still keys on something specific to that drug rather than on a shared blank.
+	 */
+	private static String matchTokenFor(DrugReference drug, List<DrugReference.Interaction> namingRules) {
+		String name = namingRules.isEmpty() ? drug.displayLabel()
+				: ChartSearchAiUtils.firstNonBlank(namingRules.get(0).getToken(), namingRules.get(0).getAtc());
+		return name == null ? "" : name.trim().toLowerCase(Locale.ROOT);
+	}
+
+	/**
+	 * @return a key equal for {@code (a, b)} and {@code (b, a)}: the two names, sorted. A two-element
+	 *         list rather than a joined string because every separator a name could be joined on is a
+	 *         character some drug name already contains — "Multivitamines et fer" a space,
+	 *         "Dexamethasone / lidocaine" a slash — and a separator that can appear inside a name
+	 *         lets two different pairs collapse to one key, silently dropping the second pair's chip.
+	 */
+	private static List<String> unorderedPairKey(String one, String other) {
+		List<String> key = new ArrayList<String>(2);
+		key.add(one.compareTo(other) <= 0 ? one : other);
+		key.add(one.compareTo(other) <= 0 ? other : one);
+		return key;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -58,9 +58,10 @@ import org.springframework.stereotype.Service;
  *       {@link CrossReactivityGroup} (cross-branch family overlap). The rule arm raises one
  *       warning per (drug, matched partner): several rules can name one partner — DDInter's
  *       route variants of a drug all publish the same match token — and they collapse to the
- *       most severe row, see {@link #bestRulePerPartner}. It also interacts with
- *       ANOTHER DRUG THE QUESTION NAMED — see {@link #addQuestionPairInteractions}, the arm that
- *       answers "does A interact with B?" for a patient on neither.</li>
+ *       most severe row, see {@link #bestRulePerPartner}. Separately, and needing no patient data at
+ *       all, one question-named drug interacts with ANOTHER DRUG THE SAME QUESTION NAMED — see
+ *       {@link #addQuestionPairInteractions}, the arm that answers "does A interact with B?" for a
+ *       patient on neither.</li>
  *   <li><b>Contraindications</b> — the drug is contraindicated by an active allergy or
  *       condition: by a hand-authored rule, by being the same drug as — or sharing an ATC
  *       chemical subgroup with — a recorded allergy (cross-reactivity reasoning), or —
@@ -593,18 +594,27 @@ public class DrugSafetyValidator {
 	 * {@link DrugReferenceInjector#preAnswerFindings} runs this same validate with an EMPTY answer,
 	 * so an answer-side pair could produce a chip with no record behind it.
 	 *
-	 * <p>The floor is the shared {@code severityFloor} the chart arm is given, so this cannot become
-	 * a route around a decision the chip path enforces; and a pair either of whose drugs is an
-	 * active order is left to {@link #addInteractions}, whose chip states a fact about THIS patient
-	 * — the stronger statement, and reporting both would say one finding in two voices.
+	 * <p>The floor is the shared {@code severityFloor} the chart arm is given, so this cannot become a
+	 * route around a decision the chip path enforces; and a pair the chart arm already reports is left
+	 * to {@link #addInteractions}, whose chip states a fact about THIS patient — the stronger statement,
+	 * and reporting both would say one finding in two voices. Stated precisely, because the looser
+	 * version ("either drug is an active order") is not what the code can ask and not what it does: the
+	 * test is whether any RULE joining the pair names an active order, {@link #coveredByActiveOrderArm}
+	 * putting the same question to {@code hasActiveDrug} that {@code addInteractions} answers when it
+	 * decides to chip. The two differ, and the difference is deliberate — a patient can be ON one of the
+	 * pair while no rule joining it names their order (the one-directional case below), and that pair is
+	 * this arm's to report, because the chart arm raises nothing for it.
 	 *
-	 * <p>{@link DrugReferenceInjector#orderedInteractionNotes} is deliberately NOT extended to match:
-	 * its documented "a partner that raises a chip is exactly a partner promoted here" is scoped to
-	 * the active-order arm, and stays exact, because a pair chip's partner is by construction not an
-	 * active order. The pair finding's prose grounding comes from elsewhere — since issue #110 the
-	 * deterministic finding is itself injected as a numbered, citable record by
-	 * {@code preAnswerFindings}, carrying this chip's string verbatim — so the promoted-note budget
-	 * and the chip/prose invariant both stay untouched.
+	 * <p>{@link DrugReferenceInjector#orderedInteractionNotes} is deliberately NOT extended to match,
+	 * and its "a partner that raises a chip is exactly a partner promoted here" should be read as scoped
+	 * to the arm it describes: across the whole chip set it no longer holds, since a pair chip's partner
+	 * is promoted nowhere. That sentence lives in a file this change does not touch — rewording it is
+	 * left to whichever PR owns that method next, so two PRs do not collide on it. What is NOT affected
+	 * is the invariant the sentence exists to protect, that a chip and the prose cannot describe the
+	 * same finding differently: since issue #110 the deterministic finding is itself injected as a
+	 * numbered, citable record by {@code preAnswerFindings}, carrying this chip's string verbatim, so a
+	 * pair finding's grounding comes from that record rather than from the promoted notes, and the
+	 * promoted-note budget is untouched.
 	 */
 	private void addQuestionPairInteractions(List<SafetyWarning> warnings, Set<DrugReference> questionDrugs,
 			PatientClinicalContext context, int severityFloor) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -37,7 +37,10 @@ import org.springframework.stereotype.Service;
  * <p>For every reference drug in play — those the question asks about, plus those the answer
  * names on its own authority (a drug the answer mentions only by echoing a cited record's own
  * text is a mention, not a proposal, and is excluded — see {@code isEchoOfCitedRecord}, issue
- * #105) — it checks three things against the patient's clinical context and the reference table:
+ * #105) — it checks three things against the patient's clinical context and the reference table.
+ * One check departs from that framing deliberately: the question-named PAIR arm reads the reference
+ * table alone, and covers the drugs the QUESTION resolved to rather than all of those in play, so it
+ * answers "does A interact with B?" for a patient on neither — see {@link #addQuestionPairInteractions}.
  * <ul>
  *   <li><b>Overdose</b> — a daily dose parsed from the answer exceeds the
  *       reference {@code maxDailyDoseMg} for the patient's age band; or, when the patient's
@@ -631,28 +634,8 @@ public class DrugSafetyValidator {
 		if (coveredByActiveOrderArm(forward, context) || coveredByActiveOrderArm(reverse, context)) {
 			return;
 		}
-		// One chip per clinical PAIR, not per pair of ENTRIES. DDInter carries a separate entry per
-		// route variant and every variant publishes the same rxnorm_name — which is the token its
-		// rules match on — so ONE word in the question resolves several entries (findByQuery returns
-		// every entry whose aliases match) that all pair off the same rule: four dexamethasone entries
-		// against voxelotor is four near-identical chips, and four near-identical injected findings,
-		// for a single clinical fact. That is issue #115's shape arriving on the question side (142
-		// rxnorm_name values are shared by more than one entry across 332 entries of the full KB), so
-		// the pair is keyed by the two drugs' MATCH TOKENS rather than by their entries — the token
-		// being the KB's own canonical name for a drug, and precisely what the variants share. Which
-		// variant's row then supplies the severity is #115's open half; the dataset's first is kept,
-		// as the chart arm keeps its first.
-		//   De-duplicating inside a safety net can only be done where nothing actionable is lost, and
-		// two entries collapse here only when the reference data gives them the SAME name. In the
-		// shape this exists for, one rule then identifies both, so the surviving chip carries that
-		// very rule's severity and mechanism and all that is dropped is a second spelling of the
-		// partner. Entries the data can tell apart are named by different tokens and keep their own
-		// chips — asserted over three drugs named in one question. The residual is a KB that gives two
-		// genuinely different drugs one token and separates them only by ATC code: the first is
-		// reported. Such a token is ambiguous in the reference data itself: the chart arm reads that
-		// same token to decide which of the patient's orders a rule names, so it cannot resolve the
-		// ambiguity either.
-		if (!reportedPairs.add(unorderedPairKey(matchTokenFor(first, reverse), matchTokenFor(second, forward)))) {
+		// One chip per clinical PAIR, not per pair of ENTRIES — see pairKeyFor.
+		if (!reportedPairs.add(pairKeyFor(first, forward, second, reverse))) {
 			return;
 		}
 		// Whichever side carries the rule owns the sentence; with symmetric data both do, and the tie
@@ -693,39 +676,39 @@ public class DrugSafetyValidator {
 	private static List<DrugReference.Interaction> aboveFloorRulesAgainst(DrugReference subject,
 			DrugReference other, int floor) {
 		List<DrugReference.Interaction> out = new ArrayList<DrugReference.Interaction>();
-		for (DrugReference.Interaction i : subject.getInteractions()) {
-			if (clearsSeverityFloor(i, floor) && identifies(i, other)) {
-				out.add(i);
+		for (DrugReference.Interaction rule : subject.getInteractions()) {
+			if (clearsSeverityFloor(rule, floor) && identifies(rule, other)) {
+				out.add(rule);
 			}
 		}
 		return out;
 	}
 
 	/**
-	 * @return true when interaction rule {@code i} names reference entry {@code other} — the
-	 *         reference-side counterpart of {@link PatientClinicalContext#hasActiveDrug}: the same
-	 *         two arms, the rule's name token and its ATC code, resolved against a loaded entry's
-	 *         aliases and normalized codes instead of against the chart's active orders. Alias
-	 *         matching goes through the shared {@link DrugReference#matchesText} — the same matcher
-	 *         {@code findByQuery}/{@code lookupByToken} use to bind free text to an entry — so
-	 *         "this rule points at that drug" is decided one way throughout.
-	 *         <p>
-	 *         Deliberately that matcher and not the order-name one {@code hasActiveDrug} reaches for
-	 *         (issue #128 splits the two): both operands here are canonical reference strings — a
-	 *         rule's match token against an entry's aliases — with no localized, inflected display
-	 *         name to tolerate a trailing letter for, and the orientation is inverted, the rule's
-	 *         TOKEN being the haystack and the entry's aliases the needles. The nesting hazard
-	 *         therefore runs the other way here, and it is the symmetric word boundary that stops an
-	 *         alias nested in a longer token from matching ({@code chlorothiazide} against a
-	 *         {@code hydrochlorothiazide} rule).
+	 * The reference-side counterpart of {@link PatientClinicalContext#hasActiveDrug}: the same two
+	 * arms, a rule's name token and its ATC code, resolved against a loaded entry's aliases and
+	 * normalized codes instead of against the chart's active orders. Alias matching goes through the
+	 * shared {@link DrugReference#matchesText} — the same matcher {@code findByQuery}/
+	 * {@code lookupByToken} use to bind free text to an entry — so "this rule points at that drug" is
+	 * decided one way throughout.
+	 *
+	 * <p>Deliberately that matcher and not the order-name one {@code hasActiveDrug} reaches for (issue
+	 * #128 splits the two): both operands here are canonical reference strings — a rule's match token
+	 * against an entry's aliases — with no localized, inflected display name to tolerate a trailing
+	 * letter for, and the orientation is inverted, the rule's TOKEN being the haystack and the entry's
+	 * aliases the needles. The nesting hazard therefore runs the other way here, and it is the
+	 * symmetric word boundary that stops an alias nested in a longer token from matching
+	 * ({@code chlorothiazide} against a {@code hydrochlorothiazide} rule).
+	 *
+	 * @return true when {@code rule} names reference entry {@code other}
 	 */
-	private static boolean identifies(DrugReference.Interaction i, DrugReference other) {
-		String token = i.getToken();
-		if (token != null && !token.trim().isEmpty()
+	private static boolean identifies(DrugReference.Interaction rule, DrugReference other) {
+		String token = rule.getToken();
+		if (!ChartSearchAiUtils.isBlank(token)
 				&& other.matchesText(token.trim().toLowerCase(Locale.ROOT))) {
 			return true;
 		}
-		String atc = DrugReference.normalizeAtcToken(i.getAtc());
+		String atc = DrugReference.normalizeAtcToken(rule.getAtc());
 		return atc != null && other.normalizedAtcCodes().contains(atc);
 	}
 
@@ -755,13 +738,48 @@ public class DrugSafetyValidator {
 	}
 
 	/**
-	 * @return the reference data's own name for {@code drug} in this pair, lower-cased: the match
-	 *         token (or, for a rule carrying only a code, the ATC code) of {@code namingRules} — the
-	 *         rules on the OTHER side of the pair, which are the ones that name this drug. Falls back
-	 *         to the entry's own label when no rule names it at all, so a pair with data on one side
-	 *         only still keys on something specific to that drug rather than on a shared blank.
+	 * One chip per clinical PAIR, not per pair of ENTRIES. DDInter carries a separate entry per route
+	 * variant and every variant publishes the same {@code rxnorm_name} — which is the token its rules
+	 * match on — so ONE word in the question resolves several entries ({@code findByQuery} returns
+	 * every entry whose aliases match) that all pair off the same rule: four dexamethasone entries
+	 * against voxelotor is four near-identical chips, and four near-identical injected findings, for a
+	 * single clinical fact. That is issue #115's shape arriving on the question side (142
+	 * {@code rxnorm_name} values are shared by more than one entry across 332 entries of the full KB),
+	 * so the pair is keyed by the two drugs' MATCH TOKENS rather than by their entries — the token
+	 * being the reference data's own canonical name for a drug, and precisely what the variants share.
+	 * Which variant's row then supplies the severity is #115's open half; the dataset's first is kept,
+	 * as the chart arm keeps its first.
+	 *
+	 * <p>De-duplicating inside a safety net can only be done where nothing actionable is lost, and two
+	 * entries collapse here only when the reference data gives them the SAME name. In the shape this
+	 * exists for, one rule then identifies both, so the surviving chip carries that very rule's
+	 * severity and mechanism and all that is dropped is a second spelling of the partner. Entries the
+	 * data can tell apart are named by different tokens and keep their own chips — asserted over three
+	 * drugs named in one question. The residual is a KB that gives two genuinely different drugs one
+	 * token and separates them only by ATC code: the first is reported. Such a token is ambiguous in
+	 * the reference data itself: the chart arm reads that same token to decide which of the patient's
+	 * orders a rule names, so it cannot resolve the ambiguity either.
+	 *
+	 * @return the key for this pair. Each drug is named by the rules on the OTHER side of it, so
+	 *         {@code first} is named by {@code reverse} and {@code second} by {@code forward} — the
+	 *         crossing is deliberate, not a transposition.
 	 */
-	private static String matchTokenFor(DrugReference drug, List<DrugReference.Interaction> namingRules) {
+	private static List<String> pairKeyFor(DrugReference first, List<DrugReference.Interaction> forward,
+			DrugReference second, List<DrugReference.Interaction> reverse) {
+		return unorderedPairKey(pairKeyNameFor(first, reverse), pairKeyNameFor(second, forward));
+	}
+
+	/**
+	 * @return the reference data's own name for {@code drug}, lower-cased: the match token (or, for a
+	 *         rule carrying only a code, the ATC code) of {@code namingRules} — the rules on the other
+	 *         side of the pair, which are the ones that name this drug. Falls back to the entry's own
+	 *         label when no rule names it at all, so a pair with data on one side only still keys on
+	 *         something specific to that drug rather than on a shared blank. That fallback is where
+	 *         variants of one drug can key differently (each on its own label), and the direction is
+	 *         the safe one for a net — an extra chip, never a dropped one. Not a matcher: this name is
+	 *         only ever a key, which is why it may be a label.
+	 */
+	private static String pairKeyNameFor(DrugReference drug, List<DrugReference.Interaction> namingRules) {
 		String name = namingRules.isEmpty() ? drug.displayLabel()
 				: ChartSearchAiUtils.firstNonBlank(namingRules.get(0).getToken(), namingRules.get(0).getAtc());
 		return name == null ? "" : name.trim().toLowerCase(Locale.ROOT);
@@ -775,9 +793,10 @@ public class DrugSafetyValidator {
 	 *         lets two different pairs collapse to one key, silently dropping the second pair's chip.
 	 */
 	private static List<String> unorderedPairKey(String one, String other) {
+		boolean inOrder = one.compareTo(other) <= 0;
 		List<String> key = new ArrayList<String>(2);
-		key.add(one.compareTo(other) <= 0 ? one : other);
-		key.add(one.compareTo(other) <= 0 ? other : one);
+		key.add(inOrder ? one : other);
+		key.add(inOrder ? other : one);
 		return key;
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -634,8 +634,10 @@ public class DrugSafetyValidator {
 		if (coveredByActiveOrderArm(forward, context) || coveredByActiveOrderArm(reverse, context)) {
 			return;
 		}
-		// One chip per clinical PAIR, not per pair of ENTRIES — see pairKeyFor.
-		if (!reportedPairs.add(pairKeyFor(first, forward, second, reverse))) {
+		// One chip per clinical PAIR, not per pair of ENTRIES, and nothing at all when the two entries
+		// are one drug — see pairKeyFor.
+		List<String> pairKey = pairKeyFor(first, forward, second, reverse);
+		if (pairKey == null || !reportedPairs.add(pairKey)) {
 			return;
 		}
 		// Whichever side carries the rule owns the sentence; with symmetric data both do, and the tie
@@ -687,29 +689,54 @@ public class DrugSafetyValidator {
 	/**
 	 * The reference-side counterpart of {@link PatientClinicalContext#hasActiveDrug}: the same two
 	 * arms, a rule's name token and its ATC code, resolved against a loaded entry's aliases and
-	 * normalized codes instead of against the chart's active orders. Alias matching goes through the
-	 * shared {@link DrugReference#matchesText} — the same matcher {@code findByQuery}/
-	 * {@code lookupByToken} use to bind free text to an entry — so "this rule points at that drug" is
-	 * decided one way throughout.
+	 * normalized codes instead of against the chart's active orders.
 	 *
-	 * <p>Deliberately that matcher and not the order-name one {@code hasActiveDrug} reaches for (issue
-	 * #128 splits the two): both operands here are canonical reference strings — a rule's match token
-	 * against an entry's aliases — with no localized, inflected display name to tolerate a trailing
-	 * letter for, and the orientation is inverted, the rule's TOKEN being the haystack and the entry's
-	 * aliases the needles. The nesting hazard therefore runs the other way here, and it is the
-	 * symmetric word boundary that stops an alias nested in a longer token from matching
-	 * ({@code chlorothiazide} against a {@code hydrochlorothiazide} rule).
+	 * <p>Both operands here are canonical reference strings — a rule's match token against an entry's
+	 * own alias list — so the question is NAME IDENTITY, and neither of the two matchers issue #128
+	 * splits {@link DrugReference#matchesText} into answers it. Both scan for a name inside a longer
+	 * string, which is right when the longer string is prose ({@code findByQuery}) or a localized order
+	 * name ({@code matchesOrderName}) and wrong here, because a token is neither. Measured on the full
+	 * KB, scanning made a multi-word token name every drug called after one of its words: 408 of 2093
+	 * distinct tokens are multi-word and 53 of those carry a word that is some other entry's whole name
+	 * — {@code ethinyl estradiol} (in 449 entries' rule lists) named the separate Estradiol entry,
+	 * {@code magnesium salicylate} named Salicylic acid, {@code iron-dextran complex} named Iron. A
+	 * word boundary does not help: it stops a name nested inside a WORD ({@code chlorothiazide} in
+	 * {@code hydrochlorothiazide}) but not one nested inside a PHRASE. The chip then stated an
+	 * interaction the KB does not carry, against a drug whose row it had read from a different drug,
+	 * and {@link DrugReferenceInjector#preAnswerFindings} injected that same sentence as a citable
+	 * record — a fabricated interaction handed to the model as evidence.
+	 *
+	 * <p>So this arm compares names rather than scanning: exactly one of {@code other}'s aliases,
+	 * case-folded. No third matcher is introduced — this reads the same {@link DrugReference#getAliases}
+	 * list {@code matchesText} reads, so #128's change to how that list is scanned cannot drift from it.
+	 * Nothing genuine is lost: {@code ddinter} writes each rule's token from its partner row's
+	 * {@code rxnorm_name} (falling back to its name), and the parser puts both in that partner's
+	 * aliases, so every real rule still names its partner exactly — and an entry whose aliases omit its
+	 * own name could never be resolved from a question in the first place, {@code findByQuery} reading
+	 * the same list.
 	 *
 	 * @return true when {@code rule} names reference entry {@code other}
 	 */
 	private static boolean identifies(DrugReference.Interaction rule, DrugReference other) {
-		String token = rule.getToken();
-		if (!ChartSearchAiUtils.isBlank(token)
-				&& other.matchesText(token.trim().toLowerCase(Locale.ROOT))) {
+		if (namesEntry(rule.getToken(), other)) {
 			return true;
 		}
 		String atc = DrugReference.normalizeAtcToken(rule.getAtc());
 		return atc != null && other.normalizedAtcCodes().contains(atc);
+	}
+
+	/** @return true when {@code token} is, case-folded, one of {@code other}'s own aliases. */
+	private static boolean namesEntry(String token, DrugReference other) {
+		if (ChartSearchAiUtils.isBlank(token)) {
+			return false;
+		}
+		String name = token.trim().toLowerCase(Locale.ROOT);
+		for (String alias : other.getAliases()) {
+			if (alias != null && name.equals(alias.trim().toLowerCase(Locale.ROOT))) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -760,13 +787,26 @@ public class DrugSafetyValidator {
 	 * the reference data itself: the chart arm reads that same token to decide which of the patient's
 	 * orders a rule names, so it cannot resolve the ambiguity either.
 	 *
-	 * @return the key for this pair. Each drug is named by the rules on the OTHER side of it, so
-	 *         {@code first} is named by {@code reverse} and {@code second} by {@code forward} — the
-	 *         crossing is deliberate, not a transposition.
+	 * <p>The degenerate case of that same rule is a pair of entries the data names IDENTICALLY, which
+	 * is one drug and not a pair at all — so it gets no key and no chip. It is reachable from a
+	 * question naming a single drug: the two-drugs guard counts ENTRIES, and one word resolves several
+	 * when the KB carries route variants of it, 33 above-floor rows in the full KB joining two entries
+	 * that share one match token (29 drug words: minoxidil, timolol, lidocaine, atropine, neomycin,
+	 * paclitaxel …). Grouping alone cannot suppress those, a self-pair's key being unique by
+	 * construction. Reporting one would assert a combination the clinician never proposed — issue
+	 * #105's over-reach — and where the variants are named after different substances it would name two
+	 * drugs the question never mentioned, the #86 failure mode this arm's wording exists to avoid. The
+	 * verdict is taken before any key is claimed, so a genuine pair keyed differently still reports.
+	 *
+	 * @return the key for this pair, or null when the two entries are one drug. Each drug is named by
+	 *         the rules on the OTHER side of it, so {@code first} is named by {@code reverse} and
+	 *         {@code second} by {@code forward} — the crossing is deliberate, not a transposition.
 	 */
 	private static List<String> pairKeyFor(DrugReference first, List<DrugReference.Interaction> forward,
 			DrugReference second, List<DrugReference.Interaction> reverse) {
-		return unorderedPairKey(pairKeyNameFor(first, reverse), pairKeyNameFor(second, forward));
+		String firstName = pairKeyNameFor(first, reverse);
+		String secondName = pairKeyNameFor(second, forward);
+		return firstName.equals(secondName) ? null : unorderedPairKey(firstName, secondName);
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -237,6 +237,11 @@ public class DrugSafetyQuestionPairInteractionTest {
 		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
 				"The records do not address this combination.", question, patientOnNeitherDrug());
 
+		// The chip's severity word comes from the NOTE, which the ddinter parser prefixes with the
+		// rating; the rating FIELD is what the floor and the most-severe-first ordering read. Both are
+		// asserted, so deleting either from the fixture fails here rather than passing quietly.
+		assertEquals("Major", fixture.findByQuery("voxelotor").get(0).getInteractions().get(0)
+				.getSeverity(), "precondition: the surviving row's rating field must be Major");
 		assertEquals(1, interactionChips(warnings),
 				"route variants of one drug are one drug for this arm, so the pair must be reported"
 						+ " once, not once per variant entry, was: " + warnings);
@@ -397,6 +402,63 @@ public class DrugSafetyQuestionPairInteractionTest {
 			}
 		}
 		return -1;
+	}
+
+	@Test
+	public void twoDrugsThatNoRuleNamesStayTwoDrugs() throws IOException {
+		// The key-name fallback, which is what a drug keys on when no rule on any other named drug's
+		// entry names it. Reachable only in one-directional data — the bundled curated seed's exact
+		// shape, where Ibuprofen and Paracetamol each carry a rule against warfarin and warfarin is not
+		// an entry at all — and only for the unnamed side of a pair, since a pair needs a joining rule
+		// and that rule names the OTHER side. Two such drugs therefore never pair with each other, but
+		// they do both pair with the drug they name, and if the fallback did not distinguish them those
+		// two pairs would collapse into one and a real interaction would be dropped silently. Nothing
+		// pinned it: replacing the fallback with a constant left the whole package green.
+		DrugReferenceService fixture = pairFixtureService();
+		String question = "Can ibuprofen or paracetamol be given with warfarin?";
+		DrugReference warfarin = fixture.findByQuery("warfarin").get(0);
+		assertTrue(warfarin.getInteractions().isEmpty(),
+				"precondition: the named drug must carry no rules of its own, so both others fall back");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"Both raise bleeding risk with anticoagulants.", question, patientOnNeitherDrug());
+
+		assertEquals(2, interactionChips(warnings),
+				"two different drugs interacting with the same third drug are two pairs, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Ibuprofen", "Warfarin"), "ibuprofen x warfarin must be reported: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Paracetamol", "Warfarin"), "paracetamol x warfarin must be reported: " + warnings);
+		// Two chips from one question also exercise the ordering, and here the RATING FIELD is what
+		// orders them — the fixture's Major row is second in dataset order, so dataset order alone would
+		// put the Moderate first.
+		assertEquals("Ibuprofen", warnings.get(0).getDrug(),
+				"the more severe pair must lead, was: " + warnings);
+	}
+
+	@Test
+	public void aDrugTheANSWERNamesIsNotPairedWithTheQuestionsDrug() {
+		// The arm's scoping decision, and its most safety-relevant one: it covers the drugs the
+		// QUESTION resolved to, never the wider inPlay set the other arms use. Answer-named additions
+		// are the model's word choice, and two drugs it names are as often alternatives ("ibuprofen, or
+		// warfarin if …") as a proposed combination, so pairing them asserts a co-administration risk
+		// nobody proposed. It would also make the chip's own words false: ", also named in the
+		// question" would be printed about a drug the question never mentioned. Nothing pinned this —
+		// widening the arm to inPlay left the whole package green — so it is pinned here.
+		String answer = "Ibuprofen is usually avoided in this situation; warfarin is often preferred.";
+		List<DrugReference> named = DrugReferenceTestSupport.ddinterService().findByQuery(answer);
+		assertTrue(named.stream().map(DrugReference::getName).collect(Collectors.toList())
+				.containsAll(Arrays.asList("Warfarin", "Ibuprofen")),
+				"precondition: the ANSWER must name both drugs of a pair the source rates above the"
+						+ " floor (warfarin x ibuprofen is Major in the bundled sample), else this proves"
+						+ " nothing: " + named);
+
+		List<SafetyWarning> warnings = ddinterValidator().validate(answer, "Is ibuprofen safe here?",
+				patientOnNeitherDrug());
+
+		assertTrue(warnings.isEmpty(),
+				"only the QUESTION's drugs may be paired: the answer naming a second drug must not"
+						+ " produce a pair chip about a combination nobody proposed, was: " + warnings);
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -247,6 +247,78 @@ public class DrugSafetyQuestionPairInteractionTest {
 	}
 
 	@Test
+	public void aMultiWordRuleTokenDoesNotNameEveryDrugCalledAfterOneOfItsWords() throws IOException {
+		// A rule's token and an entry's alias are both canonical reference names, so "does this rule
+		// name that entry?" is a question about NAME IDENTITY. Asking it with the prose matcher — the
+		// token as haystack, the entry's aliases as needles — makes "ethinyl estradiol" name the
+		// separate Estradiol entry, because word boundaries stop a name nested inside a WORD
+		// (chlorothiazide in hydrochlorothiazide) but not one nested inside a PHRASE. The chip then
+		// states an interaction the knowledge base does not contain, against a drug whose row it read
+		// from a different drug — and preAnswerFindings injects that same string as a citable record,
+		// so the model is handed a fabricated interaction as evidence it is designed to report.
+		DrugReferenceService fixture = pairFixtureService();
+		DrugReference levofloxacin = fixture.findByQuery("levofloxacin").get(0);
+		assertEquals("ethinyl estradiol", levofloxacin.getInteractions().get(0).getToken(),
+				"precondition: the only rule must be against ethinyl estradiol, a different drug");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"The records do not address this combination.",
+				"Does levofloxacin interact with estradiol?", patientOnNeitherDrug());
+
+		assertTrue(warnings.isEmpty(),
+				"no rule joins levofloxacin and estradiol, so nothing may be raised — a chip here names"
+						+ " an interaction the knowledge base does not carry, was: " + warnings);
+	}
+
+	@Test
+	public void theRealMultiWordPairIsStillReportedWhenTheQuestionNamesIt() throws IOException {
+		// The other edge of the previous test: tightening name identity must not stop a genuine
+		// multi-word token from naming its own partner. The same fixture, the same rule, the question
+		// naming ethinyl estradiol itself — which also resolves the Estradiol entry, since "estradiol"
+		// is a whole word of the question too, so this pins that exactly one of the two is reported.
+		DrugReferenceService fixture = pairFixtureService();
+		String question = "Does levofloxacin interact with ethinyl estradiol?";
+		assertTrue(fixture.findByQuery(question).stream().map(DrugReference::getName)
+				.collect(Collectors.toList()).containsAll(Arrays.asList("Ethinyl estradiol", "Estradiol")),
+				"precondition: the question must resolve BOTH the real partner and the similarly named"
+						+ " drug, else this proves nothing");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"The records do not address this combination.", question, patientOnNeitherDrug());
+
+		assertEquals(1, interactionChips(warnings),
+				"the pair the rule really carries must still be reported, exactly once, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Levofloxacin", "Ethinyl estradiol", "Moderate"),
+				"and must name the partner the rule actually points at, was: " + warnings);
+	}
+
+	@Test
+	public void aQuestionNamingOneDrugRaisesNoPairChipForItsOwnRouteVariant() throws IOException {
+		// One drug is not a pair, however many entries it resolves to. The size(inPlay) < 2 guard
+		// counts ENTRIES, so a single question word that the KB carries route variants of clears it,
+		// and the token-keyed grouping cannot collapse the result either — a self-pair's key has the
+		// same name on both sides, which is unique. The full KB has 33 above-floor rows joining two
+		// entries that share one match token, so a question naming one of those 29 drugs gets a chip
+		// about a combination the clinician never proposed (issue #105's over-reach), and for a drug
+		// whose variants are named after DIFFERENT substances the chip names two drugs the question
+		// never mentioned at all — the #86 failure mode this arm's own wording exists to avoid.
+		DrugReferenceService fixture = pairFixtureService();
+		List<String> resolved = fixture.findByQuery("Is minoxidil safe for this patient?").stream()
+				.map(DrugReference::getName).collect(Collectors.toList());
+		assertEquals(Arrays.asList("Minoxidil", "Minoxidil (topical)"), resolved,
+				"precondition: one drug word must resolve two entries, and each must carry the row that"
+						+ " joins them — that is what clears the two-drugs guard");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"Minoxidil is used for hypertension and for androgenetic alopecia.",
+				"Is minoxidil safe for this patient?", patientOnNeitherDrug());
+
+		assertTrue(warnings.isEmpty(),
+				"a question naming ONE drug must raise no pair chip, was: " + warnings);
+	}
+
+	@Test
 	public void everyDistinctPairAmongThreeNamedDrugsIsReported() {
 		// The other edge of the one-chip-per-pair grouping: it must collapse only what IS one pair.
 		// Keying pairs on the drugs' match tokens is a de-duplication inside a safety net, so its

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -247,6 +247,27 @@ public class DrugSafetyQuestionPairInteractionTest {
 	}
 
 	@Test
+	public void everyDistinctPairAmongThreeNamedDrugsIsReported() {
+		// The other edge of the one-chip-per-pair grouping: it must collapse only what IS one pair.
+		// Keying pairs on the drugs' match tokens is a de-duplication inside a safety net, so its
+		// failure direction is the dangerous one — a key too coarse drops a real interaction silently
+		// — and this pins it against real data: three drugs named in one question, three above-floor
+		// pairs among them in the bundled sample, three chips.
+		List<SafetyWarning> warnings = ddinterValidator().validate(
+				"These are commonly co-prescribed.",
+				"Is it safe to combine lisinopril, spironolactone and ibuprofen?", patientOnNeitherDrug());
+
+		assertEquals(3, interactionChips(warnings),
+				"each of the three pairs among the named drugs must raise its own chip, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Lisinopril", "Spironolactone", "Major"), "lisinopril x spironolactone: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Lisinopril", "Ibuprofen", "Moderate"), "lisinopril x ibuprofen: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Spironolactone", "Ibuprofen", "Moderate"), "spironolactone x ibuprofen: " + warnings);
+	}
+
+	@Test
 	public void aPairAlsoJoinedByARuleNamingAnActiveOrderStaysWithTheActiveOrderArm() throws IOException {
 		// Chart precedence has to be decided over EVERY rule joining the pair, not just the one this
 		// arm would chip: addInteractions walks all of an entry's rules, so when two rules join one

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -375,6 +375,85 @@ public class DrugSafetyQuestionPairInteractionTest {
 		}
 	}
 
+	/** Every drug in the bundled DDInter sample, named in one question — the polypharmacy-review shape
+	 *  a clinician can type in one line, and the arm's worst case, since pairs grow as N²/2. */
+	private static final String POLYPHARMACY_QUESTION = "Reviewing polypharmacy: lisinopril, metformin,"
+			+ " methotrexate, omeprazole, sertraline, simvastatin, spironolactone, tramadol, warfarin,"
+			+ " aspirin, ciprofloxacin, clarithromycin, digoxin, fluconazole, amiodarone and ibuprofen"
+			+ " — any interactions?";
+
+	/** The severity word the chip's own note leads with, as a rank; -1 when the chip carries none.
+	 *  Read from the segment the pair chip appends after its provenance clause, so a severity word
+	 *  occurring later inside a mechanism paragraph cannot be mistaken for the rule's rating. */
+	private static int chipSeverityRank(SafetyWarning warning) {
+		int at = warning.getDetail().indexOf("also named in the question — ");
+		if (at < 0) {
+			return -1;
+		}
+		String tail = warning.getDetail().substring(at + "also named in the question — ".length());
+		for (String severity : Arrays.asList("Major", "Moderate", "Minor", "Unknown")) {
+			if (tail.startsWith(severity)) {
+				return DrugSafetyValidator.severityRank(severity);
+			}
+		}
+		return -1;
+	}
+
+	@Test
+	public void thePairChipsAreOrderedBySeverityAndBounded() {
+		// The arm's output is question-controlled and grows as N²/2, while every chip is also an
+		// injected pre-answer finding. Before this bound, the question below raised 72 chips carrying
+		// 42,708 characters of finding text into the prompt — for a path whose per-entry reference
+		// record is capped at 1500 characters for exactly this reason. Unbounded is one half; unordered
+		// is the other, since appending in dataset order let a Minor lead several Majors, the inverse
+		// of the severity-first rule the promoted notes follow over the very same rows.
+		List<SafetyWarning> warnings = ddinterValidator().validate("", POLYPHARMACY_QUESTION,
+				patientOnNeitherDrug());
+
+		assertTrue(interactionChips(warnings) <= 10,
+				"the pair arm must bound what one question can raise, was " + interactionChips(warnings)
+						+ " chips: " + warnings);
+		int previous = Integer.MAX_VALUE;
+		for (SafetyWarning warning : warnings) {
+			int rank = chipSeverityRank(warning);
+			if (rank < 0) {
+				continue;
+			}
+			assertTrue(rank <= previous,
+					"pair chips must be ordered most-severe first, was: " + warnings);
+			previous = rank;
+		}
+		assertEquals(3, DrugSafetyValidator.severityRank("Major"),
+				"precondition: this test's ordering check reads the shared severity ranking");
+	}
+
+	@Test
+	public void theInjectedPairFindingsAreBoundedToo() {
+		// The measured harm is on the prompt side, so it is asserted there too, through the real
+		// injector: every chip becomes its own citable record, so an unbounded chip list is an
+		// unbounded question-controlled prompt expansion.
+		DrugReferenceService service = DrugReferenceTestSupport.ddinterService();
+		DrugReferenceInjector injector = DrugReferenceTestSupport.injector(service);
+		injector.setDrugSafetyValidator(DrugReferenceTestSupport.validator(service));
+
+		PatientChart result = injector.injectRecords(DrugReferenceTestSupport.oneRecordChart(),
+				patientOnNeitherDrug(), POLYPHARMACY_QUESTION);
+
+		int findings = 0;
+		int findingChars = 0;
+		for (RecordMapping mapping : result.getMappings()) {
+			if (ChartSearchAiConstants.RESOURCE_TYPE_SAFETY_FINDING.equals(mapping.getResourceType())) {
+				findings++;
+				findingChars += mapping.getText().length();
+			}
+		}
+		assertTrue(findings <= 10,
+				"a question naming N drugs must not inject N²/2 findings, was " + findings);
+		assertTrue(findingChars <= 12000,
+				"nor an unbounded number of characters, was " + findingChars + " over " + findings
+						+ " finding record(s)");
+	}
+
 	@Test
 	public void everyDistinctPairAmongThreeNamedDrugsIsReported() {
 		// The other edge of the one-chip-per-pair grouping: it must collapse only what IS one pair.

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -1,0 +1,206 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * The question-named PAIR arm (issue #114). Measured on the 3.7.1 standalone at HEAD
+ * {@code 13690b1}: Mary Smith, active order Simvastatin 20mg, asked "Does warfarin interact with
+ * aspirin?" got the answer "The records do not address the interaction between warfarin and
+ * aspirin.", {@code references: []}, and exactly one chip — "Warfarin interacts with active order
+ * simvastatin — <b>Minor</b>" — about a pair nobody asked about, while the pair she DID ask about
+ * is rated Major in the loaded KB ({@code ["DDInter1951","DDInter20","Major","749"]}). The same
+ * question fires correctly for Agnes Adams, whose chart carries Aspirin 81mg.
+ *
+ * <p>Cause: both drugs resolve from the question and both are validated, but each was only ever
+ * checked against the CHART ({@code hasActiveDrug}), never against the other drug the question
+ * named — so a two-drug question was silently reduced to two independent one-drug questions.
+ *
+ * <p>All scenarios run the real pipeline: real bundled datasets parsed by the real sources, real
+ * {@code validate}/{@code injectRecords} overloads, GP reads on their no-context defaults.
+ */
+public class DrugSafetyQuestionPairInteractionTest {
+
+	private static final String PAIR_QUESTION = "Does warfarin interact with aspirin?";
+
+	/** The abstention the standalone actually produced for {@link #PAIR_QUESTION} — the chip must
+	 *  not depend on the answer naming anything, so the defect's own answer text is used. */
+	private static final String ABSTAINING_ANSWER = "The records do not address the interaction between warfarin and aspirin.";
+
+	private static DrugSafetyValidator ddinterValidator() {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.ddinterService());
+	}
+
+	/** A patient on nothing at all: no active order can contribute, so only the pair arm can. */
+	private static PatientClinicalContext patientOnNeitherDrug() {
+		return DrugReferenceTestSupport.ctx(60, null, null, null, null, null);
+	}
+
+	/** The real parsed entry for {@code name} (real bundled DDInter sample, real parser). */
+	private static DrugReference ddinterEntry(String name) {
+		return new DdiDrugReferenceSource().load().stream()
+				.filter(r -> name.equalsIgnoreCase(r.getName())).findFirst().orElseThrow();
+	}
+
+	private static long interactionChips(List<SafetyWarning> warnings) {
+		return warnings.stream().filter(w -> SafetyWarning.TYPE_INTERACTION.equals(w.getType())).count();
+	}
+
+	@Test
+	public void questionNamedPairInteractionIsReportedForAPatientOnNeitherDrug() {
+		List<SafetyWarning> warnings = ddinterValidator().validate(ABSTAINING_ANSWER, PAIR_QUESTION,
+				patientOnNeitherDrug());
+
+		assertEquals(1, warnings.size(),
+				"the pair the question named must raise exactly one chip even though the patient takes"
+						+ " neither drug, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Warfarin", "Acetylsalicylic acid (aspirin)", "Major"),
+				"the chip must name the pair asked about and carry the source's severity, was: " + warnings);
+	}
+
+	@Test
+	public void theQuestionPairChipNeverClaimsAnActiveOrder() {
+		// The provenance distinction is the whole safety of this arm: an active-order interaction is
+		// a fact about THIS patient, a question-pair interaction is a reference lookup that may
+		// involve no drug they take. Wording the second like the first asserts a medication the
+		// patient is not on — the defect in #86, and worse than the bug being fixed here.
+		List<SafetyWarning> warnings = ddinterValidator().validate(ABSTAINING_ANSWER, PAIR_QUESTION,
+				patientOnNeitherDrug());
+
+		assertEquals(1, interactionChips(warnings), "precondition: the pair chip must have been raised");
+		for (SafetyWarning warning : warnings) {
+			assertFalse(warning.getDetail().toLowerCase().contains("active order"),
+					"this patient has no active orders at all, so no chip may claim one: " + warning);
+		}
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Warfarin", "named in the question"),
+				"the chip must attribute the pair to the question, not to the chart, was: " + warnings);
+	}
+
+	@Test
+	public void aSymmetricPairIsReportedOnlyOnce() {
+		// DDInter rows are symmetric and the parser writes each pair into BOTH drugs' entries
+		// (DdiDrugReferenceSource: "each pair contributes to both drugs' entries"), so an arm that
+		// walks ordered pairs reports one interaction twice — once from each side.
+		DrugReference warfarin = ddinterEntry("Warfarin");
+		DrugReference aspirin = ddinterEntry("Acetylsalicylic acid");
+		assertTrue(warfarin.getInteractions().stream().anyMatch(i -> "aspirin".equals(i.getToken())),
+				"precondition: warfarin's entry carries the pair");
+		assertTrue(aspirin.getInteractions().stream().anyMatch(i -> "warfarin".equals(i.getToken())),
+				"precondition: aspirin's entry carries the same pair from the other side");
+
+		List<SafetyWarning> warnings = ddinterValidator().validate(ABSTAINING_ANSWER, PAIR_QUESTION,
+				patientOnNeitherDrug());
+
+		assertEquals(1, interactionChips(warnings),
+				"a pair present on both entries must be reported once, not once per side, was: " + warnings);
+	}
+
+	@Test
+	public void aSubFloorQuestionNamedPairRaisesNothing() {
+		// The pair arm must not become a route around the decision the chip path enforces: DDInter's
+		// Unknown-severity rows carry no mechanism text and are suppressed by
+		// chartsearchai.drugSafety.minInteractionSeverity (issue #84). Simvastatin x aspirin is
+		// exactly that shape.
+		DrugReference simvastatin = ddinterEntry("Simvastatin");
+		assertTrue(simvastatin.getInteractions().stream()
+				.anyMatch(i -> "aspirin".equals(i.getToken()) && "Unknown".equals(i.getSeverity())),
+				"precondition: the sample rates simvastatin x aspirin Unknown, i.e. below the default floor");
+
+		List<SafetyWarning> warnings = ddinterValidator().validate(
+				"The records do not address the interaction between simvastatin and aspirin.",
+				"Does simvastatin interact with aspirin?", patientOnNeitherDrug());
+
+		assertTrue(warnings.isEmpty(),
+				"a question-named pair the source rates below the floor must raise nothing, was: " + warnings);
+	}
+
+	@Test
+	public void aQuestionNamedPairWithNoInteractionRowRaisesNothing() {
+		// The no-false-positive case, on the curated seed (source-independent arm): its Ibuprofen
+		// entry's rules name warfarin and aspirin, and its Paracetamol entry's rule names warfarin —
+		// neither names the other, so naming both in one question must produce nothing.
+		DrugReferenceService curated = DrugReferenceTestSupport.bundledService();
+		String question = "Can we give ibuprofen together with paracetamol?";
+		List<DrugReference> resolved = curated.findByQuery(question);
+		assertTrue(resolved.stream().anyMatch(r -> "Ibuprofen".equals(r.getName()))
+				&& resolved.stream().anyMatch(r -> "Paracetamol".equals(r.getName())),
+				"precondition: the question must resolve BOTH drugs, else the pair arm is never reached: "
+						+ resolved);
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(curated).validate(
+				"Both are commonly used for pain and fever.", question, patientOnNeitherDrug());
+
+		assertTrue(warnings.isEmpty(),
+				"two question-named drugs with no interaction row between them must raise nothing —"
+						+ " the pair arm must not become a chip generator, was: " + warnings);
+	}
+
+	@Test
+	public void theActiveOrderChipWinsWhenThePatientIsOnOneOfTheNamedDrugs() {
+		// Agnes Adams' shape on the standalone (active order Aspirin 81mg), asked about the same
+		// pair. The interaction is then a fact about THIS patient — the stronger statement — so the
+		// active-order arm owns it, and the pair must not also be reported as a reference lookup:
+		// one finding said in two voices reads as two findings.
+		List<SafetyWarning> warnings = ddinterValidator().validate(
+				"Warfarin and aspirin together increase bleeding risk.", PAIR_QUESTION,
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Aspirin 81mg"),
+						DrugReferenceTestSupport.set("N02BA01"), null, null));
+
+		assertEquals(1, warnings.size(), "the pair must be reported exactly once, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Warfarin", "active order", "Major"),
+				"the surviving chip must be the patient-specific active-order one, was: " + warnings);
+		for (SafetyWarning warning : warnings) {
+			assertFalse(warning.getDetail().contains("named in the question"),
+					"a pair covered by the chart must not also be reported as a reference lookup: " + warning);
+		}
+	}
+
+	@Test
+	public void theQuestionPairFindingIsInjectedAsACitableRecord() {
+		// How the prose gets grounding for the pair without touching the capped Interactions:
+		// rendering (#110's mechanism): preAnswerFindings runs the same validate() with an empty
+		// answer, so the pair finding becomes its own numbered, citable record. That keeps
+		// orderedInteractionNotes' invariant intact — its promotion predicate still mirrors the
+		// active-order chip decision exactly — while the model gets a line it can report.
+		DrugReferenceService service = DrugReferenceTestSupport.ddinterService();
+		DrugReferenceInjector injector = DrugReferenceTestSupport.injector(service);
+		injector.setDrugSafetyValidator(DrugReferenceTestSupport.validator(service));
+
+		PatientChart result = injector.injectRecords(DrugReferenceTestSupport.oneRecordChart(),
+				patientOnNeitherDrug(), PAIR_QUESTION);
+
+		RecordMapping finding = null;
+		for (RecordMapping mapping : result.getMappings()) {
+			if (ChartSearchAiConstants.RESOURCE_TYPE_SAFETY_FINDING.equals(mapping.getResourceType())) {
+				finding = mapping;
+			}
+		}
+		assertNotNull(finding, "the pair finding must be injected as its own record: " + result.getText());
+		assertTrue(finding.getText().contains("Acetylsalicylic acid (aspirin)")
+				&& finding.getText().contains("Major"),
+				"the finding must name the pair and its severity: " + finding.getText());
+		assertTrue(result.getText().contains("[" + finding.getIndex() + "] "),
+				"it must be a numbered, citable chart line so the answer can cite it: " + result.getText());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -12,9 +12,13 @@ package org.openmrs.module.chartsearchai.reference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
@@ -34,12 +38,18 @@ import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.Record
  * checked against the CHART ({@code hasActiveDrug}), never against the other drug the question
  * named — so a two-drug question was silently reduced to two independent one-drug questions.
  *
- * <p>All scenarios run the real pipeline: real bundled datasets parsed by the real sources, real
+ * <p>All scenarios run the real pipeline: real datasets — the bundled DDInter sample and the curated
+ * seed, plus {@link #PAIR_FIXTURE} for shapes neither carries — parsed by the real sources, real
  * {@code validate}/{@code injectRecords} overloads, GP reads on their no-context defaults.
  */
 public class DrugSafetyQuestionPairInteractionTest {
 
 	private static final String PAIR_QUESTION = "Does warfarin interact with aspirin?";
+
+	/** Shapes the bundled DDInter sample cannot express — route variants sharing a match token, a
+	 *  pair joined by two differently-tokened rules, an ATC-only rule — each a miniature of a shape
+	 *  the full KB carries; see the fixture's own description. */
+	private static final String PAIR_FIXTURE = "chartsearchai-test/drug-reference-question-pairs.json";
 
 	/** The abstention the standalone actually produced for {@link #PAIR_QUESTION} — the chip must
 	 *  not depend on the answer naming anything, so the defect's own answer text is used. */
@@ -58,6 +68,11 @@ public class DrugSafetyQuestionPairInteractionTest {
 	private static DrugReference ddinterEntry(String name) {
 		return new DdiDrugReferenceSource().load().stream()
 				.filter(r -> name.equalsIgnoreCase(r.getName())).findFirst().orElseThrow();
+	}
+
+	/** A service over {@link #PAIR_FIXTURE}, parsed by the real {@link JsonDrugReferenceSource}. */
+	private static DrugReferenceService pairFixtureService() throws IOException {
+		return DrugReferenceTestSupport.serviceWith(DrugReferenceTestSupport.fixtureEntries(PAIR_FIXTURE));
 	}
 
 	private static long interactionChips(List<SafetyWarning> warnings) {
@@ -202,5 +217,104 @@ public class DrugSafetyQuestionPairInteractionTest {
 				"the finding must name the pair and its severity: " + finding.getText());
 		assertTrue(result.getText().contains("[" + finding.getIndex() + "] "),
 				"it must be a numbered, citable chart line so the answer can cite it: " + result.getText());
+	}
+
+	@Test
+	public void routeVariantEntriesSharingAMatchTokenAreReportedAsOnePair() throws IOException {
+		// One chip per clinical PAIR, not per pair of ENTRIES. DDInter carries a separate entry per
+		// route variant and every variant publishes the same rxnorm_name — which is the token its
+		// rules match on — so ONE question word resolves several entries that all pair off the same
+		// rule. Ungrouped that is N near-identical chips, and N near-identical injected findings, for
+		// a single clinical fact: issue #115's shape arriving on the question side.
+		DrugReferenceService fixture = pairFixtureService();
+		String question = "Does voxelotor interact with dexamethasone?";
+		List<String> resolved = fixture.findByQuery(question).stream().map(DrugReference::getName)
+				.collect(Collectors.toList());
+		assertEquals(Arrays.asList("Dexamethasone", "Dexamethasone (nasal)", "Voxelotor"), resolved,
+				"precondition: the one word 'dexamethasone' must resolve BOTH variant entries alongside"
+						+ " voxelotor — that is what multiplies the pairs");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"The records do not address this combination.", question, patientOnNeitherDrug());
+
+		assertEquals(1, interactionChips(warnings),
+				"route variants of one drug are one drug for this arm, so the pair must be reported"
+						+ " once, not once per variant entry, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Dexamethasone", "Voxelotor", "named in the question"),
+				"the surviving chip is the dataset's first variant, naming the pair asked about, was: "
+						+ warnings);
+	}
+
+	@Test
+	public void aPairAlsoJoinedByARuleNamingAnActiveOrderStaysWithTheActiveOrderArm() throws IOException {
+		// Chart precedence has to be decided over EVERY rule joining the pair, not just the one this
+		// arm would chip: addInteractions walks all of an entry's rules, so when two rules join one
+		// pair under different tokens — a brand-name row and an INN row — and only the second names
+		// the patient's order, consulting the first alone concludes "the chart does not own this" and
+		// the pair is reported twice, once as a fact about the patient and once as a reference lookup.
+		DrugReferenceService fixture = pairFixtureService();
+		DrugReference ibuprofen = fixture.findByQuery("ibuprofen").get(0);
+		assertEquals(Arrays.asList("coumadin", "warfarin"), ibuprofen.getInteractions().stream()
+				.map(DrugReference.Interaction::getToken).collect(Collectors.toList()),
+				"precondition: two rules must join this pair, and the FIRST must name the partner by a"
+						+ " token the active order's name does NOT carry");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"Both are commonly prescribed.", "Can we give ibuprofen with warfarin?",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Warfarin 5mg"),
+						null, null, null));
+
+		assertEquals(1, interactionChips(warnings),
+				"the pair must be reported exactly once however many rules join it, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Ibuprofen", "active order warfarin"),
+				"the surviving chip must be the patient-specific active-order one, was: " + warnings);
+		for (SafetyWarning warning : warnings) {
+			assertFalse(warning.getDetail().contains("named in the question"),
+					"a pair the chart arm already owns must not also be a reference lookup: " + warning);
+		}
+	}
+
+	@Test
+	public void aQuestionNamedPairIdentifiedOnlyByAtcCodeIsReported() throws IOException {
+		// The ATC arm of the rule-names-that-entry check, which the ddinter source never exercises
+		// because it always writes a name token: a curated rule may carry only the partner's ATC
+		// code, and the pair must still be found — otherwise the arm silently covers one of the two
+		// ways the reference data names a partner.
+		DrugReferenceService fixture = pairFixtureService();
+		DrugReference miconazole = fixture.findByQuery("miconazole").get(0);
+		assertNotNull(miconazole.getInteractions().get(0).getAtc(),
+				"precondition: the rule must identify its partner by ATC code");
+		assertNull(miconazole.getInteractions().get(0).getToken(),
+				"precondition: and carry no name token, so only the ATC arm can match");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"The records do not address this combination.",
+				"Is miconazole safe with phenprocoumon?", patientOnNeitherDrug());
+
+		assertEquals(1, interactionChips(warnings),
+				"a pair joined only by an ATC code must raise its chip, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Miconazole", "Phenprocoumon", "named in the question", "Major"),
+				"and must name the partner ENTRY, not the bare code, was: " + warnings);
+	}
+
+	@Test
+	public void patientSpecificChipsLeadThePairChip() {
+		// Mary Smith's measured shape (active order Simvastatin 20mg, asked about warfarin x aspirin):
+		// the chip list must open with the fact about HER — the arm runs last precisely so a reference
+		// lookup about a pair she may be on neither of never outranks her own chart.
+		List<SafetyWarning> warnings = ddinterValidator().validate(ABSTAINING_ANSWER, PAIR_QUESTION,
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Simvastatin 20mg"), null, null, null));
+
+		assertEquals(2, warnings.size(),
+				"precondition: her active order and the question's pair must both be raised, was: "
+						+ warnings);
+		assertTrue(warnings.get(0).getDetail().contains("active order simvastatin"),
+				"the patient-specific chip must lead, was: " + warnings);
+		assertTrue(warnings.get(1).getDetail().contains("named in the question"),
+				"and the question-pair lookup must follow it, was: " + warnings);
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -318,6 +318,63 @@ public class DrugSafetyQuestionPairInteractionTest {
 				"a question naming ONE drug must raise no pair chip, was: " + warnings);
 	}
 
+	/** The variant family whose sibling row is sub-floor, so the two entry pairs of ONE clinical pair
+	 *  reach the arm carrying different rule sets — the shape both findings below turn on. */
+	private static final String VARIANT_PAIR_QUESTION = "Does diclofenac interact with aspirin?";
+
+	@Test
+	public void aPairIsKeyedInTheReferenceDataVocabularyOnBothSides() throws IOException {
+		// A drug must key the same way in every pair it appears in, or one clinical pair gets two keys
+		// and escapes the grouping. It did: the key name came from the OTHER side's rule token when
+		// there was one and from displayLabel() when there was not — two vocabularies, so the same
+		// entry keyed as "aspirin" against Diclofenac (whose row names it) and as "Acetylsalicylic acid
+		// (aspirin)" against Diclofenac (topical) (whose row is sub-floor, leaving nothing to name it
+		// with). Two chips, no patient data needed. And an extra chip is an extra injected pre-answer
+		// finding, which is the outcome the keying exists to prevent.
+		DrugReferenceService fixture = pairFixtureService();
+		DrugReference asa = fixture.findByQuery("acetylsalicylic acid").get(0);
+		assertEquals("Acetylsalicylic acid (aspirin)", asa.displayLabel(),
+				"precondition: this entry's display label must diverge from the token the rules use for"
+						+ " it, else the two vocabularies cannot be told apart");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(fixture).validate(
+				"The records do not address this combination.", VARIANT_PAIR_QUESTION,
+				patientOnNeitherDrug());
+
+		assertEquals(1, interactionChips(warnings),
+				"one clinical pair, one chip, however the reference data names each side, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Acetylsalicylic acid (aspirin)", "Diclofenac", "named in the question"),
+				"and it must still name the pair asked about, was: " + warnings);
+	}
+
+	@Test
+	public void aChartOwnedPairSuppressesItsRouteSiblingToo() throws IOException {
+		// Chart precedence is a verdict about the PAIR, so it has to be reached over every entry pair
+		// that is that pair. It was reached per entry pair and taken as an early return, so the
+		// chart-owned pair (Acetylsalicylic acid, Diclofenac) left no trace and its sibling
+		// (Acetylsalicylic acid, Diclofenac (topical)) — whose own row is sub-floor, so nothing on that
+		// side matched the active order — concluded the chart did not own it and chipped. One clinical
+		// pair in two voices, which #435 forbids: the patient's own medication became the subject of a
+		// sentence that reads as a reference lookup, carrying the systemic row's Major mechanism
+		// attributed to the topical variant whose own row is Unknown.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(pairFixtureService()).validate(
+				"Aspirin and diclofenac together raise bleeding risk.", VARIANT_PAIR_QUESTION,
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Aspirin 81mg"),
+						null, null, null));
+
+		assertEquals(1, interactionChips(warnings),
+				"the pair the chart already owns must be reported exactly once, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Diclofenac", "active order aspirin"),
+				"and the surviving chip must be the patient-specific one, was: " + warnings);
+		for (SafetyWarning warning : warnings) {
+			assertFalse(warning.getDetail().contains("named in the question"),
+					"no route sibling of a chart-owned pair may be reported as a reference lookup: "
+							+ warning);
+		}
+	}
+
 	@Test
 	public void everyDistinctPairAmongThreeNamedDrugsIsReported() {
 		// The other edge of the one-chip-per-pair grouping: it must collapse only what IS one pair.

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyQuestionPairInteractionTest.java
@@ -398,7 +398,7 @@ public class DrugSafetyQuestionPairInteractionTest {
 		String tail = warning.getDetail().substring(at + "also named in the question — ".length());
 		for (String severity : Arrays.asList("Major", "Moderate", "Minor", "Unknown")) {
 			if (tail.startsWith(severity)) {
-				return DrugSafetyValidator.severityRank(severity);
+				return DrugSafetyValidator.severityPriority(severity);
 			}
 		}
 		return -1;
@@ -485,8 +485,9 @@ public class DrugSafetyQuestionPairInteractionTest {
 					"pair chips must be ordered most-severe first, was: " + warnings);
 			previous = rank;
 		}
-		assertEquals(3, DrugSafetyValidator.severityRank("Major"),
-				"precondition: this test's ordering check reads the shared severity ranking");
+		assertEquals(3, DrugSafetyValidator.severityPriority("Major"),
+				"precondition: this test's ordering check reads the very ranking the arm sorts on —"
+						+ " severityPriority, which #121 made the one definition of it");
 	}
 
 	@Test

--- a/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
@@ -1,0 +1,94 @@
+{
+  "version": "1.0",
+  "description": "Test fixture for the question-named PAIR arm (issue #114), parsed by the real JsonDrugReferenceSource. Three shapes the bundled DDInter sample cannot express, each a miniature of a shape the FULL KB carries: (1) route variants of one drug sharing a match token — DDInter publishes the same rxnorm_name for every variant, so one question word resolves several entries that all pair off the same rule (142 rxnorm_name values are shared by more than one entry across 332 entries of the full KB; see issue #115); (2) one pair joined by TWO rules whose tokens differ, only the second of which names the patient's active order, so 'is this pair already the chart arm's?' cannot be answered from the first rule alone; (3) a rule that identifies its partner only by ATC code, carrying no name token — the arm the ddinter source never exercises because it always writes a token.",
+  "entries": [
+    {
+      "id": "dexamethasone",
+      "name": "Dexamethasone",
+      "aliases": ["dexamethasone"],
+      "interactions": [
+        {
+          "token": "voxelotor",
+          "severity": "Major",
+          "note": "Major. Coadministration with potent or moderate inducers of CYP450 3A4 may significantly decrease the plasma concentrations and pharmacologic effects of voxelotor."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "dexamethasone-nasal",
+      "name": "Dexamethasone (nasal)",
+      "aliases": ["dexamethasone (nasal)", "dexamethasone"],
+      "interactions": [
+        {
+          "token": "voxelotor",
+          "severity": "Moderate",
+          "note": "Moderate. Coadministration with inhibitors of CYP450 3A4 may increase the plasma concentrations and pharmacologic effects of corticosteroids."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "voxelotor",
+      "name": "Voxelotor",
+      "aliases": ["voxelotor"],
+      "interactions": [
+        {
+          "token": "dexamethasone",
+          "severity": "Major",
+          "note": "Major. Coadministration with potent or moderate inducers of CYP450 3A4 may significantly decrease the plasma concentrations and pharmacologic effects of voxelotor."
+        },
+        {
+          "token": "dexamethasone",
+          "severity": "Moderate",
+          "note": "Moderate. Coadministration with inhibitors of CYP450 3A4 may increase the plasma concentrations and pharmacologic effects of corticosteroids."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "warfarin",
+      "name": "Warfarin",
+      "aliases": ["warfarin", "coumadin"],
+      "source": "Test fixture"
+    },
+    {
+      "id": "ibuprofen",
+      "name": "Ibuprofen",
+      "aliases": ["ibuprofen"],
+      "interactions": [
+        {
+          "token": "coumadin",
+          "severity": "Major",
+          "note": "Major. NSAIDs may increase the anticoagulant effect of coumarin derivatives."
+        },
+        {
+          "token": "warfarin",
+          "severity": "Major",
+          "note": "Major. NSAIDs may increase the risk of bleeding in patients treated with warfarin."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "miconazole",
+      "name": "Miconazole",
+      "aliases": ["miconazole"],
+      "interactions": [
+        {
+          "atc": "B01AA04",
+          "severity": "Major",
+          "note": "Major. Miconazole may potentiate the anticoagulant effect of coumarin derivatives."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "phenprocoumon",
+      "name": "Phenprocoumon",
+      "aliases": ["phenprocoumon"],
+      "atcCodes": ["B01AA04"],
+      "source": "Test fixture"
+    }
+  ]
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "description": "Test fixture for the question-named PAIR arm (issue #114), parsed by the real JsonDrugReferenceSource. Three shapes the bundled DDInter sample cannot express, each a miniature of a shape the FULL KB carries: (1) route variants of one drug sharing a match token — DDInter publishes the same rxnorm_name for every variant, so one question word resolves several entries that all pair off the same rule (142 rxnorm_name values are shared by more than one entry across 332 entries of the full KB; see issue #115); (2) one pair joined by TWO rules whose tokens differ, only the second of which names the patient's active order, so 'is this pair already the chart arm's?' cannot be answered from the first rule alone; (3) a rule that identifies its partner only by ATC code, carrying no name token — the arm the ddinter source never exercises because it always writes a token.",
+  "description": "Test fixture for the question-named PAIR arm (issue #114), parsed by the real JsonDrugReferenceSource. Five shapes the bundled DDInter sample cannot express, each a miniature of a shape the FULL KB carries: (1) route variants of one drug sharing a match token — DDInter publishes the same rxnorm_name for every variant, so one question word resolves several entries that all pair off the same rule (142 rxnorm_name values are shared by more than one entry across 332 entries of the full KB; see issue #115); (2) one pair joined by TWO rules whose tokens differ, only the second of which names the patient's active order, so 'is this pair already the chart arm's?' cannot be answered from the first rule alone; (3) a rule that identifies its partner only by ATC code, carrying no name token — the arm the ddinter source never exercises because it always writes a token; (4) a MULTI-WORD rule token one of whose words is another drug's whole name ('ethinyl estradiol' vs the separate Estradiol entry) — 408 of the full KB's 2093 distinct tokens are multi-word and 53 of those name a word that is some other entry's whole name, 'ethinyl estradiol' appearing in 449 entries' rule lists; (5) two route variants joined by a KB row of their own, which is one drug and not a pair — 33 such rows exist in the full KB, all above the default floor, spanning 29 drug words (minoxidil, timolol, lidocaine, atropine, neomycin, paclitaxel ...).",
   "entries": [
     {
       "id": "dexamethasone",
@@ -66,6 +66,57 @@
           "token": "warfarin",
           "severity": "Major",
           "note": "Major. NSAIDs may increase the risk of bleeding in patients treated with warfarin."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "levofloxacin",
+      "name": "Levofloxacin",
+      "aliases": ["levofloxacin"],
+      "interactions": [
+        {
+          "token": "ethinyl estradiol",
+          "severity": "Moderate",
+          "note": "Moderate. RECOMMENDED: The effectiveness of estrogen-containing oral contraceptives may be impaired during coadministration with antibiotics."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "ethinyl-estradiol",
+      "name": "Ethinyl estradiol",
+      "aliases": ["ethinyl estradiol"],
+      "source": "Test fixture"
+    },
+    {
+      "id": "estradiol",
+      "name": "Estradiol",
+      "aliases": ["estradiol"],
+      "source": "Test fixture"
+    },
+    {
+      "id": "minoxidil",
+      "name": "Minoxidil",
+      "aliases": ["minoxidil"],
+      "interactions": [
+        {
+          "token": "minoxidil",
+          "severity": "Moderate",
+          "note": "Moderate. Coadministration of two minoxidil formulations may produce additive hypotensive effects."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "minoxidil-topical",
+      "name": "Minoxidil (topical)",
+      "aliases": ["minoxidil (topical)", "minoxidil"],
+      "interactions": [
+        {
+          "token": "minoxidil",
+          "severity": "Moderate",
+          "note": "Moderate. Coadministration of two minoxidil formulations may produce additive hypotensive effects."
         }
       ],
       "source": "Test fixture"

--- a/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
@@ -122,6 +122,46 @@
       "source": "Test fixture"
     },
     {
+      "id": "acetylsalicylic-acid",
+      "name": "Acetylsalicylic acid",
+      "genericName": "aspirin",
+      "aliases": ["acetylsalicylic acid", "aspirin"],
+      "interactions": [
+        {
+          "token": "diclofenac",
+          "severity": "Major",
+          "note": "Major. Concomitant use of two nonsteroidal anti-inflammatory drugs increases the risk of gastrointestinal bleeding and ulceration."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "diclofenac",
+      "name": "Diclofenac",
+      "aliases": ["diclofenac"],
+      "interactions": [
+        {
+          "token": "aspirin",
+          "severity": "Major",
+          "note": "Major. Concomitant use of two nonsteroidal anti-inflammatory drugs increases the risk of gastrointestinal bleeding and ulceration."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "diclofenac-topical",
+      "name": "Diclofenac (topical)",
+      "aliases": ["diclofenac (topical)", "diclofenac"],
+      "interactions": [
+        {
+          "token": "aspirin",
+          "severity": "Unknown",
+          "note": "Unknown severity interaction (DDInter 2.0; no mechanism description on file)."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
       "id": "miconazole",
       "name": "Miconazole",
       "aliases": ["miconazole"],

--- a/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-question-pairs.json
@@ -122,6 +122,19 @@
       "source": "Test fixture"
     },
     {
+      "id": "paracetamol",
+      "name": "Paracetamol",
+      "aliases": ["paracetamol"],
+      "interactions": [
+        {
+          "token": "warfarin",
+          "severity": "Moderate",
+          "note": "Moderate. Regular or prolonged use of paracetamol may potentiate the anticoagulant effect of warfarin."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
       "id": "acetylsalicylic-acid",
       "name": "Acetylsalicylic acid",
       "genericName": "aspirin",


### PR DESCRIPTION
## The defect

Asked directly about a drug pair the knowledge base rates **Major**, the module said it had no
information — and raised an unrequested **Minor** chip about a different pair instead.

Mary Smith, active order Simvastatin 20mg, 3.7.1 standalone at `13690b1`:

> **Q:** Does warfarin interact with aspirin?
> **A:** "The records do not address the interaction between warfarin and aspirin."
> **chips:** 1 — "Warfarin interacts with active order simvastatin — **Minor**. …"
> **references:** `[]`

The pair asked about is in the loaded KB (`["DDInter1951","DDInter20","Major","749"]`) and fires
correctly for Agnes Adams, who is actually on aspirin. The only difference was whether the second
drug happened to be on the chart.

## Root cause

`DrugSafetyValidator.addInteractions` raises an interaction chip only when the rule's partner is one
of the patient's **active orders**:

```java
if (context.hasActiveDrug(i.getToken(), i.getAtc())) {
```

Both warfarin and aspirin resolve from the question and both land in `inPlay`, but every interaction
arm joins one drug to the patient's own data — the drugs in `inPlay` were each checked against the
chart and never against **each other**. There was no pairwise arm, so a two-drug question was
silently reduced to two independent one-drug questions.

The prompt path did not rescue it either: warfarin's rendered record is capped at
`MAX_INTERACTION_RENDER_CHARS` and ordered patient-relevance-first, so with aspirin not on the chart
it had no promotion claim among ~934 partners. `references: []` is the model citing nothing.

## What changed

One production file, `DrugSafetyValidator`: a pairwise arm over the drugs the question resolved to
(`addQuestionPairInteractions`) plus three small helpers.

- **Each pair once.** Unordered pairs only. DDInter rows are symmetric and the parser writes every
  pair into both drugs' entries, so walking ordered pairs would report one interaction twice, once
  from each side. Either side's rule can raise it (`aboveFloorRuleAgainst` is asked in both
  directions), so asymmetric curated data still works.
- **Same floor, one definition.** The arm is handed the same `severityFloor` the chart arm gets from
  `configuredSeverityFloor()` and decides with `clearsSeverityFloor` — no second definition of the
  floor or of severity. A sub-floor pair raises nothing, so this is not a route around the decision
  the chip path enforces.
- **The active-order arm keeps precedence, and the wording distinguishes provenance.** A pair either
  of whose drugs is an active order is left to `addInteractions`, whose chip states a fact about
  *this* patient — the stronger statement, and raising both would say one finding in two voices. What
  the new arm raises therefore never says "active order"; it reads
  `"<Drug> interacts with <Partner>, also named in the question — <severity>. <mechanism>"`. That
  claim is about the **question**, so it stays true whatever the chart holds. Wording it as "neither
  drug is on the chart" would have been false for the one-sided-data case that can reach this arm
  (the patient is on one of the pair, but only that drug's entry carries the rule, so no
  active-order chip fires from either side) — and misstating a patient's medications is #86.
- **Scoped to the question's drugs, not all of `inPlay`.** The issue proposed "evaluate `inPlay`
  pairwise"; the arm deliberately covers only the *question-resolved* subset. Two drugs an **answer**
  names are as often alternatives ("ibuprofen, or paracetamol if …") as a proposed combination, so
  pairing them would assert a co-administration risk nobody proposed — the over-reach echo scoping
  exists to prevent (#105). It also keeps chips aligned with the injected findings:
  `DrugReferenceInjector.preAnswerFindings` runs this same `validate` with an *empty* answer, so an
  answer-side pair could produce a chip with no record behind it.
- **Patient-specific findings still lead.** The new arm runs after the per-drug arms, so an allergy
  or active-order chip — a fact about this patient — is never pushed below a reference lookup.
- **No change to `render` / `orderedInteractionNotes`.** The issue asks whether the partner should
  also be promoted into the rendered record so the prose has grounding. It does not need to be: since
  #110 the deterministic finding is itself injected as a numbered, citable record, and
  `preAnswerFindings` calls the very `validate` this arm lives in — so the pair finding becomes a
  record the model can report, carrying the chip's string verbatim. `orderedInteractionNotes`'
  documented invariant is therefore untouched: its promotion predicate still mirrors the
  active-order chip decision exactly. The live evidence below shows this working — P1's `references`
  went from `[]` to a cited `safety_finding` record.

## Live standalone evidence

3.7.1 standalone, full 19MB DDInter KB, `sourceFormat=ddinter`, `minInteractionSeverity=minor`,
`chartMode=fullChart`, local LLM. Full-JVM restart on this build; querystore retrieval proven alive
(`hits=75`) and the known-positive control fired before any capture was taken. Chips are
deterministic Java; answer prose on this box is not reproducible (`cache_prompt` KV reuse), so the
assertions below are on chips and their wording.

**Before** (HEAD `13690b1`) — Mary Smith + "Does warfarin interact with aspirin?":

```
--- ANSWER ---
The records do not address the interaction between warfarin and aspirin.
--- safetyWarnings (1) ---
  [interaction] drug='Warfarin'
      Warfarin interacts with active order simvastatin — Minor. Simvastatin may slightly increase the
      anticoagulant response to warfarin. …
--- references (0) ---
```

**After** — same patient, same question:

```
--- ANSWER ---
Warfarin interacts with Acetylsalicylic acid (aspirin) — Major. Aspirin, even in small doses, may
increase the risks of bleeding in patients on oral anticoagulants by inhibiting platelet aggregation,
prolonged bleeding time, and inducing gastrointestinal lesions [79].
--- safetyWarnings (2) ---
  [interaction] drug='Warfarin'
      Warfarin interacts with active order simvastatin — Minor. Simvastatin may slightly increase the
      anticoagulant response to warfarin. …
  [interaction] drug='Warfarin'
      Warfarin interacts with Acetylsalicylic acid (aspirin), also named in the question — Major.
      Aspirin, even in small doses, may increase the risk of bleeding in patients on oral
      anticoagulants by inhibiting platelet aggregation, prolonging bleeding time, and inducing
      gastrointestinal lesions. …
--- references (2) ---
  #79 type=safety_finding group=reference grounded=True
```

The pre-existing Minor active-order chip is untouched — it is a true fact about Mary and suppressing
it is a relevance question, not this one.

**Independent of the chart** — Susan Young (active order Tiotropium 18mg only, on *neither* named
drug), same question:

```
--- safetyWarnings (1) ---
  [interaction] drug='Warfarin'
      Warfarin interacts with Acetylsalicylic acid (aspirin), also named in the question — Major. …
```

**Precedence** — Agnes Adams (active order Aspirin 81mg), same question. The patient-specific chip
wins and the pair is *not* also reported as a reference lookup:

```
--- safetyWarnings (1) ---
  [interaction] drug='Warfarin'
      Warfarin interacts with active order aspirin — Major. …
```

**No false pair chips** — Mary Smith + "Does ascorbic acid interact with aspirin?" (both drugs
resolve; the KB carries no row for the pair):

```
--- ANSWER ---
The records do not address the interaction between ascorbic acid and aspirin.
--- safetyWarnings (0) ---
--- references (0) ---
```

**Regression controls, all unchanged:**

| control | result |
|---|---|
| Mary + "Is it safe to give her clarithromycin?" | 1 chip — `Clarithromycin interacts with active order simvastatin — Major.` |
| Agnes + "Is it safe to start warfarin?" | 1 chip — `Warfarin interacts with active order aspirin — Major.` (active-order wording, **not** the new pair wording) |
| Joshua + "Can I give ibuprofen?" | 2 chips — NSAID cross-reactivity contraindication + `Ibuprofen interacts with active order lisinopril — Moderate.` |
| Mary + "Is it safe to give her paracetamol?" | 0 chips |

No test data was created or modified on the standalone for this verification.

## Hardening (post-review)

Review found two ways this arm reported one clinical fact **twice**. Both are silent — wrong output,
no warning — and both are now red-first tested through the real `validate(...)` seam.

**1. Route variants multiplied the chips.** DDInter carries a separate entry per route variant and
every variant publishes the same `rxnorm_name` — which is the token its rules match on — so ONE word
in the question resolves several entries (`findByQuery` returns every entry whose aliases match) that
all pair off the same rule. On the full KB, `dexamethasone` is four entries (plain, nasal,
ophthalmic, topical) and voxelotor carries rows against three of them, so "does voxelotor interact
with dexamethasone?" raised a chip per resolved entry — and a near-identical injected
`safety_finding` per chip — for a single pair. That is #115's measured shape (142 `rxnorm_name`
values shared by more than one entry across 332 entries) arriving on the **question** side, which
this PR would have shipped. Pairs are now keyed by the two drugs' **match tokens** rather than by
their entries: the token is the reference data's own canonical name for a drug, and precisely what
the variants share.

De-duplicating inside a safety net is only safe where nothing actionable is lost, so the key is
argued in both directions and both are asserted. Two entries share a key only when the data names
them identically, in which case one rule identifies both — the surviving chip carries that very
rule's severity and mechanism and all that is dropped is a second spelling of the partner. And three
drugs named in one question still raise three chips. The residual (a KB naming two genuinely
different drugs with one token, separated only by ATC code) is written down, with why the chart arm
cannot resolve it either: it reads the same token to decide which order a rule names. Which variant's
row supplies the surviving severity stays #115's open half.

**2. Chart precedence was decided from one rule, not all of them.** `addInteractions` walks every
rule an entry carries. When two rules join one pair under different tokens — a brand-name row and an
INN row — and only the second names the patient's active order, consulting the first alone concluded
"the chart does not own this pair", and the pair was reported twice: once as a fact about the patient
(*"active order warfarin"*), once as a reference lookup (*"also named in the question"*).
`aboveFloorRulesAgainst` now returns every joining rule and the precedence check asks all of them,
which is what makes `coveredByActiveOrderArm`'s *"the two cannot disagree about which pairs the chart
already owns"* true rather than nearly true. The chip still carries one row — a pair is one clinical
fact however many rows join it.

Recorded, no behaviour change: why `identifies()` delegates to `DrugReference.matchesText` and not to
the order-name matcher #128 splits out (both operands here are canonical reference strings, with no
localized inflected display name to tolerate a trailing letter for, and the orientation is inverted —
the rule's *token* is the haystack and the entry's aliases the needles, so the nesting hazard runs the
other way and the symmetric word boundary is the one that stops `chlorothiazide` matching a
`hydrochlorothiazide` rule); that `orderedInteractionNotes` is deliberately not extended, its *"a
partner that raises a chip is exactly a partner promoted here"* being scoped to the active-order arm
and still exact, because a pair chip's partner is by construction not an active order; and that the
subject tie-break follows **dataset** order, not the question's word order — both phrasings of the
voxelotor/dexamethasone question chip with Voxelotor as subject, its entry sitting at index 1055
against dexamethasone's 1744.

### Depends on #128

This PR's **precedence** behaviour rests entirely on `PatientClinicalContext.hasActiveDrug`, which
#128 replaces with a left-boundary + inflection-tolerant order-name matcher. The Agnes Adams
precedence case, `theActiveOrderChipWinsWhenThePatientIsOnOneOfTheNamedDrugs` and
`aPairAlsoJoinedByARuleNamingAnActiveOrderStaysWithTheActiveOrderArm` all decide "is this pair
already the chart's?" through that predicate, so **whichever of the two lands second should re-run the
Agnes precedence assertion.** The direction of #128's change is safe for this arm on the argument that
it makes `hasActiveDrug` match more localized order spellings and fewer nested substrings — the chart
arm then claims strictly more of the pairs it should and strictly fewer of the ones it should not —
but that is an argument, not a measurement.

## Post-hardening live re-verification

Same instance and configuration as above; full-JVM restart on the hardened build, querystore
retrieval proven alive and the known-positive control fired before any capture. Chip absence is
never concluded from one run (a cold-start race can load the KB empty for a whole JVM lifetime with
no WARN), so both zero-chip cases were re-run at the end — both still zero.

| probe | chips | result |
|---|---|---|
| Mary + "Does voxelotor interact with dexamethasone?" | 2 | `active order simvastatin — Moderate`, then **one** `Voxelotor interacts with Dexamethasone, also named in the question — Major` — four dexamethasone entries resolved, one pair chip |
| Mary + "Can dexamethasone be given with voxelotor?" | 2 | identical, incl. the same subject — the dedup is not sensitive to question word order |
| **Mary + "Does warfarin interact with aspirin?"** | 2 | `active order simvastatin — Minor`, then `Acetylsalicylic acid (aspirin), also named in the question — Major`; `references: 2`, one a cited `safety_finding` |
| Susan Young (on neither drug) + same | 1 | the pair chip alone, `activeOrder=0` — chart-independent |
| Agnes Adams (on aspirin) + same | 1 | `active order aspirin — Major` only; `pair=0`, so no duplicate reference lookup |
| Mary + "Does ascorbic acid interact with aspirin?" | 0 | both drugs resolve, no KB row joins them (re-run: 0) |
| Mary + "Is it safe to give her clarithromycin?" | 1 | `active order simvastatin — Major` |
| Agnes + "Is it safe to start warfarin?" | 1 | `active order aspirin — Major` — active-order wording, not pair wording |
| Joshua + "Can I give ibuprofen?" | 2 | NSAID cross-reactivity contraindication + `active order lisinopril — Moderate` |
| Mary + "Is it safe to give her paracetamol?" | 0 | (re-run: 0) |

All four regression controls unchanged. No test data was created or modified on the standalone.

## Hardening round 2 — a structural review's nine findings

An independent structural review of this arm found nine issues, three of them blocking. **Every one
was reproduced here before being fixed** (the reviewer's own runs are cited where they measured
something I did not re-measure). Each fix is red-first through the real `validate(...)` seam.

The branch is now rebased onto `623be82`, so all of this runs against **#128's `hasActiveDrug`** —
the predicate the precedence arm delegates to — and every number below is re-derived, not reused.

### Blocking: one clinical pair reported twice, two ways

**Chart precedence was decided per ENTRY pair, as an early return.** Route variants make one clinical
pair arrive as several entry pairs carrying *different rule sets*: the sub-floor sibling of an
above-floor row loses that row to the severity floor, so its entry pair sees different tokens and can
reach the opposite verdict. A chart-owned pair therefore left no trace and its sibling chipped.
Reproduced with a new fixture family, patient on Aspirin 81mg:

```
Diclofenac interacts with active order aspirin — Major. …
Acetylsalicylic acid (aspirin) interacts with Diclofenac (topical), also named in the question — Major. …
```

Worse than a duplicate: the patient's own medication becomes the subject of a sentence that reads as
a reference lookup, carrying the systemic row's Major mechanism attributed to the topical variant
whose own row is `Unknown`. The arm now **groups first and decides second** — candidates collect per
pair key, a chart-owned verdict is *recorded against the key* rather than returned on, and emission
happens once every entry pair has been seen. Entry-pair ordering no longer matters, which the
previous shape silently depended on.

**A drug could key two ways.** The key name came from the other side's rule token where there was one
and from `displayLabel()` where there was not — two vocabularies. So one entry keyed as `aspirin`
against the partner whose row names it and as `Acetylsalicylic acid (aspirin)` against the sibling
whose row is sub-floor: one drug, two keys, pair escapes the grouping, two chips with no patient data
at all. The reviewer is right that this cannot be waved through as "an extra chip, never a dropped
one" — every extra chip is an extra injected pre-answer finding, the outcome the keying exists to
prevent. Names are now resolved **per drug, once**, from the first above-floor rule any *other*
question drug uses to name it, so a drug keys identically in every pair and variants agree by
construction.

Measured on the full KB to bound the same-name suppression this introduces: of 2093 distinct tokens
only **6** are an exact alias of entries with different `rxnorm_name`s, and all 6 are one substance
family (the trastuzumab conjugates, isosorbide and its mononitrate, the COVID-19 vaccines) — so no
pair worth reporting is suppressed. In all **142** variant families the token is an exact alias of
every member, so the grouping catches them all.

### Blocking: an uncapped, question-controlled prompt expansion

This is the one safety input whose size a *question* controls; the others are bounded by the
patient's chart, which held findings to 0–3. Measured on the real bundled sample, one line naming its
16 drugs: **72 chips, 72 injected findings, 42,708 characters** of finding text — against a path that
caps a single reference record at `MAX_INTERACTION_RENDER_CHARS = 1500` for exactly this reason. And
they appended in dataset order, so that question led with two Moderates ahead of the first Major, the
inverse of the severity-first rule the promoted notes apply to the same rows.

Now sorted most-severe-first, capped at `MAX_QUESTION_PAIR_CHIPS = 10`, and what is withheld is
logged at WARN — a clinician cannot tell a bounded list from a complete one, so silent truncation in
a safety net reads as "nothing else was found". Live, the same question produced:

```
WARN Question-pair safety: 10 of 65 question-named drug pairs shown (cap 10); the question
resolved 16 reference drugs, and pairs grow as N^2/2. Withheld, least severe last:
[Major, Major, … ×10, Moderate ×37, Minor ×8]
```

**Flagging the trade honestly:** at 16 named drugs there are 20 Major pairs, so ten Majors are
withheld. They are named in the log, and the alternative measured above is 42 KB of prompt, but
whether 10 is the right number for a polypharmacy-review question is a judgement worth a second
opinion — the constant carries the arithmetic behind it.

### Two more defects found while reproducing those

**A multi-word rule token named every drug called after one of its words.** `identifies()` asked
"does this rule name that entry?" with the *prose* matcher — token as haystack, aliases as needles —
but both operands are canonical reference strings, so the question is name identity. A word boundary
does not save it: it stops a name nested inside a WORD (`chlorothiazide` in `hydrochlorothiazide`)
but not one nested inside a PHRASE. Measured on the full KB: **408 of 2093** distinct tokens are
multi-word and **53** carry a word that is some other entry's whole name — `ethinyl estradiol` (in
449 entries' rule lists) named the separate Estradiol entry, `magnesium salicylate` named Salicylic
acid, `iron-dextran complex` named Iron. The chip then stated an interaction the KB does not carry,
against a drug whose row it read from a different drug, and `preAnswerFindings` injected that
sentence as a citable record — a fabricated interaction handed to the model as evidence.

**A question naming ONE drug chipped it against its own route variant.** The two-drugs guard counts
*entries*, and one word resolves several when the KB carries variants of it, so "is minoxidil safe?"
raised `Minoxidil interacts with Minoxidil (topical), also named in the question`. The token keying
cannot suppress those either — a self-pair's key has the same name on both sides, so it is unique by
construction. 33 above-floor rows in the full KB join two entries sharing one token, across 29 drug
words (minoxidil, timolol, lidocaine, atropine, neomycin, paclitaxel …), and where the variants are
named after different substances the chip names two drugs the question never mentioned, which is #86.

> ### Deviation from a stated load-bearing decision
>
> The brief for this hardening listed *"`identifies()` delegates to `DrugReference.matchesText`"* as
> settled, and said not to hand-roll a third matcher. **I changed it, deliberately, and am flagging it
> rather than burying it.** The same brief directed me to check which contract that delegation
> actually wants — and the contract fails at this call site, measurably, in the direction that
> fabricates clinical claims. The replacement **removes** a matcher rather than adding one: it reads
> the same `getAliases()` list `matchesText` reads and compares for equality, so #128's change to how
> that list is scanned cannot drift from it, and the "no third matcher" concern is honoured more
> strictly than before. Nothing genuine is lost — `ddinter` writes each token from its partner row's
> `rxnorm_name` (else its name) and the parser puts both in that partner's aliases, so every real rule
> still names its partner exactly. If the maintainer prefers the original delegation, this is the one
> commit to revert (`97a188d`), and the `aMultiWordRuleTokenDoesNotNameEveryDrugCalledAfterOneOfItsWords`
> test documents what comes back.

### Coverage holes, mutation-verified

Both of the reviewer's mutation-proven holes were re-run against this branch and are now killed:

- **Question-only scoping** — the arm's most safety-relevant decision — was pinned by nothing.
  Widening it to `inPlay` left the whole package green. It now fails, and the mutation's output shows
  why it matters: `Ibuprofen interacts with Warfarin, also named in the question`, about a drug the
  question never mentioned.
- **The key-name fallback** was pinned by nothing, and still was after the per-drug rework. The
  reachable shape is narrow — a pair needs a joining rule, and that rule names the *other* side, so
  only the unnamed side falls back and two fallback drugs never pair with each other. They do both
  pair with the drug they name, which is the bundled curated seed's own shape. Under a constant
  fallback that second pair vanishes silently: 2 chips → 1.
- **The fixture's severity fields were inert** (the chip renders the note, which the parser prefixes
  with the rating). They are load-bearing now — the floor and the new ordering both read the field —
  and the tests assert the field as well as the rendered word.

### Corrections to the record

Two javadoc claims this change leaned on were false. *"A pair either of whose drugs is an active order
is left to `addInteractions`"* is not what the code asks: the test is whether any **rule** joining the
pair names an active order, and the difference is deliberate — a patient can be on one of the pair
while no joining rule names their order, and that pair is this arm's to report because the chart arm
raises nothing for it. And `orderedInteractionNotes`' *"a partner that raises a chip is exactly a
partner promoted here"* does not hold across the whole chip set, since a pair chip's partner is
promoted nowhere; rewording that neighbour's sentence is left to whichever PR owns the method next
rather than collided over. What is preserved is the invariant it exists to protect — a chip and the
prose cannot describe one finding differently — because #110 injects the finding itself verbatim.

## Live re-verification, round 2

Same instance, rebased onto `623be82` (#128, #123, #119, #125, #124 landed). Full-JVM restart on this
build; querystore retrieval proven alive (`hits=75`) and the known-positive control fired before any
capture. Every zero-chip case was run **twice**, late in the run, because a cold-start race can load
the KB empty for a whole JVM lifetime with no WARN.

| probe | chips | result |
|---|---|---|
| 16-drug polypharmacy line | 17 | 7 active-order + **exactly 10** pair chips, all Major, severity-descending; WARN names the 55 withheld |
| Mary + "Does voxelotor interact with dexamethasone?" | 2 | active-order simvastatin, then **one** `Voxelotor interacts with Dexamethasone … Major` — four variant entries, one chip |
| Mary + "Can dexamethasone be given with voxelotor?" | 2 | identical, same subject — dedup insensitive to question word order |
| Mary + "Does levofloxacin interact with estradiol?" | **0** | the fabricated `ethinyl estradiol` chip is gone (re-run: 0) |
| Mary + "Is minoxidil safe for this patient?" | **0** | no self-pair against its own route variant (re-run: 0) |
| **Mary + "Does warfarin interact with aspirin?"** | 2 | `active order simvastatin — Minor`, then `Acetylsalicylic acid (aspirin), also named in the question — Major`, with a cited `safety_finding` |
| Susan Young (on neither) + same | 1 | the pair chip alone, `activeOrder=0` — chart-independent |
| **Agnes Adams (on aspirin) + same** | 1 | `active order aspirin — Major` only; `pair=0` — precedence re-derived against #128's `hasActiveDrug` |
| Mary + "Does ascorbic acid interact with aspirin?" | 0 | both resolve, no row joins them (re-run: 0) |
| Mary + "Is it safe to give her clarithromycin?" | 1 | `active order simvastatin — Major` |
| Agnes + "Is it safe to start warfarin?" | 1 | `active order aspirin — Major` — active-order wording, not pair wording |
| Joshua + "Can I give ibuprofen?" | 2 | NSAID cross-reactivity contraindication + `active order lisinopril — Moderate` |
| Mary + "Is it safe to give her paracetamol?" | 0 | (re-run: 0) |

All four regression controls unchanged. No test data was created or modified on the standalone.

`mvn clean install` on `623be82`: **API 740 + OMOD 58 = 798 run, 0 failures, 0 errors, 34 skipped**;
`DrugSafetyQuestionPairInteractionTest` contributes 21.

## Tests

`DrugSafetyQuestionPairInteractionTest` — 12 tests through the real
`DrugSafetyValidator.validate(...)` and `DrugReferenceInjector.injectRecords(...)` seams, over the
real bundled datasets parsed by the real sources. Every one of them is red on `main`; the two marked
**⭐** were red on this PR's own first push, i.e. they are the hardening's regression tests.

- a question naming two interacting drugs, patient on **neither** ⇒ exactly one chip naming the pair
- the pair chip never claims an active order, and does attribute the pair to the question
- a symmetric pair (present on both entries) is reported **once**, not once per side
- a sub-floor pair (Unknown-severity simvastatin × aspirin) raises **nothing**
- two question-named drugs with no interaction row between them raise **nothing** (curated seed, so
  the arm is exercised source-independently)
- the active-order chip wins, and is not duplicated, when the patient is on one of the named drugs
- the pair finding is injected as a numbered, citable `safety_finding` record
- **⭐** route-variant entries sharing a match token are reported as **one** pair, not one per entry
- **⭐** a pair also joined by a rule naming an active order stays with the active-order arm — the
  precedence check reads every joining rule, not just the first
- every distinct pair among **three** named drugs is reported (three chips) — the other edge of the
  grouping, and the direction where a key too coarse would silently drop a real interaction
- a pair identified only by ATC code is reported — the arm of "does this rule name that entry?" the
  `ddinter` source never exercises, since it always writes a name token
- the patient-specific chip **leads** the pair chip (Mary Smith's measured shape: her active-order
  simvastatin finding first, the question's pair second)

One new fixture, `drug-reference-question-pairs.json`, parsed by the real `JsonDrugReferenceSource`.
It carries the three shapes the bundled DDInter sample cannot express — variants sharing a token, one
pair joined by two differently-tokened rules, and a rule identifying its partner by ATC code alone —
each a miniature of a shape the full KB carries.

`mvn clean install` on `623be82`: **API 740 + OMOD 58 = 798 run, 0 failures, 0 errors, 34 skipped**
(21 tests in this file, up from the 7 of the first push). No existing test was
modified. Note for anyone reproducing: `mvn clean test` cannot build the omod module in this reactor
(`unpack-dependencies` hits MDEP-98 — "Artifact has not been packaged yet"), so the full-reactor
command is `mvn clean install`.

## Relationship to #113

Same underlying shape — the safety join was only ever question-drug against chart — but the opposite
input. This is the *two drugs named* case and is fixed entirely within the question-resolved set.
#113 is the *no drug named* case, which needs an anchor this change does not provide (the patient's
own order list, cross-referenced against itself) and intent detection to decide when to do it. The
two arms are independent: this one reads `questionDrugs`, a screening arm would read active orders.
They will both hang off `chartsearchai.drugSafety.warnOnInteractions`, whose `config.xml` description
still describes only the answer-versus-orders join; I left that text alone rather than collide with
#113, which needs the same sentence rewritten — worth doing once, in whichever lands second.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu


