### PR TITLE
Raise one interaction chip per (drug, active order): collapse DDInter route-variant rows (closes #115)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -304,6 +304,18 @@ public class DrugReferenceInjector {
 	 * a partner that raises a chip is exactly a partner promoted here, and the rendered text cannot
 	 * drift from the chip.
 	 *
+	 * <p>That correspondence is per PARTNER, and since issue #115 it is no longer one note per chip:
+	 * {@link DrugSafetyValidator#bestRulePerPartner} collapses several rules naming one partner —
+	 * DDInter's route variants of a drug all publish the same match token — into a single
+	 * most-severe chip, while this method still promotes one entry per row. A patient on one
+	 * dexamethasone order therefore gets one Major chip beside a record reading "dexamethasone
+	 * (Major …); dexamethasone (Moderate …); dexamethasone (Moderate …)", so a model answering from
+	 * the record can still name a severity the chip deliberately discarded. Collapsing here needs
+	 * the same thing the chip cannot decide either — which variant the order is — and so waits on
+	 * the route vocabulary that is the data-side half of #115. Until then the two paths agree on
+	 * WHICH partners concern the patient, which is what the ordering above exists to guarantee, but
+	 * not on how many rows or which severity.
+	 *
 	 * <p>Ordering alone is not sufficient, which is why {@code render} also overrides the budget for
 	 * this segment: two above-floor partners can exceed {@link #MAX_INTERACTION_RENDER_CHARS}
 	 * between them (measured on the bundled sample: methotrexate 783 + aspirin 809 against a 1500

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -310,11 +310,15 @@ public class DrugReferenceInjector {
 	 * most-severe chip, while this method still promotes one entry per row. A patient on one
 	 * dexamethasone order therefore gets one Major chip beside a record reading "dexamethasone
 	 * (Major …); dexamethasone (Moderate …); dexamethasone (Moderate …)", so a model answering from
-	 * the record can still name a severity the chip deliberately discarded. Collapsing here needs
-	 * the same thing the chip cannot decide either — which variant the order is — and so waits on
-	 * the route vocabulary that is the data-side half of #115. Until then the two paths agree on
-	 * WHICH partners concern the patient, which is what the ordering above exists to guarantee, but
-	 * not on how many rows or which severity.
+	 * the record can still name a severity the chip deliberately discarded — and does so from the
+	 * more quotable half, because in that measured case the discarded Moderate note is 659 characters
+	 * against the surviving Major row's 326. Nothing goes missing: {@code render} emits every promoted
+	 * note, so a duplicated partner can only push another partner into its compact
+	 * {@code name (Severity)} form, never out. Collapsing here needs the same thing the chip cannot
+	 * decide either — which variant the order is — and so waits on the route vocabulary that is the
+	 * data-side half of #115. Until then the two paths agree on WHICH partners concern the patient,
+	 * which is what the ordering above exists to guarantee, but not on how many rows or which
+	 * severity.
 	 *
 	 * <p>Ordering alone is not sufficient, which is why {@code render} also overrides the budget for
 	 * this segment: two above-floor partners can exceed {@link #MAX_INTERACTION_RENDER_CHARS}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -363,8 +363,7 @@ public class DrugReferenceInjector {
 			}
 			boolean promote = context != null && context.hasActiveDrug(i.getToken(), i.getAtc())
 					&& DrugSafetyValidator.clearsSeverityFloor(i, floor);
-			(promote ? promoted : rest).add(new InteractionNote(rendered, compact,
-					DrugSafetyValidator.severityRank(i.getSeverity())));
+			(promote ? promoted : rest).add(new InteractionNote(rendered, compact, i.getSeverity()));
 		}
 		// Within the promoted segment, severity — not dataset position — decides who keeps their
 		// mechanism prose when the budget can only afford one full note (see render). Measured on the
@@ -409,14 +408,14 @@ public class DrugReferenceInjector {
 
 		final String compact;
 
-		/** {@link DrugSafetyValidator#severityRank} with unrated raised above Major — see
-		 *  {@link #SEVERITY_DESCENDING}. */
+		/** {@link DrugSafetyValidator#severityPriority} — the shared ordering in which unrated sits
+		 *  above Major; see {@link #SEVERITY_DESCENDING}. */
 		final int severityPriority;
 
-		InteractionNote(String full, String compact, int severityRank) {
+		InteractionNote(String full, String compact, String severity) {
 			this.full = full;
 			this.compact = compact;
-			this.severityPriority = severityRank < 0 ? Integer.MAX_VALUE : severityRank;
+			this.severityPriority = DrugSafetyValidator.severityPriority(severity);
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -424,13 +424,14 @@ public class DrugSafetyValidator {
 	 * <p>Trimmed to fold the way the MATCH folds. {@link PatientClinicalContext#hasActiveDrug} trims
 	 * and case-folds the rule's token before testing it against an order name, so two rows whose
 	 * tokens differ only in case or in surrounding whitespace are one partner to the only predicate
-	 * that decides an interaction concerns this patient — and must be one partner here too, or #115's
-	 * duplicate chip
-	 * returns for a hand-authored dataset with two labels a clinician cannot tell apart. That is a
-	 * live shape, not a hypothetical: the {@code ddinter} and {@code atc} sources normalize their
-	 * tokens at parse, but the curated {@code json} source is plain Jackson over an operator-editable
-	 * file and sanitizes nothing. Trimming also keeps that padding out of the chip text, as
-	 * {@link DrugReferenceInjector#orderedInteractionNotes} already does for its own rendered label.
+	 * that decides an interaction concerns this patient — and must be one partner here too, or issue
+	 * #115's duplicate chip returns for a hand-authored dataset, silently and with two labels a
+	 * clinician cannot tell apart. That shape reaches this method: {@code ddinter} lower-cases every
+	 * token it derives and takes it from the trimmed RxNorm generic whenever the partner row has one,
+	 * and {@code atc} carries no rules at all, but the curated {@code json} source is plain Jackson
+	 * over an operator-editable file and sanitizes neither case nor padding. Trimming also keeps that
+	 * padding out of the chip text, as {@link DrugReferenceInjector#orderedInteractionNotes} already
+	 * does for its own rendered label.
 	 *
 	 * @return the label, or null when the rule carries neither — which a rule that matched an active
 	 *         order cannot ({@code hasActiveDrug} needs a non-blank token or a non-blank ATC), so
@@ -467,7 +468,8 @@ public class DrugSafetyValidator {
 	 * class arm ({@link #addClassInteractions}) is untouched, so the rule-plus-class double chip
 	 * of issue #88 is a different defect and stays open.
 	 *
-	 * <p><b>Which row wins.</b> The most severe rating, then the longer note. Route variants
+	 * <p><b>Which row wins.</b> The most severe rating, then the longer note — longer in prose, not
+	 * in whitespace, see {@link #noteLength}. Route variants
 	 * genuinely differ — topical dexamethasone does not have systemic dexamethasone's interaction
 	 * profile, which is why DDInter rates voxelotor Major against one variant and Moderate against
 	 * the others — but nothing on a {@code DrugOrder} tells this layer which variant the order is
@@ -525,8 +527,18 @@ public class DrugSafetyValidator {
 		return noteLength(candidate) > noteLength(incumbent);
 	}
 
+	/**
+	 * @return how much mechanism prose {@code interaction}'s note carries — its <em>trimmed</em>
+	 *         length. Whitespace is not the informativeness signal the tie-break is reading: measured
+	 *         raw, a short referral note with a block of blank lines pasted onto it outranks a longer
+	 *         real mechanism paragraph, and the surviving chip then says nothing about the mechanism
+	 *         while the row explaining it is discarded. Trimmed for the comparison only — the note
+	 *         still renders as authored, exactly as it does for a row with no competitor;
+	 *         {@link DrugReferenceInjector#orderedInteractionNotes} makes the same "trim before you
+	 *         compare lengths" call for the same reason.
+	 */
 	private static int noteLength(DrugReference.Interaction interaction) {
-		return interaction.getNote() == null ? 0 : interaction.getNote().length();
+		return interaction.getNote() == null ? 0 : interaction.getNote().trim().length();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -473,12 +473,11 @@ public class DrugSafetyValidator {
 	 * class arm ({@link #addClassInteractions}) is untouched, so the rule-plus-class double chip
 	 * of issue #88 is a different defect and stays open.
 	 *
-	 * <p><b>Which row wins.</b> The most severe rating, then the longer note — longer in prose, not
-	 * in whitespace, see {@link #noteLength}. Route variants
-	 * genuinely differ — topical dexamethasone does not have systemic dexamethasone's interaction
-	 * profile, which is why DDInter rates voxelotor Major against systemic dexamethasone, Moderate
-	 * against two others and carries no row at all against the topical variant — but nothing on a
-	 * {@code DrugOrder} tells this layer which variant the order is
+	 * <p><b>Which row wins.</b> The most severe rating, then the longer note — longer in prose, not in
+	 * whitespace, see {@link #noteLength}. Route variants genuinely differ — topical dexamethasone does
+	 * not have systemic dexamethasone's interaction profile, which is why DDInter rates voxelotor Major
+	 * against systemic dexamethasone, Moderate against two others and carries no row at all against the
+	 * topical variant — but nothing on a {@code DrugOrder} tells this layer which variant the order is
 	 * (the context carries names and ATC codes; all four variants publish an identical ATC list),
 	 * so the variant cannot be resolved here. Reporting the strongest rating over-warns rather than
 	 * under-warns on a non-blocking advisory the clinician adjudicates, which is the fail-safe

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -10,9 +10,12 @@
 package org.openmrs.module.chartsearchai.reference;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -47,7 +50,10 @@ import org.springframework.stereotype.Service;
  *       {@code chartsearchai.drugSafety.minInteractionSeverity} is not raised — unrated rules
  *       are never floor-filtered), by sharing an ATC chemical subgroup with an active order
  *       (duplicate-therapy reasoning), or — failing that — by sharing a curated
- *       {@link CrossReactivityGroup} (cross-branch family overlap).</li>
+ *       {@link CrossReactivityGroup} (cross-branch family overlap). The rule arm raises one
+ *       warning per (drug, matched partner): several rules can name one partner — DDInter's
+ *       route variants of a drug all publish the same match token — and they collapse to the
+ *       most severe row, see {@link #bestRulePerPartner}.</li>
  *   <li><b>Contraindications</b> — the drug is contraindicated by an active allergy or
  *       condition: by a hand-authored rule, by being the same drug as — or sharing an ATC
  *       chemical subgroup with — a recorded allergy (cross-reactivity reasoning), or —
@@ -273,6 +279,22 @@ public class DrugSafetyValidator {
 		}
 	}
 
+	/**
+	 * {@link #severityRank} raised so that an <em>unrated</em> rule sorts above {@code major}: every
+	 * curated hand-authored rule is unrated and {@link #clearsSeverityFloor} already treats unrated
+	 * as exempt rather than low — unrated is not low-rated, so wherever a most-severe-wins choice is
+	 * made it must not lose to a rated row. The one definition of that ordering, shared by the chip
+	 * grouping here ({@link #bestRulePerPartner}) and the promoted-note ordering in
+	 * {@link DrugReferenceInjector.InteractionNote}; two copies could drift into ranking the same
+	 * pair of rules oppositely, which is how the chip and the prompt text come to disagree.
+	 *
+	 * @return the rank, with null/unrecognized mapped to {@link Integer#MAX_VALUE}
+	 */
+	static int severityPriority(String severity) {
+		int rank = severityRank(severity);
+		return rank < 0 ? Integer.MAX_VALUE : rank;
+	}
+
 	/** @return the floor rank for the GP value, falling back to the default floor when the
 	 *          value is unrecognized (a typo'd GP must not silently disable all rated rules). */
 	private static int floorRank(String gpValue) {
@@ -374,30 +396,112 @@ public class DrugSafetyValidator {
 		}
 	}
 
+	/**
+	 * Rule-based interaction chips for {@code ref}: <b>one chip per (this drug, matched partner)</b>
+	 * — see {@link #bestRulePerPartner} for why several rules can match one order.
+	 */
 	private void addInteractions(List<SafetyWarning> warnings, DrugReference ref,
 			PatientClinicalContext context, int severityFloor) {
 		if (context == null) {
 			return;
 		}
+		for (DrugReference.Interaction i : bestRulePerPartner(ref, context, severityFloor)) {
+			// A matched rule has a non-blank token or ATC, so the coalesce never yields null.
+			String detail = ref.displayLabel() + " interacts with active order "
+					+ ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc());
+			if (i.getNote() != null && !i.getNote().isEmpty()) {
+				detail += " — " + i.getNote();
+			}
+			warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.displayLabel(), detail));
+		}
+	}
+
+	/**
+	 * The matched interaction rules of {@code ref} worth chipping, at most one per partner, in
+	 * dataset order of first appearance.
+	 *
+	 * <p><b>Why grouping is needed (issue #115).</b> DDInter carries one entry per <em>route
+	 * variant</em> and every variant of a drug publishes the same {@code rxnorm_name}, so the
+	 * variants' rows all reach this arm carrying the same match token: one active order matches
+	 * every one of them, and ungrouped that is N chips for a single pair, at N different
+	 * severities. Measured on the 3.7.1 standalone: a patient on one Dexamethasone 4mg order,
+	 * asked about voxelotor, raised three chips — Major + Moderate + Moderate — of which the two
+	 * Moderate details were byte-identical strings, because the nasal and ophthalmic variants
+	 * share a mechanism group. Across the full KB 142 {@code rxnorm_name} values are shared by
+	 * more than one entry (332 entries), and 1004 question-drugs would raise 3 or more chips for
+	 * some single active drug. {@link SafetyWarning} carries no {@code equals}, so nothing
+	 * downstream can collapse them — and because the chips are also injected as citable
+	 * safety-finding records ({@code DrugReferenceInjector.preAnswerFindings}), each duplicate
+	 * became a near-identical record in the prompt as well.
+	 *
+	 * <p><b>What is grouped.</b> The key is the label the chip actually renders
+	 * ({@code firstNonBlank(token, atc)}, case-folded), so rules that would produce the same
+	 * "interacts with active order X" subject collapse while rules naming different partners each
+	 * keep their chip — even when their notes are identical strings. Grouping is per {@code ref}
+	 * and per arm: two different drugs in play still chip separately about the same order, and the
+	 * class arm ({@link #addClassInteractions}) is untouched, so the rule-plus-class double chip
+	 * of issue #88 is a different defect and stays open.
+	 *
+	 * <p><b>Which row wins.</b> The most severe rating, then the longer note. Route variants
+	 * genuinely differ — topical dexamethasone does not have systemic dexamethasone's interaction
+	 * profile, which is why DDInter rates voxelotor Major against one variant and Moderate against
+	 * the others — but nothing on a {@code DrugOrder} tells this layer which variant the order is
+	 * (the context carries names and ATC codes; all four variants publish an identical ATC list),
+	 * so the variant cannot be resolved here. Reporting the strongest rating over-warns rather than
+	 * under-warns on a non-blocking advisory the clinician adjudicates, which is the fail-safe
+	 * direction; the accepted cost is that a patient on a topical form may see the systemic
+	 * severity. Making the severity route-aware needs a dose-form/route vocabulary that does not
+	 * exist yet — the data-side half of #115. The note length is the only informativeness signal a
+	 * row carries: DDInter's "no mechanism description on file" fallback is shorter than any real
+	 * mechanism paragraph, and where two equally-rated rows both carry prose the longer one has been
+	 * the superset in the shapes measured (the two dolutegravir x iron rows, where it adds the
+	 * dose-separation INTERVAL guidance), so a tie on severity keeps the fuller note. Equal on both
+	 * keeps the incumbent, so a group's chip is the dataset's first such row.
+	 */
+	private static Collection<DrugReference.Interaction> bestRulePerPartner(DrugReference ref,
+			PatientClinicalContext context, int severityFloor) {
+		Map<String, DrugReference.Interaction> best = new LinkedHashMap<String, DrugReference.Interaction>();
 		for (DrugReference.Interaction i : ref.getInteractions()) {
 			// The severity floor (issue #84): a rule the SOURCE rated below the floor is not
 			// raised — DDInter's Unknown-severity rows carry no mechanism text and would bury
 			// the chips that matter (measured: an uncharacterized aspirin x simvastatin row
 			// sharing equal billing with a severe-allergy contraindication). A rule with no
 			// severity (every curated hand-authored rule) is exempt: unrated is not low-rated.
+			// Filtered BEFORE grouping, so a sub-floor row can never become a group's winner and
+			// the floor keeps deciding exactly which rules exist for this arm.
 			if (!clearsSeverityFloor(i, severityFloor)) {
 				continue;
 			}
-			if (context.hasActiveDrug(i.getToken(), i.getAtc())) {
-				// A matched rule has a non-blank token or ATC, so the coalesce never yields null.
-				String detail = ref.displayLabel() + " interacts with active order "
-						+ ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc());
-				if (i.getNote() != null && !i.getNote().isEmpty()) {
-					detail += " — " + i.getNote();
-				}
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.displayLabel(), detail));
+			if (!context.hasActiveDrug(i.getToken(), i.getAtc())) {
+				continue;
+			}
+			String key = ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc()).toLowerCase(Locale.ROOT);
+			DrugReference.Interaction incumbent = best.get(key);
+			if (incumbent == null || outranks(i, incumbent)) {
+				// LinkedHashMap keeps a re-put key in its original position, so replacing a group's
+				// winner does not reorder the chips.
+				best.put(key, i);
 			}
 		}
+		return best.values();
+	}
+
+	/**
+	 * @return true when {@code candidate} is the row worth chipping for a partner {@code incumbent}
+	 *         already covers — a more severe rating, or an equal rating with a longer note. See
+	 *         {@link #bestRulePerPartner} for the rationale.
+	 */
+	private static boolean outranks(DrugReference.Interaction candidate, DrugReference.Interaction incumbent) {
+		int candidateSeverity = severityPriority(candidate.getSeverity());
+		int incumbentSeverity = severityPriority(incumbent.getSeverity());
+		if (candidateSeverity != incumbentSeverity) {
+			return candidateSeverity > incumbentSeverity;
+		}
+		return noteLength(candidate) > noteLength(incumbent);
+	}
+
+	private static int noteLength(DrugReference.Interaction interaction) {
+		return interaction.getNote() == null ? 0 : interaction.getNote().length();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -406,14 +406,39 @@ public class DrugSafetyValidator {
 			return;
 		}
 		for (DrugReference.Interaction i : bestRulePerPartner(ref, context, severityFloor)) {
-			// A matched rule has a non-blank token or ATC, so the coalesce never yields null.
-			String detail = ref.displayLabel() + " interacts with active order "
-					+ ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc());
+			String detail = ref.displayLabel() + " interacts with active order " + partnerLabel(i);
 			if (i.getNote() != null && !i.getNote().isEmpty()) {
 				detail += " — " + i.getNote();
 			}
 			warnings.add(new SafetyWarning(SafetyWarning.TYPE_INTERACTION, ref.displayLabel(), detail));
 		}
+	}
+
+	/**
+	 * The partner label a chip names for {@code interaction} — its match token, else its ATC code.
+	 *
+	 * <p>One definition, because the chip detail renders it and {@link #bestRulePerPartner} groups on
+	 * it: that grouping is only correct while the key IS the label the chip says, and two copies of
+	 * the same coalesce could drift into grouping rules by something a clinician never sees.
+	 *
+	 * <p>Trimmed to fold the way the MATCH folds. {@link PatientClinicalContext#hasActiveDrug} trims
+	 * and case-folds the rule's token before testing it against an order name, so two rows whose
+	 * tokens differ only in case or in surrounding whitespace are one partner to the only predicate
+	 * that decides an interaction concerns this patient — and must be one partner here too, or #115's
+	 * duplicate chip
+	 * returns for a hand-authored dataset with two labels a clinician cannot tell apart. That is a
+	 * live shape, not a hypothetical: the {@code ddinter} and {@code atc} sources normalize their
+	 * tokens at parse, but the curated {@code json} source is plain Jackson over an operator-editable
+	 * file and sanitizes nothing. Trimming also keeps that padding out of the chip text, as
+	 * {@link DrugReferenceInjector#orderedInteractionNotes} already does for its own rendered label.
+	 *
+	 * @return the label, or null when the rule carries neither — which a rule that matched an active
+	 *         order cannot ({@code hasActiveDrug} needs a non-blank token or a non-blank ATC), so
+	 *         callers inside the matched loop never see it
+	 */
+	private static String partnerLabel(DrugReference.Interaction interaction) {
+		String label = ChartSearchAiUtils.firstNonBlank(interaction.getToken(), interaction.getAtc());
+		return label == null ? null : label.trim();
 	}
 
 	/**
@@ -435,7 +460,7 @@ public class DrugSafetyValidator {
 	 * became a near-identical record in the prompt as well.
 	 *
 	 * <p><b>What is grouped.</b> The key is the label the chip actually renders
-	 * ({@code firstNonBlank(token, atc)}, case-folded), so rules that would produce the same
+	 * ({@link #partnerLabel}, case-folded), so rules that would produce the same
 	 * "interacts with active order X" subject collapse while rules naming different partners each
 	 * keep their chip — even when their notes are identical strings. Grouping is per {@code ref}
 	 * and per arm: two different drugs in play still chip separately about the same order, and the
@@ -475,7 +500,7 @@ public class DrugSafetyValidator {
 			if (!context.hasActiveDrug(i.getToken(), i.getAtc())) {
 				continue;
 			}
-			String key = ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc()).toLowerCase(Locale.ROOT);
+			String key = partnerLabel(i).toLowerCase(Locale.ROOT);
 			DrugReference.Interaction incumbent = best.get(key);
 			if (incumbent == null || outranks(i, incumbent)) {
 				// LinkedHashMap keeps a re-put key in its original position, so replacing a group's

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -261,7 +261,7 @@ public class DrugSafetyValidator {
 	 *         or {@code -1} for null/unrecognized — which the rule filter treats as exempt
 	 *         (unrated is not low-rated).
 	 */
-	static int severityRank(String severity) {
+	private static int severityRank(String severity) {
 		if (severity == null) {
 			return -1;
 		}
@@ -422,16 +422,21 @@ public class DrugSafetyValidator {
 	 * the same coalesce could drift into grouping rules by something a clinician never sees.
 	 *
 	 * <p>Trimmed to fold the way the MATCH folds. {@link PatientClinicalContext#hasActiveDrug} trims
-	 * and case-folds the rule's token before testing it against an order name, so two rows whose
+	 * the rule's token and matches it case-insensitively against the order name, so two rows whose
 	 * tokens differ only in case or in surrounding whitespace are one partner to the only predicate
 	 * that decides an interaction concerns this patient — and must be one partner here too, or issue
 	 * #115's duplicate chip returns for a hand-authored dataset, silently and with two labels a
 	 * clinician cannot tell apart. That shape reaches this method: {@code ddinter} lower-cases every
 	 * token it derives and takes it from the trimmed RxNorm generic whenever the partner row has one,
 	 * and {@code atc} carries no rules at all, but the curated {@code json} source is plain Jackson
-	 * over an operator-editable file and sanitizes neither case nor padding. Trimming also keeps that
-	 * padding out of the chip text, as {@link DrugReferenceInjector#orderedInteractionNotes} already
-	 * does for its own rendered label.
+	 * over an operator-editable file and sanitizes neither case nor padding — nor does the ATC arm,
+	 * which is why the fold is applied to the coalesced value rather than to the token alone.
+	 *
+	 * <p>Not yet the only label site: {@link DrugReferenceInjector#orderedInteractionNotes} still
+	 * coalesces its own, untrimmed (it trims the assembled {@code label (note)} piece, not the label),
+	 * so a padded curated token reaches the citable record as {@code "warfarin   (Major. …)"} beside a
+	 * chip reading {@code "active order warfarin"}. Same partner, different spelling; giving the
+	 * injector this method is the follow-up.
 	 *
 	 * @return the label, or null when the rule carries neither — which a rule that matched an active
 	 *         order cannot ({@code hasActiveDrug} needs a non-blank token or a non-blank ATC), so
@@ -471,8 +476,9 @@ public class DrugSafetyValidator {
 	 * <p><b>Which row wins.</b> The most severe rating, then the longer note — longer in prose, not
 	 * in whitespace, see {@link #noteLength}. Route variants
 	 * genuinely differ — topical dexamethasone does not have systemic dexamethasone's interaction
-	 * profile, which is why DDInter rates voxelotor Major against one variant and Moderate against
-	 * the others — but nothing on a {@code DrugOrder} tells this layer which variant the order is
+	 * profile, which is why DDInter rates voxelotor Major against systemic dexamethasone, Moderate
+	 * against two others and carries no row at all against the topical variant — but nothing on a
+	 * {@code DrugOrder} tells this layer which variant the order is
 	 * (the context carries names and ATC codes; all four variants publish an identical ATC list),
 	 * so the variant cannot be resolved here. Reporting the strongest rating over-warns rather than
 	 * under-warns on a non-blocking advisory the clinician adjudicates, which is the fail-safe
@@ -481,9 +487,23 @@ public class DrugSafetyValidator {
 	 * exist yet — the data-side half of #115. The note length is the only informativeness signal a
 	 * row carries: DDInter's "no mechanism description on file" fallback is shorter than any real
 	 * mechanism paragraph, and where two equally-rated rows both carry prose the longer one has been
-	 * the superset in the shapes measured (the two dolutegravir x iron rows, where it adds the
-	 * dose-separation INTERVAL guidance), so a tie on severity keeps the fuller note. Equal on both
-	 * keeps the incumbent, so a group's chip is the dataset's first such row.
+	 * a strict superset in the shapes measured — in the two dolutegravir x iron rows (171 and 236
+	 * characters of note) the surplus is the sentence "The mechanism of interaction has not been
+	 * established.", so the fuller row says everything the shorter one does and states its own limit
+	 * — so a tie on severity keeps the fuller note. Equal on both keeps the incumbent, so a group's
+	 * chip is the dataset's first such row.
+	 *
+	 * <p><b>Two corners this rule accepts.</b> A row with no note at all still wins its group on
+	 * severity alone, so an operator's token-only unrated rule beats a rated row carrying a mechanism
+	 * paragraph and the chip then gives no reason — reachable only in hand-authored data, since every
+	 * DDInter row has a note, and left as it is because the alternative (a note outranking a rating)
+	 * would drop the operator's own rule, which is the thing {@link #severityPriority} exists to
+	 * protect. And grouping is by label, so two tokens that both match one order but are not the same
+	 * string stay two chips: across the full KB exactly one such pair exists — {@code enalapril} and
+	 * {@code enalaprilat}, which 376 entries carry as separate partners, and which a single order
+	 * named "Enalaprilat 1.25 mg" matches through the order-name matcher's inflection tolerance.
+	 * Prodrug and active metabolite are genuinely different DDInter entries, so that pair is reported
+	 * rather than merged.
 	 */
 	private static Collection<DrugReference.Interaction> bestRulePerPartner(DrugReference ref,
 			PatientClinicalContext context, int severityFloor) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
@@ -369,8 +369,9 @@ public class DdiDrugReferenceSourceTest {
 		// Real slice (#115): DDInter carries one entry per ROUTE VARIANT, and all four Dexamethasone
 		// variants publish rxnorm_name "dexamethasone" plus an identical ATC list. The route
 		// distinction is clinically real — topical dexamethasone does not have systemic
-		// dexamethasone's interaction profile, which is why Voxelotor is rated Major against one
-		// variant and Moderate against the others — so the DATASET must stay unflattened and the
+		// dexamethasone's interaction profile, which is why Voxelotor is rated Major against the
+		// systemic variant, Moderate against two others, and carries no row at all against the
+		// topical one (three rows over four variants) — so the DATASET must stay unflattened and the
 		// one-chip-per-pair decision belongs to the validator (pinned below).
 		List<DrugReference> entries = routeVariantEntries();
 		List<DrugReference> variants = entries.stream()
@@ -434,8 +435,9 @@ public class DdiDrugReferenceSourceTest {
 	@Test
 	public void strongestSeverityWinsEvenWhenItIsNeitherTheFirstRowNorTheLongestNote() throws Exception {
 		// Real slice: Lapatinib carries two rows against the shared token "sirolimus" — Sirolimus
-		// (Moderate, 285-char note) at dataset position 2 and Sirolimus (protein-bound) (Major,
-		// 280-char note) at position 4. The Major row is neither the first match nor the longest
+		// (Moderate, a 285-char mechanism inside a 295-char note) at dataset position 2 and Sirolimus
+		// (protein-bound) (Major, 280 inside 287) at position 4; the note is what the tie-break
+		// compares, and it carries the severity prefix. The Major row is neither the first match nor the longest
 		// note, so this is the arrangement that separates "most severe wins" from "keep the first
 		// row" and from "keep the longest note", both of which would pass the dexamethasone case.
 		List<SafetyWarning> warnings = routeVariantValidator().validate(

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
@@ -475,6 +475,35 @@ public class DdiDrugReferenceSourceTest {
 	}
 
 	@Test
+	public void replacingAGroupsWinnerLeavesTheChipsInDatasetOrderOfFirstAppearance() throws Exception {
+		// Real slice: Dolutegravir's rows in dataset order are phenytoin (Major), iron (Major, the
+		// shorter note), dexamethasone (Minor), iron (Major, the fuller note). With iron AND
+		// dexamethasone both active, iron's group is opened first, dexamethasone's group is opened
+		// next, and only THEN does iron's second row take its group — so this is the arrangement in
+		// which a collapse that re-inserts a replaced winner (a HashMap, or remove-then-put) puts
+		// dexamethasone's chip ahead of iron's. Chip order is first-appearance order and the
+		// clinician reads the list top-down, so the most severe finding must not be demoted by the
+		// mechanics of the collapse.
+		List<SafetyWarning> warnings = routeVariantValidator().validate(
+				"Dolutegravir could be started.", "Is it safe to start dolutegravir?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Iron 65mg", "Dexamethasone 4mg"), null, null, null));
+
+		assertEquals(2, warnings.size(),
+				"two active partners must raise two chips, was: " + warnings);
+		// Asserted on the partner and rating only, not on the winning row's mechanism prose — which
+		// row wins the iron group is equalSeveritiesKeepTheRowCarryingTheFullerMechanismNote's
+		// business, and pinning its opening words here would couple this case to the note text.
+		assertTrue(warnings.get(0).getDetail()
+				.startsWith("Dolutegravir interacts with active order iron — Major. "),
+				"iron's row appears first in the dataset, so its chip must come first even though its"
+						+ " group's winner was decided last, was: " + warnings.get(0).getDetail());
+		assertTrue(warnings.get(1).getDetail()
+				.startsWith("Dolutegravir interacts with active order dexamethasone — Minor. "),
+				"dexamethasone's chip must stay second, was: " + warnings.get(1).getDetail());
+	}
+
+	@Test
 	public void sharedRxcuiDoesNotCollapseEntryIds() throws Exception {
 		// Real slice: three Lidocaine route variants all map to RxCUI 6387. The injector dedups
 		// citations by id, so the rxcui is used only when unique — else the DDInter id — keeping

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,12 +33,21 @@ import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.Record
  * <p>The tests that need a KB slice the 60-mechanism bundled sample does not contain feed the real
  * {@link DdiDrugReferenceSource#parse} a fixture instead (see {@link #ddiFixtureEntries}); the
  * pipeline exercised is the same, only the dataset is narrowed.
+ *
+ * <p>Not only parser behaviour: six of these cases specify {@link DrugSafetyValidator}'s
+ * one-chip-per-(drug, active order) collapse of issue #115, because the shape that motivates it —
+ * several route variants of one drug publishing the same match token — only exists in a DDInter
+ * dataset. The shapes only a hand-authored dataset can pose live in
+ * {@link InteractionPartnerGroupingTest}. Between them they are the collapse's specification, so a
+ * change to it should run both.
  */
 public class DdiDrugReferenceSourceTest {
 
 	private static final String SEVERITY = "Major Moderate Minor Unknown";
 
 	private static final String MARKER_FIXTURE = "chartsearchai-test/ddi-field-marker-mechanism.json";
+
+	private static final String ROUTE_VARIANT_FIXTURE = "chartsearchai-test/ddi-route-variants.json";
 
 	/** The real mechanism text of KB group 2248, verbatim minus the {@code INTERVAL:} marker. */
 	private static final String DOLUTEGRAVIR_MECHANISM = "Coadministration with medications containing "
@@ -204,6 +214,14 @@ public class DdiDrugReferenceSourceTest {
 		}
 	}
 
+	/**
+	 * The real shared-{@code rxnorm_name} slices — the four Dexamethasone route variants, the two
+	 * Sirolimus formulations, the two Iron products and their partners, with their own mechanism
+	 * texts — parsed by the real production parser.
+	 */
+	private static List<DrugReference> routeVariantEntries() throws Exception {
+		return ddiFixtureEntries(ROUTE_VARIANT_FIXTURE);
+	}
 	private static List<DrugReference> markerFixtureEntries() throws Exception {
 		return ddiFixtureEntries(MARKER_FIXTURE);
 	}
@@ -340,6 +358,120 @@ public class DdiDrugReferenceSourceTest {
 				"the finding line the model reads first must read as a sentence, with no field marker");
 		assertFalse(result.getText().contains("INTERVAL"),
 				"no field marker may reach the prompt through either renderer, was: " + result.getText());
+	}
+
+	private static DrugSafetyValidator routeVariantValidator() throws Exception {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.serviceWith(routeVariantEntries()));
+	}
+
+	@Test
+	public void routeVariantsOfOneGenericParseAsDistinctEntriesKeepingPerVariantSeverities() throws Exception {
+		// Real slice (#115): DDInter carries one entry per ROUTE VARIANT, and all four Dexamethasone
+		// variants publish rxnorm_name "dexamethasone" plus an identical ATC list. The route
+		// distinction is clinically real — topical dexamethasone does not have systemic
+		// dexamethasone's interaction profile, which is why Voxelotor is rated Major against one
+		// variant and Moderate against the others — so the DATASET must stay unflattened and the
+		// one-chip-per-pair decision belongs to the validator (pinned below).
+		List<DrugReference> entries = routeVariantEntries();
+		List<DrugReference> variants = entries.stream()
+				.filter(r -> r.getName().startsWith("Dexamethasone")).collect(Collectors.toList());
+		assertEquals(4, variants.size(), "the four route variants must parse as four entries");
+		assertEquals(4, variants.stream().map(DrugReference::getId).distinct().count(),
+				"route variants sharing a RxCUI must not collapse to one id");
+
+		DrugReference voxelotor = entries.stream().filter(r -> "Voxelotor".equals(r.getName()))
+				.findFirst().orElseThrow();
+		List<String> severities = voxelotor.getInteractions().stream()
+				.filter(i -> "dexamethasone".equals(i.getToken()))
+				.map(DrugReference.Interaction::getSeverity).collect(Collectors.toList());
+		assertEquals(Arrays.asList("Major", "Moderate", "Moderate"), severities,
+				"each variant's row must keep its own severity — flattening the dataset is the wrong fix");
+	}
+
+	@Test
+	public void oneActiveOrderMatchingSeveralRouteVariantsRaisesOneChipAtTheHighestSeverity() throws Exception {
+		// Live-reproduced twice on the 3.7.1 standalone (Margaret King, one active order
+		// "Dexamethasone 4mg", "Is it safe to give voxelotor?"): THREE chips for the one pair —
+		// Major + Moderate + Moderate, the last two byte-identical — because the single order name
+		// matches the shared "dexamethasone" token on every variant's row. One drug against one
+		// active order is one chip, and it must carry the most severe rating the pair publishes.
+		List<SafetyWarning> warnings = routeVariantValidator().validate(
+				"Voxelotor could be started.", "Is it safe to give voxelotor?",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Dexamethasone 4mg"),
+						null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"one drug against one active order must raise exactly one chip, was: " + warnings);
+		String detail = warnings.get(0).getDetail();
+		assertTrue(detail.startsWith("Voxelotor interacts with active order dexamethasone — Major. "),
+				"the surviving chip must carry the pair's most severe rating, was: " + detail);
+		assertFalse(detail.contains("Cushing"),
+				"the surviving note must be the Major row's mechanism, not a Moderate variant's, was: " + detail);
+	}
+
+	@Test
+	public void differentPartnersKeepTheirOwnChipEvenWhenTheirNotesAreIdentical() throws Exception {
+		// The collapse must apply ONLY to rows that would render the same subject. Voxelotor's
+		// Phenytoin row shares the systemic Dexamethasone row's mechanism group, so the two notes
+		// are the same string at the same severity — a dedup keyed on the note text, or on the drug
+		// alone, would silently drop one of two genuinely different warnings.
+		List<SafetyWarning> warnings = routeVariantValidator().validate(
+				"Voxelotor could be started.", "Is it safe to give voxelotor?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Dexamethasone 4mg", "Phenytoin 100mg"),
+						null, null, null));
+
+		assertEquals(2, warnings.size(),
+				"two distinct interaction partners must raise two chips, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Voxelotor", "active order dexamethasone"),
+				"the dexamethasone chip must survive, was: " + warnings);
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Voxelotor", "active order phenytoin"),
+				"the phenytoin chip must survive, was: " + warnings);
+	}
+
+	@Test
+	public void strongestSeverityWinsEvenWhenItIsNeitherTheFirstRowNorTheLongestNote() throws Exception {
+		// Real slice: Lapatinib carries two rows against the shared token "sirolimus" — Sirolimus
+		// (Moderate, 285-char note) at dataset position 2 and Sirolimus (protein-bound) (Major,
+		// 280-char note) at position 4. The Major row is neither the first match nor the longest
+		// note, so this is the arrangement that separates "most severe wins" from "keep the first
+		// row" and from "keep the longest note", both of which would pass the dexamethasone case.
+		List<SafetyWarning> warnings = routeVariantValidator().validate(
+				"Lapatinib could be started.", "Is it safe to give lapatinib?",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Sirolimus 2mg"),
+						null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"the two sirolimus rows must collapse to one chip, was: " + warnings);
+		assertTrue(warnings.get(0).getDetail()
+				.startsWith("Lapatinib interacts with active order sirolimus — Major. "),
+				"the chip must carry the Major rating even though its row is neither first nor longest,"
+						+ " was: " + warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void equalSeveritiesKeepTheRowCarryingTheFullerMechanismNote() throws Exception {
+		// Real slice — the pair in #115's description: Dolutegravir carries two Major rows against the
+		// shared token "iron" (Iron (bisglycinate) then Iron). Severity cannot separate them, and the
+		// second row's note is a strict superset of the first's — the 55-character surplus is the
+		// sentence "The mechanism of interaction has not been established." — so the tie-break must
+		// keep the fuller note rather than the dataset's first row. The lengths the tie-break compares
+		// are 171 and 226: this row is the one mechanism in the fixture that #116 strips a residual
+		// INTERVAL: marker from, so the comparison reads the POST-strip text (236 before), which is
+		// why the expected value here is main's own DOLUTEGRAVIR_MECHANISM constant — the same
+		// stripped text, asserted whole rather than by prefix.
+		List<SafetyWarning> warnings = routeVariantValidator().validate(
+				"Dolutegravir could be started.", "Can I start dolutegravir?",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Iron 65mg"),
+						null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"the two iron rows must collapse to one chip, was: " + warnings);
+		assertEquals("Dolutegravir interacts with active order iron — Major. " + DOLUTEGRAVIR_MECHANISM,
+				warnings.get(0).getDetail(),
+				"the surviving chip must carry the fuller of the two equally-rated notes");
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
@@ -46,8 +46,8 @@ public class InteractionPartnerGroupingTest {
 	@Test
 	public void rowsWhoseTokensDifferOnlyInCaseOrWhitespaceNameOnePartnerAndRaiseOneChip() throws IOException {
 		// The fixture's two Fluconazole rows carry the tokens "Warfarin" and "  warfarin  ".
-		// PatientClinicalContext.hasActiveDrug folds a rule token with trim().toLowerCase() before
-		// matching it, so BOTH rows match the one Warfarin order — they are the same partner by the
+		// PatientClinicalContext.hasActiveDrug trims a rule token and matches it case-insensitively
+		// against the order name, so BOTH rows match the one Warfarin order — same partner by the
 		// only predicate that decides an interaction concerns this patient. The grouping key must
 		// fold the same way, or #115's duplicate chip comes straight back for a hand-authored
 		// dataset, silently and with two labels a clinician cannot tell apart. Asserted verbatim,

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
@@ -68,8 +68,9 @@ public class InteractionPartnerGroupingTest {
 	@Test
 	public void aHandAuthoredUnratedRowOutranksASourceRatedMajorRowForTheSamePartner() throws IOException {
 		// DrugSafetyValidator.severityPriority ranks an UNRATED rule above Major, deliberately:
-		// clearsSeverityFloor already exempts unrated rules from the floor because every curated
-		// hand-authored rule is unrated, and unrated is not low-rated. Since #115 that ordering also
+		// clearsSeverityFloor already exempts unrated rules from the floor because every rule in the
+		// bundled curated seed is unrated, and unrated is not low-rated. (A hand-authored file CAN
+		// rate a row — this fixture does, which is what makes the two comparable at all.) Since #115 that ordering also
 		// decides which chip a clinician sees, so an operator's own rule must not be dropped in
 		// favour of a source rating for the same partner. The fixture's rated row comes FIRST, so
 		// "keep the incumbent" fails here too.
@@ -90,11 +91,13 @@ public class InteractionPartnerGroupingTest {
 	public void theFullerNoteTieBreakMeasuresProseNotPadding() throws IOException {
 		// Severity cannot separate the fixture's two Linezolid rows, so the tie-break falls to the
 		// note — "the only informativeness signal a row carries". Whitespace is not that signal: the
-		// first row's note is a 79-character referral to a policy document with eleven newlines
-		// pasted onto the end (90 raw), the second is the 89-character mechanism. Measured raw, the
+		// SECOND row's note is a 79-character referral to a policy document with eleven newlines
+		// pasted onto the end (90 raw), the first is the 89-character mechanism. Measured raw, the
 		// referral wins and the clinician gets a chip that says nothing about serotonin syndrome
 		// while the row explaining it is discarded — decided by padding, which is exactly what the
-		// tie-break exists NOT to do.
+		// tie-break exists NOT to do. The winner being the FIRST row is deliberate: it also rules
+		// out "keep the last matching row", which passes every other case in this file because their
+		// intended winners all happen to sit last.
 		List<SafetyWarning> warnings = validator().validate("Linezolid could be started.",
 				"Is it safe to give linezolid?",
 				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Citalopram 20mg"),
@@ -106,5 +109,49 @@ public class InteractionPartnerGroupingTest {
 				+ " reversible MAO inhibitor and risks serotonin syndrome with an SSRI.",
 				warnings.get(0).getDetail(),
 				"the fuller note is the one carrying more PROSE, not the one carrying more whitespace");
+	}
+
+	@Test
+	public void rowsEqualOnSeverityAndOnNoteLengthKeepTheIncumbent() throws IOException {
+		// "Equal on both keeps the incumbent, so a group's chip is the dataset's first such row" is
+		// the last clause of the winner rule, and length cannot pin it while the two lengths differ.
+		// The fixture's two Amiodarone rows are both Moderate with 99-character notes saying
+		// different things, so only the incumbent rule decides — and a tie-break that replaced the
+		// incumbent on equality (a >= where the code has a >) would silently swap which of two
+		// equally-informative mechanisms the clinician reads.
+		List<SafetyWarning> warnings = validator().validate("Amiodarone could be started.",
+				"Is it safe to give amiodarone?",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Digoxin 125mcg"),
+						null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"two rows naming one partner must raise one chip, was: " + warnings);
+		assertEquals("Amiodarone interacts with active order digoxin — Moderate. Amiodarone reduces"
+				+ " digoxin clearance; halve the digoxin dose and check a level in a week.",
+				warnings.get(0).getDetail(),
+				"a full tie must keep the dataset's first row, not the last one seen");
+	}
+
+	@Test
+	public void rowsCarryingOnlyAnAtcCodeAreGroupedAndLabelledByThatCode() throws IOException {
+		// The partner label is the token ELSE the ATC code, and no shipped dataset exercises the
+		// second half: DDInter always derives a token, the WHO ATC source carries no rules at all,
+		// and all five bundled curated rules carry both fields. An operator's file need not — and
+		// hasActiveDrug matches on the ATC arm alone, after which the label is what the chip says AND
+		// what the group key is folded from. So `return getToken().trim()` would pass every other
+		// test in the repo and NPE here. The two Rivaroxaban rows carry the same code written
+		// " b01aa03 " and "B01AA03", which also pins that the fold applies to the ATC half; the two
+		// rows above them carry neither field and must simply match nothing rather than throw.
+		List<SafetyWarning> warnings = validator().validate("Rivaroxaban could be started.",
+				"Is it safe to start rivaroxaban?",
+				DrugReferenceTestSupport.ctx(60, null, null, DrugReferenceTestSupport.set("B01AA03"),
+						null, null));
+
+		assertEquals(1, warnings.size(),
+				"two rows naming one ATC-coded partner must raise one chip, was: " + warnings);
+		assertEquals("Rivaroxaban interacts with active order B01AA03 — Major. Do not co-prescribe two"
+				+ " oral anticoagulants outside a documented switching protocol.",
+				warnings.get(0).getDetail(),
+				"the chip must name the partner by its ATC code and carry the most severe row's note");
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
@@ -1,0 +1,87 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * How {@link DrugSafetyValidator} decides that two interaction rules name the <em>same</em>
+ * partner, and which of them keeps the chip — the two questions the one-chip-per-(drug, active
+ * order) collapse of issue #115 turns on, exercised on the source that can actually pose them.
+ *
+ * <p>The DDInter arm of #115 is covered by {@code DdiDrugReferenceSourceTest} against real KB
+ * slices. These cases need the <em>curated</em> source instead, because it is the operator-editable
+ * one: {@link JsonDrugReferenceSource} is plain Jackson over a hand-authored file, so unlike
+ * {@link DdiDrugReferenceSource} (which lower-cases and trims every match token it derives, and
+ * whose rows always carry a severity) it can hand the validator a partner token padded with
+ * whitespace, and a rule with no severity at all competing with a rated one. Both shapes reach
+ * decisions the clinician sees, and neither is expressible in a DDInter dataset.
+ *
+ * <p>Tests parse the fixture with the real {@link JsonDrugReferenceSource#parse} and drive the real
+ * {@link DrugSafetyValidator#validate(String, String, PatientClinicalContext)} — the exact
+ * production path an operator's extended dataset takes.
+ */
+public class InteractionPartnerGroupingTest {
+
+	private static final String FIXTURE = "chartsearchai-test/drug-reference-partner-label-variants.json";
+
+	private DrugSafetyValidator validator() throws IOException {
+		return DrugReferenceTestSupport.validator(
+				DrugReferenceTestSupport.serviceWith(DrugReferenceTestSupport.fixtureEntries(FIXTURE)));
+	}
+
+	@Test
+	public void rowsWhoseTokensDifferOnlyInCaseOrWhitespaceNameOnePartnerAndRaiseOneChip() throws IOException {
+		// The fixture's two Fluconazole rows carry the tokens "Warfarin" and "  warfarin  ".
+		// PatientClinicalContext.hasActiveDrug folds a rule token with trim().toLowerCase() before
+		// matching it, so BOTH rows match the one Warfarin order — they are the same partner by the
+		// only predicate that decides an interaction concerns this patient. The grouping key must
+		// fold the same way, or #115's duplicate chip comes straight back for a hand-authored
+		// dataset, silently and with two labels a clinician cannot tell apart. Asserted verbatim,
+		// so it also pins that the winning row's padding never reaches the chip text.
+		List<SafetyWarning> warnings = validator().validate("Fluconazole could be started.",
+				"Is it safe to give fluconazole?",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Warfarin 5mg"),
+						null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"two rows naming one partner in different case/whitespace must raise one chip, was: " + warnings);
+		assertEquals("Fluconazole interacts with active order warfarin — Major. Fluconazole markedly"
+				+ " increases warfarin exposure; monitor INR and adjust the warfarin dose.",
+				warnings.get(0).getDetail(),
+				"the surviving chip must carry the most severe row's note under a clean partner label");
+	}
+
+	@Test
+	public void aHandAuthoredUnratedRowOutranksASourceRatedMajorRowForTheSamePartner() throws IOException {
+		// DrugSafetyValidator.severityPriority ranks an UNRATED rule above Major, deliberately:
+		// clearsSeverityFloor already exempts unrated rules from the floor because every curated
+		// hand-authored rule is unrated, and unrated is not low-rated. Since #115 that ordering also
+		// decides which chip a clinician sees, so an operator's own rule must not be dropped in
+		// favour of a source rating for the same partner. The fixture's rated row comes FIRST, so
+		// "keep the incumbent" fails here too.
+		List<SafetyWarning> warnings = validator().validate("Phenobarbital could be added.",
+				"Is it safe to add phenobarbital?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Sodium valproate 500mg"), null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"two rows naming one partner must raise one chip, was: " + warnings);
+		assertEquals("Phenobarbital interacts with active order valproate — Locally curated rule: do"
+				+ " not co-prescribe without measuring the phenobarbital level first.",
+				warnings.get(0).getDetail(),
+				"the operator's unrated rule must keep the chip, not the source-rated Major row");
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
@@ -23,11 +23,12 @@ import org.junit.jupiter.api.Test;
  *
  * <p>The DDInter arm of #115 is covered by {@code DdiDrugReferenceSourceTest} against real KB
  * slices. These cases need the <em>curated</em> source instead, because it is the operator-editable
- * one: {@link JsonDrugReferenceSource} is plain Jackson over a hand-authored file, so unlike
- * {@link DdiDrugReferenceSource} (which lower-cases and trims every match token it derives, and
- * whose rows always carry a severity) it can hand the validator a partner token padded with
- * whitespace, and a rule with no severity at all competing with a rated one. Both shapes reach
- * decisions the clinician sees, and neither is expressible in a DDInter dataset.
+ * one: {@link JsonDrugReferenceSource} is plain Jackson over a hand-authored file and sanitizes
+ * nothing, where {@link DdiDrugReferenceSource} lower-cases every match token it derives (taking it
+ * from the trimmed RxNorm generic whenever the partner row has one) and rates every row it builds.
+ * So the three shapes below are the operator's to produce, not the KB's: a partner token padded with
+ * whitespace, two notes whose raw and trimmed lengths rank the rows oppositely, and a rule with no
+ * severity at all competing with a rated one. Each decides something the clinician sees.
  *
  * <p>Tests parse the fixture with the real {@link JsonDrugReferenceSource#parse} and drive the real
  * {@link DrugSafetyValidator#validate(String, String, PatientClinicalContext)} — the exact

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InteractionPartnerGroupingTest.java
@@ -84,4 +84,26 @@ public class InteractionPartnerGroupingTest {
 				warnings.get(0).getDetail(),
 				"the operator's unrated rule must keep the chip, not the source-rated Major row");
 	}
+
+	@Test
+	public void theFullerNoteTieBreakMeasuresProseNotPadding() throws IOException {
+		// Severity cannot separate the fixture's two Linezolid rows, so the tie-break falls to the
+		// note — "the only informativeness signal a row carries". Whitespace is not that signal: the
+		// first row's note is a 79-character referral to a policy document with eleven newlines
+		// pasted onto the end (90 raw), the second is the 89-character mechanism. Measured raw, the
+		// referral wins and the clinician gets a chip that says nothing about serotonin syndrome
+		// while the row explaining it is discarded — decided by padding, which is exactly what the
+		// tie-break exists NOT to do.
+		List<SafetyWarning> warnings = validator().validate("Linezolid could be started.",
+				"Is it safe to give linezolid?",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("Citalopram 20mg"),
+						null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"two rows naming one partner must raise one chip, was: " + warnings);
+		assertEquals("Linezolid interacts with active order citalopram — Major. Linezolid is a"
+				+ " reversible MAO inhibitor and risks serotonin syndrome with an SSRI.",
+				warnings.get(0).getDetail(),
+				"the fuller note is the one carrying more PROSE, not the one carrying more whitespace");
+	}
 }

--- a/api/src/test/resources/chartsearchai-test/ddi-route-variants.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-route-variants.json
@@ -1,0 +1,793 @@
+{
+ "metadata": {
+  "schema_version": "1.0",
+  "title": "Test fixture: DDInter variants sharing one rxnorm_name (issue #115)",
+  "note": "Three real slices of the full DDInter KB, each the induced subgraph over the named drugs, with their own mechanism texts and in dataset row order. (1) The four Dexamethasone route variants x Voxelotor: all four publish rxnorm_name \"dexamethasone\" and an identical ATC list, and Voxelotor carries a row against three of them at Major/Moderate/Moderate, so one active dexamethasone order matches every row; Phenytoin is a second Voxelotor partner sharing the Major row's mechanism group. (2) Sirolimus / Sirolimus (protein-bound) x Lapatinib: the strongest severity is the SECOND row, so keeping the first row is not the same as keeping the most severe. (3) Iron / Iron (bisglycinate) x Dolutegravir (the pair in the issue description): both Major, and the longer mechanism note is the SECOND row."
+ },
+ "mechanisms": {
+  "3758": {
+   "text": "Coadministration with potent inducers of CYP450 3A4 may significantly decrease the plasma concentrations of lapatinib, which is primarily metabolized by the isoenzyme.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "981": {
+   "text": "Coadministration with lapatinib may increase the plasma concentrations of drugs that are substrates of the CYP450 2C8 isoenzyme, CYP450 3A4 isoenzyme, and/or P-glycoprotein (P-gp) efflux transporter. The mechanism is decreased clearance via these routes due to inhibition by lapatinib.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "4680": {
+   "text": "Coadministration with inhibitors of CYP450 3A4 may increase the plasma concentrations of lapatinib, which is primarily metabolized by the isoenzyme.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "8505": {
+   "text": "Coadministration of protein-bound sirolimus intravenous suspension with moderate or weak inhibitors of CYP450 3A4 may increase the systemic exposure to sirolimus, which is primarily metabolized by the isoenzyme and also a substrate of the P-glycoprotein (P-gp) efflux transporter.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "4318": {
+   "text": "Coadministration with potent inducers of CYP450 3A4 and/or P-glycoprotein may significantly decrease the plasma concentrations and pharmacologic effects of sirolimus. The mechanism probably involves reduced absorption as well as accelerated clearance of sirolimus due to induction of both intestinal P-glycoprotein drug efflux transporter and hepatic/intestinal CYP450 3A4 isoenzymes.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "3595": {
+   "text": "Coadministration with potent or moderate inducers of CYP450 3A4 may significantly decrease the plasma concentrations and pharmacologic effects of voxelotor. The proposed mechanism is accelerated clearance of voxelotor due to induction of the CYP450 3A4 isoenzyme, which is the primary route of elimination of voxelotor.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "7071": {
+   "text": "Coadministration of protein-bound sirolimus intravenous suspension with potent inducers of CYP450 3A4 and/or P-glycoprotein (P-gp) may significantly decrease the systemic exposure to sirolimus, which is a known substrate for both the isoenzyme and efflux transporter.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "2280": {
+   "text": "Phenytoin and other hydantoins may induce the CYP450 3A4 hepatic metabolism of corticosteroids and increase their clearance and decrease their half-lives, possibly reducing their therapeutic efficacy.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "3062": {
+   "text": "Coadministration with potent inducers of UGT1A1 and CYP450 3A4 isoenzymes may significantly decrease the plasma concentrations of dolutegravir, which is primarily metabolized by UGT1A1 with some contribution from CYP450 3A4. Dolutegravir is also a substrate of UGT1A3, UGT1A9, and P-glycoprotein in vitro.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "3362": {
+   "text": "Coadministration with drugs that are inhibitors of CYP450 3A4 may increase the blood concentrations of the macrolide immunosuppressants sirolimus and tacrolimus, both of which are metabolized by the isoenzyme.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "4815": {
+   "text": "Coadministration with inducers of CYP450 3A4 may decrease the plasma concentrations of sirolimus and tacrolimus, both of which are primarily metabolized by the isoenzyme.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "3270": {
+   "text": "Coadministration with inhibitors of CYP450 3A4 may increase the plasma concentrations and pharmacologic effects of corticosteroids, which are primarily metabolized by the isoenzyme. The interaction has been reported with potent inhibitors such as clarithromycin, erythromycin, itraconazole, nefazodone, cobicistat, and ritonavir during concomitant use of various corticosteroids, including inhaled, nasal, and ophthalmic formulations. Systemic corticosteroid adverse effects may occur following intensive or long-term continuous ophthalmic corticosteroid therapy. Cushing's syndrome and adrenal insufficiency have been attributed to the interaction.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "8190": {
+   "text": "Coadministration of protein-bound sirolimus intravenous suspension with inducers of CYP450 3A4 may decrease the systemic exposure to sirolimus, which is primarily metabolized by the isoenzyme and also a substrate of the P-glycoprotein (P-gp) efflux transporter.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "7199": {
+   "text": "Coadministration with medications containing polyvalent cations such as aluminum, calcium, iron, or magnesium may decrease the oral bioavailability of dolutegravir.",
+   "categories": [
+    "absorption"
+   ]
+  },
+  "1619": {
+   "text": "Coadministration with inducers of UGT1A and CYP450 3A4 isoenzymes may decrease the plasma concentrations of dolutegravir, which is primarily metabolized by UGT1A1 with some contribution from CYP450 3A4. Given the risk of reduced viral susceptibility and resistance development associated with subtherapeutic antiretroviral drug levels, caution may be advisable if dolutegravir is used in combination with mild or moderate UGT1A/CYP450 3A4 inducers.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "2248": {
+   "text": "INTERVAL: Coadministration with medications containing polyvalent cations such as aluminum, calcium, iron, or magnesium may decrease the oral bioavailability of dolutegravir. The mechanism of interaction has not been established.",
+   "categories": [
+    "absorption"
+   ]
+  }
+ },
+ "drugs": [
+  {
+   "id": "DDInter513",
+   "name": "Dexamethasone",
+   "rxcui": "3264",
+   "rxnorm_name": "dexamethasone",
+   "drugbank_id": "DB01234",
+   "atc": [
+    "A01AC02",
+    "C05AA09",
+    "D07AB19",
+    "D07XB05",
+    "D10AA03",
+    "H02AB02",
+    "R01AD03",
+    "S01BA01",
+    "S01CB01",
+    "S02BA06",
+    "S03BA01"
+   ],
+   "ciel": [
+    {
+     "code": "104317",
+     "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Ciprofloxacin / dexamethasone"
+    },
+    {
+     "code": "104422",
+     "uuid": "104422AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / hypromellose"
+    },
+    {
+     "code": "104423",
+     "uuid": "104423AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / lidocaine"
+    },
+    {
+     "code": "104424",
+     "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin"
+    },
+    {
+     "code": "104425",
+     "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin / polymyxin B"
+    },
+    {
+     "code": "104426",
+     "uuid": "104426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tobramycin"
+    },
+    {
+     "code": "104427",
+     "uuid": "104427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tramazoline"
+    },
+    {
+     "code": "168548",
+     "uuid": "f5c7c86c-2b95-42d4-95f2-6d9e8949f39e",
+     "name": "Dexamethasone / gentamicin"
+    },
+    {
+     "code": "170697",
+     "uuid": "d2a620d9-138d-4125-a84a-7ddbf3b2ee45",
+     "name": "Dexamethasone / framycetin"
+    },
+    {
+     "code": "74609",
+     "uuid": "74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone"
+    },
+    {
+     "code": "74610",
+     "uuid": "74610AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone acetate"
+    },
+    {
+     "code": "74612",
+     "uuid": "74612AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone isonicotinate"
+    },
+    {
+     "code": "74613",
+     "uuid": "74613AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone phosphate"
+    },
+    {
+     "code": "74614",
+     "uuid": "74614AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone sodium phosphate"
+    },
+    {
+     "code": "74615",
+     "uuid": "74615AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone trimethyl acetate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter514",
+   "name": "Dexamethasone (nasal)",
+   "rxcui": "3264",
+   "rxnorm_name": "dexamethasone",
+   "drugbank_id": "DB01234",
+   "atc": [
+    "A01AC02",
+    "C05AA09",
+    "D07AB19",
+    "D07XB05",
+    "D10AA03",
+    "H02AB02",
+    "R01AD03",
+    "S01BA01",
+    "S01CB01",
+    "S02BA06",
+    "S03BA01"
+   ],
+   "ciel": [
+    {
+     "code": "104317",
+     "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Ciprofloxacin / dexamethasone"
+    },
+    {
+     "code": "104422",
+     "uuid": "104422AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / hypromellose"
+    },
+    {
+     "code": "104423",
+     "uuid": "104423AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / lidocaine"
+    },
+    {
+     "code": "104424",
+     "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin"
+    },
+    {
+     "code": "104425",
+     "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin / polymyxin B"
+    },
+    {
+     "code": "104426",
+     "uuid": "104426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tobramycin"
+    },
+    {
+     "code": "104427",
+     "uuid": "104427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tramazoline"
+    },
+    {
+     "code": "168548",
+     "uuid": "f5c7c86c-2b95-42d4-95f2-6d9e8949f39e",
+     "name": "Dexamethasone / gentamicin"
+    },
+    {
+     "code": "170697",
+     "uuid": "d2a620d9-138d-4125-a84a-7ddbf3b2ee45",
+     "name": "Dexamethasone / framycetin"
+    },
+    {
+     "code": "74609",
+     "uuid": "74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone"
+    },
+    {
+     "code": "74610",
+     "uuid": "74610AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone acetate"
+    },
+    {
+     "code": "74612",
+     "uuid": "74612AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone isonicotinate"
+    },
+    {
+     "code": "74613",
+     "uuid": "74613AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone phosphate"
+    },
+    {
+     "code": "74614",
+     "uuid": "74614AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone sodium phosphate"
+    },
+    {
+     "code": "74615",
+     "uuid": "74615AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone trimethyl acetate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter515",
+   "name": "Dexamethasone (ophthalmic)",
+   "rxcui": "3264",
+   "rxnorm_name": "dexamethasone",
+   "drugbank_id": "DB01234",
+   "atc": [
+    "A01AC02",
+    "C05AA09",
+    "D07AB19",
+    "D07XB05",
+    "D10AA03",
+    "H02AB02",
+    "R01AD03",
+    "S01BA01",
+    "S01CB01",
+    "S02BA06",
+    "S03BA01"
+   ],
+   "ciel": [
+    {
+     "code": "104317",
+     "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Ciprofloxacin / dexamethasone"
+    },
+    {
+     "code": "104422",
+     "uuid": "104422AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / hypromellose"
+    },
+    {
+     "code": "104423",
+     "uuid": "104423AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / lidocaine"
+    },
+    {
+     "code": "104424",
+     "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin"
+    },
+    {
+     "code": "104425",
+     "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin / polymyxin B"
+    },
+    {
+     "code": "104426",
+     "uuid": "104426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tobramycin"
+    },
+    {
+     "code": "104427",
+     "uuid": "104427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tramazoline"
+    },
+    {
+     "code": "168548",
+     "uuid": "f5c7c86c-2b95-42d4-95f2-6d9e8949f39e",
+     "name": "Dexamethasone / gentamicin"
+    },
+    {
+     "code": "170697",
+     "uuid": "d2a620d9-138d-4125-a84a-7ddbf3b2ee45",
+     "name": "Dexamethasone / framycetin"
+    },
+    {
+     "code": "74609",
+     "uuid": "74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone"
+    },
+    {
+     "code": "74610",
+     "uuid": "74610AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone acetate"
+    },
+    {
+     "code": "74612",
+     "uuid": "74612AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone isonicotinate"
+    },
+    {
+     "code": "74613",
+     "uuid": "74613AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone phosphate"
+    },
+    {
+     "code": "74614",
+     "uuid": "74614AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone sodium phosphate"
+    },
+    {
+     "code": "74615",
+     "uuid": "74615AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone trimethyl acetate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter516",
+   "name": "Dexamethasone (topical)",
+   "rxcui": "3264",
+   "rxnorm_name": "dexamethasone",
+   "drugbank_id": "DB01234",
+   "atc": [
+    "A01AC02",
+    "C05AA09",
+    "D07AB19",
+    "D07XB05",
+    "D10AA03",
+    "H02AB02",
+    "R01AD03",
+    "S01BA01",
+    "S01CB01",
+    "S02BA06",
+    "S03BA01"
+   ],
+   "ciel": [
+    {
+     "code": "104317",
+     "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Ciprofloxacin / dexamethasone"
+    },
+    {
+     "code": "104422",
+     "uuid": "104422AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / hypromellose"
+    },
+    {
+     "code": "104423",
+     "uuid": "104423AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / lidocaine"
+    },
+    {
+     "code": "104424",
+     "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin"
+    },
+    {
+     "code": "104425",
+     "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / neomycin / polymyxin B"
+    },
+    {
+     "code": "104426",
+     "uuid": "104426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tobramycin"
+    },
+    {
+     "code": "104427",
+     "uuid": "104427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone / tramazoline"
+    },
+    {
+     "code": "168548",
+     "uuid": "f5c7c86c-2b95-42d4-95f2-6d9e8949f39e",
+     "name": "Dexamethasone / gentamicin"
+    },
+    {
+     "code": "170697",
+     "uuid": "d2a620d9-138d-4125-a84a-7ddbf3b2ee45",
+     "name": "Dexamethasone / framycetin"
+    },
+    {
+     "code": "74609",
+     "uuid": "74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone"
+    },
+    {
+     "code": "74610",
+     "uuid": "74610AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone acetate"
+    },
+    {
+     "code": "74612",
+     "uuid": "74612AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone isonicotinate"
+    },
+    {
+     "code": "74613",
+     "uuid": "74613AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone phosphate"
+    },
+    {
+     "code": "74614",
+     "uuid": "74614AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone sodium phosphate"
+    },
+    {
+     "code": "74615",
+     "uuid": "74615AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dexamethasone trimethyl acetate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1460",
+   "name": "Phenytoin",
+   "rxcui": "8183",
+   "rxnorm_name": "phenytoin",
+   "drugbank_id": "DB00252",
+   "atc": [
+    "N03AB02"
+   ],
+   "ciel": [
+    {
+     "code": "105152",
+     "uuid": "105152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Phenobarbital / phenytoin"
+    },
+    {
+     "code": "82023",
+     "uuid": "82023AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Phenytoin"
+    },
+    {
+     "code": "82024",
+     "uuid": "82024AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Phenytoin sodium"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1949",
+   "name": "Voxelotor",
+   "rxcui": "2265678",
+   "rxnorm_name": "voxelotor",
+   "drugbank_id": "DB14975",
+   "atc": [
+    "B06AX03"
+   ],
+   "ciel": [
+    {
+     "code": "167645",
+     "uuid": "de5159de-adc3-4e71-ba84-4b09396a54db",
+     "name": "Voxelotor"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1678",
+   "name": "Sirolimus",
+   "rxcui": "35302",
+   "rxnorm_name": "sirolimus",
+   "drugbank_id": "DB00877",
+   "atc": [
+    "L01EG04",
+    "L04AH01",
+    "S01XA23"
+   ],
+   "ciel": [
+    {
+     "code": "83983",
+     "uuid": "83983AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Sirolimus"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2041",
+   "name": "Sirolimus (protein-bound)",
+   "rxcui": "35302",
+   "rxnorm_name": "sirolimus",
+   "drugbank_id": null,
+   "atc": [
+    "L01EG04",
+    "L04AH01",
+    "S01XA23"
+   ],
+   "ciel": [
+    {
+     "code": "83983",
+     "uuid": "83983AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Sirolimus"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1024",
+   "name": "Lapatinib",
+   "rxcui": "480167",
+   "rxnorm_name": "lapatinib",
+   "drugbank_id": "DB01259",
+   "atc": [
+    "L01EH01"
+   ],
+   "ciel": [
+    {
+     "code": "167558",
+     "uuid": "6146d372-0b8a-4fc9-a9c4-f513067aeb01",
+     "name": "Lapatinib"
+    }
+   ]
+  },
+  {
+   "id": "DDInter975",
+   "name": "Iron",
+   "rxcui": "90176",
+   "rxnorm_name": "iron",
+   "drugbank_id": "DB01592",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "78218",
+     "uuid": "78218AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Iron"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2187",
+   "name": "Iron (bisglycinate)",
+   "rxcui": "90176",
+   "rxnorm_name": "iron",
+   "drugbank_id": "DB01592",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "78218",
+     "uuid": "78218AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Iron"
+    }
+   ]
+  },
+  {
+   "id": "DDInter582",
+   "name": "Dolutegravir",
+   "rxcui": "1433868",
+   "rxnorm_name": "dolutegravir",
+   "drugbank_id": "DB08930",
+   "atc": [
+    "J05AJ03"
+   ],
+   "ciel": [
+    {
+     "code": "165085",
+     "uuid": "165085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dolutegravir"
+    },
+    {
+     "code": "165606",
+     "uuid": "165606AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Abacavir / dolutegravir / lamivudine"
+    },
+    {
+     "code": "169361",
+     "uuid": "0af318f4-94a2-4dbe-9727-fb1d682e75fb",
+     "name": "Dolutegravir / lamivudine / tenofovir alafenamide"
+    },
+    {
+     "code": "170472",
+     "uuid": "72f7a185-3673-4499-a314-9487a715eabc",
+     "name": "Dolutegravir / lamivudine"
+    },
+    {
+     "code": "170548",
+     "uuid": "66e5599c-7424-4252-b357-6949b0a50459",
+     "name": "Dolutegravir / rilpivirine"
+    },
+    {
+     "code": "170670",
+     "uuid": "7e00083b-c345-4c2d-9b87-81be50eff8b1",
+     "name": "Dolutegravir / emtricitabine / tenofovir alafenamide"
+    },
+    {
+     "code": "170671",
+     "uuid": "b944c518-10b4-4a93-a928-d0e4d10a66e4",
+     "name": "Dolutegravir / lamivudine / tenofovir disoproxil"
+    }
+   ]
+  }
+ ],
+ "interactions": [
+  [
+   "DDInter1024",
+   "DDInter1460",
+   "Moderate",
+   "3758"
+  ],
+  [
+   "DDInter1024",
+   "DDInter1678",
+   "Moderate",
+   "981"
+  ],
+  [
+   "DDInter1024",
+   "DDInter1949",
+   "Moderate",
+   "4680"
+  ],
+  [
+   "DDInter1024",
+   "DDInter2041",
+   "Major",
+   "8505"
+  ],
+  [
+   "DDInter1024",
+   "DDInter513",
+   "Moderate",
+   "3758"
+  ],
+  [
+   "DDInter1460",
+   "DDInter1678",
+   "Major",
+   "4318"
+  ],
+  [
+   "DDInter1460",
+   "DDInter1949",
+   "Major",
+   "3595"
+  ],
+  [
+   "DDInter1460",
+   "DDInter2041",
+   "Major",
+   "7071"
+  ],
+  [
+   "DDInter1460",
+   "DDInter513",
+   "Moderate",
+   "2280"
+  ],
+  [
+   "DDInter1460",
+   "DDInter582",
+   "Major",
+   "3062"
+  ],
+  [
+   "DDInter1678",
+   "DDInter1949",
+   "Moderate",
+   "3362"
+  ],
+  [
+   "DDInter1678",
+   "DDInter513",
+   "Moderate",
+   "4815"
+  ],
+  [
+   "DDInter1949",
+   "DDInter2041",
+   "Major",
+   "8505"
+  ],
+  [
+   "DDInter1949",
+   "DDInter513",
+   "Major",
+   "3595"
+  ],
+  [
+   "DDInter1949",
+   "DDInter514",
+   "Moderate",
+   "3270"
+  ],
+  [
+   "DDInter1949",
+   "DDInter515",
+   "Moderate",
+   "3270"
+  ],
+  [
+   "DDInter2041",
+   "DDInter513",
+   "Moderate",
+   "8190"
+  ],
+  [
+   "DDInter2187",
+   "DDInter582",
+   "Major",
+   "7199"
+  ],
+  [
+   "DDInter513",
+   "DDInter582",
+   "Minor",
+   "1619"
+  ],
+  [
+   "DDInter582",
+   "DDInter975",
+   "Major",
+   "2248"
+  ]
+ ]
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-partner-label-variants.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-partner-label-variants.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "description": "Test fixture (issue #115): curated entries whose interaction rows name ONE partner twice. The curated source is the operator-editable one — plain Jackson over a hand-authored file, with no trimming of rule tokens or notes and no required severity — so it is the only source that can produce (a) two rows for one partner whose tokens differ only in case or in surrounding whitespace, which PatientClinicalContext.hasActiveDrug already folds to the same partner, (b) a hand-authored UNRATED row competing with a source-rated one, which is the mixed configuration in which DrugSafetyValidator.severityPriority's 'unrated outranks Major' ordering is observable at all, and (c) two equally-rated rows whose note LENGTHS order one way raw and the other way trimmed, which is what makes the fuller-note tie-break's measurement observable. The padding in (c) is written as \\n escapes rather than trailing spaces on purpose: invisible trailing whitespace in a fixture is one editor away from being stripped, which would leave the test passing while testing nothing. Parsed by the real JsonDrugReferenceSource parser.",
+  "description": "Test fixture (issue #115): curated entries whose interaction rows name ONE partner twice. The curated source is the operator-editable one — plain Jackson over a hand-authored file, with no trimming of rule tokens or notes, no required severity, and no required token — so it is the only source that can pose the questions the one-chip-per-partner collapse turns on: (a) two rows for one partner whose tokens differ only in case or in surrounding whitespace, which PatientClinicalContext.hasActiveDrug already folds to the same partner; (b) a hand-authored UNRATED row competing with a rated one, the mixed configuration in which DrugSafetyValidator.severityPriority's 'unrated outranks Major' ordering is observable at all; (c) two equally-rated rows whose note lengths order one way raw and the other way trimmed, which is what makes the fuller-note tie-break's measurement observable; (d) two equally-rated rows whose notes are the same LENGTH but different text, which is the only way to see that a full tie keeps the incumbent rather than the last row; and (e) rows carrying an ATC code but no token at all, which is the half of the partner label no shipped dataset exercises. The padding in (c) is written as \\n escapes rather than trailing spaces on purpose: invisible trailing whitespace in a fixture is one editor away from being stripped, which would leave the test passing while testing nothing. In (c) and (d) the intended winner is the FIRST row, so 'keep the last matching row' fails as well as 'measure the note raw'. Parsed by the real JsonDrugReferenceSource parser.",
   "entries": [
     {
       "id": "fluconazole-curated",
@@ -64,12 +64,64 @@
         {
           "token": "citalopram",
           "severity": "Major",
-          "note": "Major. Withhold per the local antimicrobial policy; see the pharmacy monograph.\n\n\n\n\n\n\n\n\n\n\n"
+          "note": "Major. Linezolid is a reversible MAO inhibitor and risks serotonin syndrome with an SSRI."
         },
         {
           "token": "citalopram",
           "severity": "Major",
-          "note": "Major. Linezolid is a reversible MAO inhibitor and risks serotonin syndrome with an SSRI."
+          "note": "Major. Withhold per the local antimicrobial policy; see the pharmacy monograph.\n\n\n\n\n\n\n\n\n\n\n"
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "amiodarone-curated",
+      "name": "Amiodarone",
+      "drugClass": "Class III antiarrhythmic",
+      "aliases": [
+        "amiodarone"
+      ],
+      "atcCodes": [
+        "C01BD01"
+      ],
+      "interactions": [
+        {
+          "token": "digoxin",
+          "severity": "Moderate",
+          "note": "Moderate. Amiodarone reduces digoxin clearance; halve the digoxin dose and check a level in a week."
+        },
+        {
+          "token": "digoxin",
+          "severity": "Moderate",
+          "note": "Moderate. Monitor for digoxin toxicity: nausea, visual halos and bradycardia in the first few days."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "rivaroxaban-curated",
+      "name": "Rivaroxaban",
+      "drugClass": "Direct factor Xa inhibitor",
+      "aliases": [
+        "rivaroxaban"
+      ],
+      "atcCodes": [
+        "B01AF01"
+      ],
+      "interactions": [
+        {},
+        {
+          "note": "An unmatchable stub: no token and no ATC, so it names no partner."
+        },
+        {
+          "atc": " b01aa03 ",
+          "severity": "Moderate",
+          "note": "Moderate. Overlapping anticoagulants raise bleeding risk; bridge deliberately, not by accident."
+        },
+        {
+          "atc": "B01AA03",
+          "severity": "Major",
+          "note": "Major. Do not co-prescribe two oral anticoagulants outside a documented switching protocol."
         }
       ],
       "source": "Test fixture"

--- a/api/src/test/resources/chartsearchai-test/drug-reference-partner-label-variants.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-partner-label-variants.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "description": "Test fixture (issue #115): curated entries whose interaction rows name ONE partner twice. The curated source is the operator-editable one — plain Jackson over a hand-authored file, with no trimming of rule tokens and no required severity — so it is the only source that can produce (a) two rows for one partner whose tokens differ only in case or in surrounding whitespace, which PatientClinicalContext.hasActiveDrug already folds to the same partner, and (b) a hand-authored UNRATED row competing with a source-rated one, which is the mixed configuration in which DrugSafetyValidator.severityPriority's 'unrated outranks Major' ordering is observable at all. Parsed by the real JsonDrugReferenceSource parser.",
+  "description": "Test fixture (issue #115): curated entries whose interaction rows name ONE partner twice. The curated source is the operator-editable one — plain Jackson over a hand-authored file, with no trimming of rule tokens or notes and no required severity — so it is the only source that can produce (a) two rows for one partner whose tokens differ only in case or in surrounding whitespace, which PatientClinicalContext.hasActiveDrug already folds to the same partner, (b) a hand-authored UNRATED row competing with a source-rated one, which is the mixed configuration in which DrugSafetyValidator.severityPriority's 'unrated outranks Major' ordering is observable at all, and (c) two equally-rated rows whose note LENGTHS order one way raw and the other way trimmed, which is what makes the fuller-note tie-break's measurement observable. The padding in (c) is written as \\n escapes rather than trailing spaces on purpose: invisible trailing whitespace in a fixture is one editor away from being stripped, which would leave the test passing while testing nothing. Parsed by the real JsonDrugReferenceSource parser.",
   "entries": [
     {
       "id": "fluconazole-curated",
@@ -46,6 +46,30 @@
         {
           "token": "valproate",
           "note": "Locally curated rule: do not co-prescribe without measuring the phenobarbital level first."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "linezolid-curated",
+      "name": "Linezolid",
+      "drugClass": "Oxazolidinone antibacterial",
+      "aliases": [
+        "linezolid"
+      ],
+      "atcCodes": [
+        "J01XX08"
+      ],
+      "interactions": [
+        {
+          "token": "citalopram",
+          "severity": "Major",
+          "note": "Major. Withhold per the local antimicrobial policy; see the pharmacy monograph.\n\n\n\n\n\n\n\n\n\n\n"
+        },
+        {
+          "token": "citalopram",
+          "severity": "Major",
+          "note": "Major. Linezolid is a reversible MAO inhibitor and risks serotonin syndrome with an SSRI."
         }
       ],
       "source": "Test fixture"

--- a/api/src/test/resources/chartsearchai-test/drug-reference-partner-label-variants.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-partner-label-variants.json
@@ -1,0 +1,54 @@
+{
+  "version": "1.0",
+  "description": "Test fixture (issue #115): curated entries whose interaction rows name ONE partner twice. The curated source is the operator-editable one — plain Jackson over a hand-authored file, with no trimming of rule tokens and no required severity — so it is the only source that can produce (a) two rows for one partner whose tokens differ only in case or in surrounding whitespace, which PatientClinicalContext.hasActiveDrug already folds to the same partner, and (b) a hand-authored UNRATED row competing with a source-rated one, which is the mixed configuration in which DrugSafetyValidator.severityPriority's 'unrated outranks Major' ordering is observable at all. Parsed by the real JsonDrugReferenceSource parser.",
+  "entries": [
+    {
+      "id": "fluconazole-curated",
+      "name": "Fluconazole",
+      "drugClass": "Triazole antifungal",
+      "aliases": [
+        "fluconazole"
+      ],
+      "atcCodes": [
+        "J02AC01"
+      ],
+      "interactions": [
+        {
+          "token": "Warfarin",
+          "severity": "Moderate",
+          "note": "Moderate. Fluconazole inhibits CYP2C9 and may increase the anticoagulant effect of warfarin."
+        },
+        {
+          "token": "  warfarin  ",
+          "severity": "Major",
+          "note": "Major. Fluconazole markedly increases warfarin exposure; monitor INR and adjust the warfarin dose."
+        }
+      ],
+      "source": "Test fixture"
+    },
+    {
+      "id": "phenobarbital-curated",
+      "name": "Phenobarbital",
+      "drugClass": "Barbiturate anticonvulsant",
+      "aliases": [
+        "phenobarbital",
+        "phenobarbitone"
+      ],
+      "atcCodes": [
+        "N03AA02"
+      ],
+      "interactions": [
+        {
+          "token": "valproate",
+          "severity": "Major",
+          "note": "Major. Valproate inhibits phenobarbital metabolism; phenobarbital concentrations and sedation may rise."
+        },
+        {
+          "token": "valproate",
+          "note": "Locally curated rule: do not co-prescribe without measuring the phenobarbital level first."
+        }
+      ],
+      "source": "Test fixture"
+    }
+  ]
+}


### PR DESCRIPTION
## The defect

DDInter carries one entry per **route variant**, and every variant of a drug publishes the same
`rxnorm_name`. `DdiDrugReferenceSource.interactionsFor` turns each variant's row into its own
interaction rule with that shared name as the match token, so **one** active order matches **all**
of them and `DrugSafetyValidator.addInteractions` raises a chip per row — N chips for one pair, at N
different severities.

Live on the 3.7.1 standalone (HEAD `13690b1`), Margaret King with one active order Dexamethasone
4mg, asked "Is it safe to give voxelotor?": **3 chips, Major + Moderate + Moderate**, and the two
Moderate details were byte-identical strings (the nasal and ophthalmic variants share a mechanism
group, so there was not even a severity difference to preserve between them). Because chips are also
injected as citable safety-finding records (`preAnswerFindings`, #110), each duplicate chip also
became a near-identical record in the prompt — `[121] [122] [123]`.

Scale, re-measured against the loaded 19 MB KB (2283 drugs / 295,184 rows) rather than taken from the
issue: **142** `rxnorm_name` values are shared by more than one entry, covering **332** entries;
**1004** question-drugs have a ≥3-row group for one partner token and **1876** have a ≥2-row group —
i.e. for 1876 of 2283 drugs there is some active drug that duplicates a chip. `SafetyWarning` has no
`equals`/`hashCode`, so nothing downstream can collapse them.

## Root cause

The rule arm iterates `ref.getInteractions()` and emits one `SafetyWarning` per matching row. It has
no notion of "these rows are about the same partner", and the shared `rxnorm_name` guarantees the
route variants' rows are indistinguishable to it: same token, same first ATC code (all four
dexamethasone variants publish an *identical* ATC list), often the same note.

## Which of the two designs, and why

The issue documents two fixes. I implemented **(1) dedup per (drug, active order), keeping the most
severe row**, at the validator.

(2) — matching the order's dose form/route to the right variant — is the more correct fix and I did
not attempt it, for two reasons beyond "harder":

- The information is not at this layer. `PatientClinicalContext` carries active-order **names** and
  **ATC codes**; there is no dose form or route on it, and ATC cannot discriminate the variants
  because all four publish the same code list. Resolving the variant means a new route vocabulary
  plus plumbing it through the context builder — a data-side project (belongs with
  openmrs-ddi-knowledge-base), not a validator change.
- Half-built, it fails in the **unsafe** direction: an order whose form string does not parse would
  silently drop a Major systemic interaction.

So (1), with the direction chosen deliberately: **most severe wins**. The route distinction is
clinically real (voxelotor is Major against systemic dexamethasone and Moderate against the nasal
and ophthalmic forms), so this is not a free collapse.

**Trade-off accepted, stated plainly:** a patient on a topical/ophthalmic form may now be shown the
systemic severity. Over-warning on a non-blocking advisory the clinician adjudicates is the fail-safe
direction; under-warning (picking Moderate in case the order is topical) would hide a real Major
interaction for the much more common systemic order. **Severity honesty is deferred** — making the
rating route-aware is the data-side half of #115 and is not in this PR.

## What changed

- `DrugSafetyValidator.bestRulePerPartner` (new, private): after the existing severity-floor filter
  and the active-order match, matched rules are grouped by **the label the chip actually renders**
  (`firstNonBlank(token, atc)`, case-folded) and one rule per group survives. Grouping on the
  rendered label means rules that would produce the same "interacts with active order X" subject
  collapse, while rules naming different partners each keep their chip — even when their note text is
  identical. Chip order is unchanged (first appearance in dataset order).
- Winner: highest severity; on a tie, the fuller mechanism note; on both equal, the incumbent. The
  note is the only informativeness signal a row carries — DDInter's "no mechanism description on
  file" fallback is shorter than any real mechanism paragraph, and in the equal-severity pair
  measured (dolutegravir × iron) the longer note is a strict superset of the shorter one, adding the
  dose-separation INTERVAL guidance.
- `DrugSafetyValidator.severityPriority` (new, package-private): the ordering in which an *unrated*
  rule sits above Major — previously encoded inline in `DrugReferenceInjector.InteractionNote`. Now
  one definition used by both the chip grouping and the injector's promoted-note ordering, so the two
  cannot drift into ranking the same pair of rules oppositely. `InteractionNote`'s constructor takes
  the severity string instead of a pre-computed rank; behaviour is identical.
- The **dataset is untouched**. Flattening the variants at parse time would destroy the per-variant
  severities that design (2) needs, so the collapse lives at the validator and a test pins that the
  parser still produces distinct entries at their own severities.

Not touched: `addClassInteractions`.

## Relationship to #88 / PR #89 (please read before merging either)

**This is not #88.** That defect is *cross-arm* — one chip from `addInteractions`, one from
`addClassInteractions`, for the same pair. These were two *rule-arm* chips.

I checked PR #89 ("Fold same-class explicit interactions into one chip"), which implements #88.
Three things a maintainer should know:

1. **#89 does not fix this defect.** Its correlation key is the *order's ATC code*, and that cannot
   separate route variants: all four dexamethasone entries publish an identical ATC list, so every
   variant's row carries the same `atc`. More concretely, in `addInteractionWarnings` (read at its head
   `83393f1`) a rule whose ATC is not among the patient's active-order codes falls to the name-only
   branch, which adds a warning per row with no grouping at all — and the live repro is exactly that
   shape: Margaret King's Dexamethasone order is concept 92, which carries no ATC mapping in this
   dictionary, so the match is purely the name token.
2. **Where #89 does collapse variants, it does so severity-blind.** For a patient whose order *does*
   carry the partner's ATC code, #89's `ruleByOrderCode` keeps the *first* row for that code
   (`if (!containsKey) put`). That would have picked whichever variant the dataset lists first, not
   the most severe — the thing this PR's `strongestSeverityWinsEvenWhenItIsNeitherTheFirstRowNorTheLongestNote`
   test exists to rule out.
3. **They compose, and there should be one collapse point, not two.** The two keys answer different
   questions: `bestRulePerPartner` decides *which rule row* survives for a partner; #89 decides
   *which arms* describe one order. Composed in that order they are complementary; kept as two
   independent mechanisms they are a maintenance trap. #89 is `CONFLICTING` against `main`
   independently of this PR — it is based on `83cc33e` and predates both #108 (which added the
   rule-arm severity floor and the `displayLabel()`-led standalone-sentence chip detail) and #110
   (which extracted `clearsSeverityFloor` and started injecting findings as records), and both of
   those commits changed the very method it rewrites. Its `addInteractionWarnings` carries no
   severity-floor check at all, so a straight rebase must also restore #84's floor.
   **Recommendation:** land this PR first, and when #89 is rebased have
   its rule-row loop iterate `bestRulePerPartner(ref, context, severityFloor)` instead of
   `ref.getInteractions()` and drop its own `ruleByOrderCode` first-wins `put`. That leaves one
   grouping mechanism, with severity-aware selection, feeding the cross-arm fold.

I did not base this branch on #89. My tests assert the current chip contract — the
`displayLabel()`-led standalone sentence (`"Voxelotor interacts with active order dexamethasone —
Major. …"`) and the severity floor — neither of which exists on #89's head, so building there would
have meant rebasing someone else's PR inside this one.

## Tests

New fixture `api/src/test/resources/chartsearchai-test/ddi-route-variants.json` — three **real**
slices of the full DDInter KB (each the induced subgraph over the named drugs, real mechanism texts,
dataset row order), parsed by the real production parser and driven through the real
`DrugSafetyValidator.validate(...)`:

| test | pins |
|---|---|
| `routeVariantsOfOneGenericParseAsDistinctEntriesKeepingPerVariantSeverities` | four Dexamethasone variants stay four entries, and Voxelotor keeps one row per variant at `Major/Moderate/Moderate` — the fix must not be a flattened dataset |
| `oneActiveOrderMatchingSeveralRouteVariantsRaisesOneChipAtTheHighestSeverity` | the live repro: one active dexamethasone order ⇒ **1** chip, and it is the Major one (was 3) |
| `differentPartnersKeepTheirOwnChipEvenWhenTheirNotesAreIdentical` | Voxelotor's Phenytoin row shares the Major dexamethasone row's mechanism group — same severity, same note string, different partner ⇒ still **2** chips (was 4) |
| `strongestSeverityWinsEvenWhenItIsNeitherTheFirstRowNorTheLongestNote` | Lapatinib × Sirolimus: the Major row is the *second* match and has the *shorter* note, so "keep the first" and "keep the longest" both fail here |
| `equalSeveritiesKeepTheRowCarryingTheFullerMechanismNote` | Dolutegravir × Iron (the pair in the issue description): two Major rows, the fuller note is second |

All four behaviour tests fail on `13690b1` (3, 4, 2 and 2 chips respectively) and pass with the fix;
the parser test passes on both, by design.

`mvn package` (api tests + omod tests): **API 667 + OMOD 53 = 720 run, 0 failures, 0 errors, 34
skipped** (the 34 skipped are the pre-existing LLM-requiring evals). Baseline on `13690b1` was 715;
this adds 5.

## Live standalone evidence

3.7.1 standalone, full 19 MB DDInter KB, `sourceFormat=ddinter`, `minInteractionSeverity=minor`,
`chartMode=fullChart`, local LLM. Full-JVM restart, retrieval proven alive (`hits>0`), warm control
fired before any capture. Chips are deterministic Java, so the assertions below are on chips; answer
prose is not reproducible on this box (`cache_prompt` KV reuse) and no claim is made from it.

Same patient, same question, same instance and same GPs in both directions. Margaret King's order was
re-confirmed active at the start of the pass, so a vanished chip cannot be a vanished order:

```
PRE-CHECK — Margaret King's active drug orders
    drug orders: 1
       (NEW) Dexamethasone: 4.0 Milligram Oral Once daily | voided= False | stopped= None | expires= None
```

### Before — Margaret King + "Is it safe to give voxelotor?" (HEAD `13690b1`, the two runs in #115's comment)

```
safetyWarnings (3)
  [interaction] drug='Voxelotor'
      Voxelotor interacts with active order dexamethasone — Major. Coadministration with potent or
      moderate inducers of CYP450 3A4 may significantly decrease the plasma concentrations and
      pharmacologic effects of voxelotor. […]
  [interaction] drug='Voxelotor'
      Voxelotor interacts with active order dexamethasone — Moderate. Coadministration with
      inhibitors of CYP450 3A4 may increase the plasma concentrations and pharmacologic effects of
      corticosteroids […] Cushing's syndrome and adrenal insufficiency have been attributed to the
      interaction.
  [interaction] drug='Voxelotor'
      Voxelotor interacts with active order dexamethasone — Moderate. Coadministration with
      inhibitors of CYP450 3A4 may increase the plasma concentrations and pharmacologic effects of
      corticosteroids […] Cushing's syndrome and adrenal insufficiency have been attributed to the
      interaction.

chip2.detail == chip3.detail  ->  True
run 1: references [(2,'condition','chart'), (121,'safety_finding'), (122,'safety_finding'), (123,'safety_finding')]
       safety_finding records: 3   answer 1919 chars   inline markers {121:1, 122:9, 123:8, 2:5}
run 2: references [(2,'condition','chart'), (121,'safety_finding'), (122,'safety_finding'), (123,'safety_finding')]
       safety_finding records: 3   answer 1975 chars   inline markers {121:2, 122:10, 123:14, 2:3}
```

### After — this build (verbatim from the capture; both runs identical on chips)

```
--- Margaret King + "Is it safe to give voxelotor?" [i115-vox-1] chips=1
    [interaction] drug='Voxelotor'
        Voxelotor interacts with active order dexamethasone — Major. Coadministration with potent or moderate inducers of CYP450 3A4 may significantly decrease the plasma concentrations and pharmacologic effects of voxelotor. The proposed mechanism is accelerated clearance of voxelotor due to induction of the CYP450 3A4 isoenzyme, which is the primary route of elimination of voxelotor.
    references: [(121, 'safety_finding', 'reference', True), (120, 'drug_reference', 'reference', None)]
    safety_finding records: 1
    answer chars: 452   inline markers: {'121': 1, '120': 1}
--- Margaret King + "Is it safe to give voxelotor?" [i115-vox-2] chips=1
    [interaction] drug='Voxelotor'
        Voxelotor interacts with active order dexamethasone — Major. Coadministration with potent or moderate inducers of CYP450 3A4 may significantly decrease the plasma concentrations and pharmacologic effects of voxelotor. The proposed mechanism is accelerated clearance of voxelotor due to induction of the CYP450 3A4 isoenzyme, which is the primary route of elimination of voxelotor.
    references: [(121, 'safety_finding', 'reference', False), (120, 'drug_reference', 'reference', None)]
    safety_finding records: 1
    answer chars: 626   inline markers: {'121': 1, '120': 1}
```

**3 chips → 1, and it is the Major one.** The chip that survived is byte-identical to the Major chip
from the before-capture, so nothing was reworded — two rows were dropped. Both runs agree, which is
the confirmation the brief asks for before believing a chip disappeared. The duplicate
`safety_finding` records went with them: 3 → 1.

### Regression controls — all four from the brief, same pass, same build

```
--- CONTROL Mary + clarithromycin (expect 1 Major x simvastatin) [i115-c1] chips=1
    [interaction] drug='Clarithromycin'
        Clarithromycin interacts with active order simvastatin — Major. Coadministration with potent inhibitors of CYP450 3A4 may significantly increase the plasma concentrations of simvastatin and lovastatin […]
--- CONTROL Agnes + warfarin (expect 1 Major x aspirin) [i115-c2] chips=1
    [interaction] drug='Warfarin'
        Warfarin interacts with active order aspirin — Major. Aspirin, even in small doses, may increase the risk of bleeding in patients on oral anticoagulants […]
--- CONTROL Joshua + ibuprofen (expect 2 chips) [i115-c3] chips=2
    [contraindication] drug='Ibuprofen'
        Ibuprofen is in the same cross-reactivity group (NSAID) as the patient's allergy to Acetylsalicylic acid (aspirin) — possible cross-reactivity
    [interaction] drug='Ibuprofen'
        Ibuprofen interacts with active order lisinopril — Moderate. Nonsteroidal anti-inflammatory drugs (NSAIDs) may attenuate the antihypertensive effects of ACE inhibitors […]
--- CONTROL Mary + paracetamol (expect 0 chips) [i115-c4] chips=0

13/13 checks passed
```

(Mechanism prose elided at `[…]` for length only; the chips are otherwise verbatim.)

### On the citation spraying #115's comment reported — observed, not claimed

The comment noted that the duplicate records induced marker spraying (`[122]`×9, `[123]`×8, plus five
`[2]` markers pointing at an unrelated `condition` record). In both after-runs the answer came back at
452 and 626 chars with one marker per record (`{121:1, 120:1}`) and no `[2]`. That is consistent with
the duplicate records having been the cause, and it is the direction you would expect — but answer
prose is not reproducible on this box (`cache_prompt` KV reuse), n=2, so **this is an observation, not
a claim**. The deterministic part is what the chips and record set show: one finding record instead of
three near-identical ones.

Not fixed by this change, and still worth its own look: the grounding verdict on the single
deterministic finding record came back `grounded=True` on run 1 and `grounded=False` on run 2 — the
verifier is inconsistent about a module-generated line, which is finding #3 in #115's comment. It is
unrelated to the chip count and out of scope here.

## Notes / limits

- Test data on the standalone: Margaret King's Dexamethasone 4mg order was created for #115's
  reproduction (it is not part of the demo data set).
- `DrugReferenceInjector.orderedInteractionNotes` still renders one entry per variant row inside the
  drug-reference record's `Interactions:` section (e.g. "dexamethasone (Major …); dexamethasone
  (Moderate …); dexamethasone (Moderate …)"). That is prompt text, not a citable record, and the
  render budget there is a measured, settled area, so it is out of this PR's scope — reported, not
  fixed.
- The mirror-image shape is also still open and is **not** this defect: when the *question* names a
  generic shared by several entries ("Is it safe to give dexamethasone?" with the partner active),
  the four variants each enter play as their own reference drug and raise a chip apiece — measured 3
  chips through the real validator, but carrying *distinguishable* labels ("Dexamethasone",
  "Dexamethasone (nasal)", "Dexamethasone (ophthalmic)"), not duplicates. Collapsing those means
  choosing which variant the clinician meant — the same route vocabulary design (2) needs.
- Not attempted: `equals`/`hashCode` on `SafetyWarning`. Collapsing at the point of generation is the
  root-cause fix; a downstream `equals` would only have hidden the byte-identical pair and would have
  masked the differing-severity duplicates entirely.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
