### PR TITLE
fix(drug-safety): match interaction tokens by word start in order names (supersedes #87)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
@@ -175,7 +175,8 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 			DrugReference.Interaction i = new DrugReference.Interaction();
 			// Match on the RxNorm generic name (e.g. "aspirin", "acetaminophen") rather than the
 			// DDInter display name ("Acetylsalicylic acid"), since the validator matches this token
-			// as a substring of the order's display name; fall back to the display name.
+			// against the order's display name (by DrugReference.matchesOrderName, which needs the
+			// token to start a word of that name); fall back to the display name.
 			String token = p.rxnormName != null && !p.rxnormName.isEmpty() ? p.rxnormName : p.name;
 			i.setToken(token.toLowerCase(Locale.ROOT));
 			i.setAtc(p.atc.isEmpty() ? null : p.atc.get(0));

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -278,7 +278,7 @@ public class DrugReference {
 	 *         each side by a non-alphanumeric character or the string edge. Whole-word, not
 	 *         substring, so a drug name nested inside a longer one does not spuriously match
 	 *         ("chlorothiazide" is not a whole word in "hydrochlorothiazide"), while a real token
-	 *         still matches ("aspirin" in "Aspirin 81 mg"). Case-insensitive; a null/blank word
+	 *         still matches ("aspirin" in "Aspirin 81 mg"). Case-insensitive; a null or empty word
 	 *         never matches. Backs {@link #matchesText} (alias-in-prose); the active-order
 	 *         counterpart is {@link #matchesOrderName}, which shares this rule's left boundary but
 	 *         not its right one — see there for why one matcher cannot serve both.
@@ -353,9 +353,19 @@ public class DrugReference {
 	 * The one boundary-aware containment scan, shared by prose matching ({@link #containsWord}) and
 	 * order-name matching ({@link #matchesOrderName}) so the boundary rule cannot drift between
 	 * them. A match needs {@code token} to start at a word boundary in {@code text} and to end at
-	 * one, give or take up to {@code maxTrailingLetters} letters — never digits, which in a drug
-	 * name are a strength rather than part of the name. Case-insensitive; a null/blank token never
-	 * matches.
+	 * one, give or take up to {@code maxTrailingLetters} letters. Letters only: a digit is never an
+	 * inflection, so a digit sitting against the token is neither stepped over nor treated as the
+	 * end of the name, and a display name that glues its strength straight onto the drug name
+	 * ({@code Aspirin81mg}) therefore does not match. That shape does not occur in the measured
+	 * dictionary — of the 67 matches this rule drops relative to bare containment, 61 are a token
+	 * inside a longer word and 6 are tails longer than two letters, none is a glued digit — and
+	 * treating a digit as the end of the name instead scores identically over that corpus (829
+	 * either way), so the two are indistinguishable on real data and this is the conservative one.
+	 * Case-insensitive; a null or empty token never matches. Whitespace-only is the caller's
+	 * business, deliberately not this method's: {@link PatientClinicalContext#hasActiveDrug} trims
+	 * its token, and the {@code ddinter} and {@code atc} sources drop blank aliases at parse. A
+	 * hand-authored {@code json} KB is NOT sanitized, so a blank alias there still matches any text
+	 * carrying two adjacent spaces — pre-existing, and an authoring guard belongs in that parser.
 	 */
 	private static boolean containsBoundedToken(String text, String token, int maxTrailingLetters) {
 		if (text == null || token == null || token.isEmpty()) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -279,23 +279,104 @@ public class DrugReference {
 	 *         substring, so a drug name nested inside a longer one does not spuriously match
 	 *         ("chlorothiazide" is not a whole word in "hydrochlorothiazide"), while a real token
 	 *         still matches ("aspirin" in "Aspirin 81 mg"). Case-insensitive; a null/blank word
-	 *         never matches. This is the one matcher shared by {@link #matchesText}
-	 *         (alias-in-question) and {@link PatientClinicalContext#hasActiveDrug}
-	 *         (token-in-order-name), so the two cannot drift.
+	 *         never matches. Backs {@link #matchesText} (alias-in-prose); the active-order
+	 *         counterpart is {@link #matchesOrderName}, which shares this rule's left boundary but
+	 *         not its right one — see there for why one matcher cannot serve both.
 	 */
 	static boolean containsWord(String text, String word) {
-		if (text == null || word == null || word.isEmpty()) {
+		return containsBoundedToken(text, word, 0);
+	}
+
+	/**
+	 * How many trailing letters an active-order display name may carry past a matched drug token
+	 * before the token stops naming that drug. Two: a localized drug name suffixes the INN stem with
+	 * one inflectional ending — Romance singulars ({@code Aspirine}, {@code Aspirina},
+	 * {@code Ondansetrona}) and their plurals ({@code Multivitamines}) — while a longer tail is a
+	 * different substance ({@code Heparinoids}, {@code Multi-Vitamin Adult}). See
+	 * {@link #matchesOrderName} for the measurement behind the number.
+	 */
+	private static final int MAX_ORDER_NAME_INFLECTION_LETTERS = 2;
+
+	/**
+	 * Order-name matching: whether {@code token} — an interaction rule's drug token — names the drug
+	 * in a patient's active drug ORDER, whose {@code orderName} is one display name rather than
+	 * prose.
+	 *
+	 * <p>A bare containment test here reports drugs the patient has never taken, because drug names
+	 * nest: {@code "tiotropium".contains("opium")} and {@code "spironolactone".contains("iron")} are
+	 * both true, and both were raised as Major interaction chips on the 3.7.1 standalone (issue #86).
+	 * The discriminating half of the fix is the LEFT boundary shared with {@link #containsWord}: an
+	 * alphanumeric character immediately before the token means the token sits inside a longer word,
+	 * i.e. a different molecule — {@code tiotr|opium}, {@code sp|iron|olactone},
+	 * {@code nitro|glycerin}, {@code bud|esonide}, {@code hydro|chlorothiazide},
+	 * {@code cipr|ofloxacin}.
+	 *
+	 * <p>The right-hand side is where this deliberately differs from {@link #containsWord}, because
+	 * the two kinds of string differ: prose is words, an order name is one localized, inflected
+	 * display name with a dose appended. Measured over the 3.7.1 demo dictionary (2531 drug and
+	 * drug-concept names x the full KB's 2093 rule tokens), by tolerated trailing letters:
+	 *
+	 * <pre>
+	 *   rule                    matches   nested-name collisions leaking   what enters at this step
+	 *   contains (the defect)     896     9 of 9                           —
+	 *   symmetric boundary        761     0 of 9                           —
+	 *   left + &lt;=1 letter         828     0 of 9   67 localized spellings (Aspirine Co 81mg, Aspirina,
+	 *                                              Amoxicilline, Clarithromycine Co 500mg, Ondansetrona)
+	 *   left + &lt;=2 letters        829     0 of 9   1 localized plural (Multivitamines et fer)
+	 *   left + &lt;=3 letters        829     0 of 9   nothing
+	 *   left + &lt;=4 letters        834     0 of 9   5 FALSE positives (Heparinoids ~ heparin,
+	 *                                              Multi-Vitamin Adult ~ vitamin a)
+	 * </pre>
+	 *
+	 * A symmetric boundary would therefore stop checking a patient on {@code Aspirine Co 81mg} for
+	 * aspirin interactions at all — trading a false positive for a false NEGATIVE, the wrong
+	 * direction for a safety net, and one that looks exactly like the noise being removed. Two is the
+	 * far edge of the plateau where every legitimate name is matched and no false positive has yet
+	 * appeared; the first ones appear at four. Stopping at one (this issue's originally measured
+	 * recommendation) leaves exactly one legitimate name unmatched, {@code Multivitamines et fer},
+	 * whose reference entry carries 2 Major and 8 Moderate rules that would silently stop being
+	 * checked.
+	 *
+	 * <p>A bound on the tail, rather than a list of known inflections: stripping
+	 * {@code -e}/{@code -a}/{@code -o} from both sides was measured on the same corpus at 826
+	 * matches, a strict subset of this rule, and trades one bound for a per-language whitelist that a
+	 * differently-localized deployment falls off silently. Residual imprecision this rule keeps, for
+	 * the record: 2 of the 829 are a nitroglycerin order matching the token {@code glycerin} through
+	 * its own parenthetical synonym ("glycerine trinitrate") — a mislabel, not a fabricated drug, and
+	 * one every rule that tolerates an inflectional tail shares.
+	 */
+	static boolean matchesOrderName(String orderName, String token) {
+		return containsBoundedToken(orderName, token, MAX_ORDER_NAME_INFLECTION_LETTERS);
+	}
+
+	/**
+	 * The one boundary-aware containment scan, shared by prose matching ({@link #containsWord}) and
+	 * order-name matching ({@link #matchesOrderName}) so the boundary rule cannot drift between
+	 * them. A match needs {@code token} to start at a word boundary in {@code text} and to end at
+	 * one, give or take up to {@code maxTrailingLetters} letters — never digits, which in a drug
+	 * name are a strength rather than part of the name. Case-insensitive; a null/blank token never
+	 * matches.
+	 */
+	private static boolean containsBoundedToken(String text, String token, int maxTrailingLetters) {
+		if (text == null || token == null || token.isEmpty()) {
 			return false;
 		}
 		String t = text.toLowerCase(Locale.ROOT);
-		String w = word.toLowerCase(Locale.ROOT);
+		String w = token.toLowerCase(Locale.ROOT);
 		int idx = t.indexOf(w);
 		while (idx >= 0) {
-			boolean leftOk = idx == 0 || !Character.isLetterOrDigit(t.charAt(idx - 1));
-			int end = idx + w.length();
-			boolean rightOk = end >= t.length() || !Character.isLetterOrDigit(t.charAt(end));
-			if (leftOk && rightOk) {
-				return true;
+			if (idx == 0 || !Character.isLetterOrDigit(t.charAt(idx - 1))) {
+				int end = idx + w.length();
+				for (int tail = 0; tail <= maxTrailingLetters; tail++) {
+					int at = end + tail;
+					// A tail character must itself be a letter to be stepped over.
+					if (tail > 0 && !Character.isLetter(t.charAt(at - 1))) {
+						break;
+					}
+					if (at >= t.length() || !Character.isLetterOrDigit(t.charAt(at))) {
+						return true;
+					}
+				}
 			}
 			idx = t.indexOf(w, idx + 1);
 		}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -266,20 +266,38 @@ public class DrugReference {
 			return false;
 		}
 		for (String alias : aliases) {
-			if (alias == null || alias.isEmpty()) {
-				continue;
+			if (containsWord(lowerText, alias)) {
+				return true;
 			}
-			String a = alias.toLowerCase(Locale.ROOT);
-			int idx = lowerText.indexOf(a);
-			while (idx >= 0) {
-				boolean leftOk = idx == 0 || !Character.isLetterOrDigit(lowerText.charAt(idx - 1));
-				int end = idx + a.length();
-				boolean rightOk = end >= lowerText.length() || !Character.isLetterOrDigit(lowerText.charAt(end));
-				if (leftOk && rightOk) {
-					return true;
-				}
-				idx = lowerText.indexOf(a, idx + 1);
+		}
+		return false;
+	}
+
+	/**
+	 * @return true when {@code word} occurs in {@code text} as a <em>whole word</em> — bounded on
+	 *         each side by a non-alphanumeric character or the string edge. Whole-word, not
+	 *         substring, so a drug name nested inside a longer one does not spuriously match
+	 *         ("chlorothiazide" is not a whole word in "hydrochlorothiazide"), while a real token
+	 *         still matches ("aspirin" in "Aspirin 81 mg"). Case-insensitive; a null/blank word
+	 *         never matches. This is the one matcher shared by {@link #matchesText}
+	 *         (alias-in-question) and {@link PatientClinicalContext#hasActiveDrug}
+	 *         (token-in-order-name), so the two cannot drift.
+	 */
+	static boolean containsWord(String text, String word) {
+		if (text == null || word == null || word.isEmpty()) {
+			return false;
+		}
+		String t = text.toLowerCase(Locale.ROOT);
+		String w = word.toLowerCase(Locale.ROOT);
+		int idx = t.indexOf(w);
+		while (idx >= 0) {
+			boolean leftOk = idx == 0 || !Character.isLetterOrDigit(t.charAt(idx - 1));
+			int end = idx + w.length();
+			boolean rightOk = end >= t.length() || !Character.isLetterOrDigit(t.charAt(end));
+			if (leftOk && rightOk) {
+				return true;
 			}
+			idx = t.indexOf(w, idx + 1);
 		}
 		return false;
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
@@ -144,6 +144,18 @@ public class PatientClinicalContext {
 		return containsToken(conditionTokens, token);
 	}
 
+	/**
+	 * Deliberately still bare containment, unlike the order-name arm above (issue #86): these
+	 * haystacks are free text — an allergen name plus its comments, a condition in the clinician's
+	 * own wording — where a curated rule is meant to match a fragment ({@code nsaid} inside "NSAID
+	 * class reaction", {@code peptic ulcer} inside "history of peptic ulcer disease"), so the
+	 * word-start rule would silently stop matching the rules that exist. The nesting risk is the
+	 * same in principle ({@code opium} against an allergen recorded as "Tiotropium") and wants its
+	 * own measurement over real allergy and condition text, not the order-name corpus that settled
+	 * #86. Exposure today is confined to hand-authored contraindication rules: neither the
+	 * {@code ddinter} nor the {@code atc} source emits any, and the class-based allergy arm resolves
+	 * allergens through {@link DrugReferenceService#lookupByToken}, which is already boundary-aware.
+	 */
 	private static boolean containsToken(Set<String> haystack, String token) {
 		if (token == null || token.trim().isEmpty()) {
 			return false;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
@@ -114,9 +114,11 @@ public class PatientClinicalContext {
 	/** @return true when any active-order name or ATC code matches the given interaction rule. */
 	boolean hasActiveDrug(String nameToken, String atcCode) {
 		if (nameToken != null && !nameToken.trim().isEmpty()) {
-			String n = nameToken.trim().toLowerCase(Locale.ROOT);
+			String n = nameToken.trim();
 			for (String drug : activeDrugNames) {
-				if (drug.contains(n)) {
+				// Whole-word, not substring: an interaction token that is a sub-token of a longer
+				// order name (e.g. "chlorothiazide" inside "hydrochlorothiazide") must not match.
+				if (DrugReference.containsWord(drug, n)) {
 					return true;
 				}
 			}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/PatientClinicalContext.java
@@ -111,14 +111,21 @@ public class PatientClinicalContext {
 		return conditionTokens;
 	}
 
-	/** @return true when any active-order name or ATC code matches the given interaction rule. */
+	/**
+	 * @return true when any active-order name or ATC code matches the given interaction rule. The
+	 *         name arm goes through {@link DrugReference#matchesOrderName} — not bare containment,
+	 *         which reported drugs the patient had never taken because drug names nest ("tiotropium"
+	 *         contains "opium"; issue #86), and not the prose rule either, because an order's display
+	 *         name is localized and inflected rather than prose (see there). Both callers — the chip
+	 *         decision in {@link DrugSafetyValidator} and the prompt-promotion predicate in
+	 *         {@link DrugReferenceInjector} — reach that rule only through here, which is what keeps
+	 *         the chips and the promoted prose agreeing about which orders a rule matches.
+	 */
 	boolean hasActiveDrug(String nameToken, String atcCode) {
 		if (nameToken != null && !nameToken.trim().isEmpty()) {
 			String n = nameToken.trim();
 			for (String drug : activeDrugNames) {
-				// Whole-word, not substring: an interaction token that is a sub-token of a longer
-				// order name (e.g. "chlorothiazide" inside "hydrochlorothiazide") must not match.
-				if (DrugReference.containsWord(drug, n)) {
+				if (DrugReference.matchesOrderName(drug, n)) {
 					return true;
 				}
 			}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
@@ -130,7 +130,8 @@ public class DdiDrugReferenceSourceTest {
 	@Test
 	public void interactionFiresAgainstOrderNamedByGenericName() {
 		// Warfarin's DDInter partner "Acetylsalicylic acid" must fire against an order named
-		// "Aspirin" — the token is the generic "aspirin", matched as a substring of the order name.
+		// "Aspirin" — the token is the generic "aspirin", matched against the order name by word
+		// start (DrugReference.matchesOrderName, issue #86), not as a bare substring.
 		DrugSafetyValidator validator = DrugReferenceTestSupport.validator(DrugReferenceTestSupport.ddinterService());
 		List<SafetyWarning> warnings = validator.validate(
 				"Warfarin is a reasonable anticoagulant choice.",

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
@@ -212,7 +212,9 @@ public class DrugSafetyOrderNameMatchingTest {
 		// chips again, which is the defect issue #86 is about. Together with the localized-plural
 		// test above, this holds MAX_ORDER_NAME_INFLECTION_LETTERS in [2, 3] — no name in the
 		// measured corpus has a three-letter tail, so 2 versus 3 is not observable from real data
-		// and 2 is the value shipped.
+		// and 2 is the value shipped. The slice carries no salicylic-acid row, so "no warning at
+		// all" below is exactly "no heparin warning" — add one and the fix is a narrower assertion
+		// here, never a wider tail allowance.
 		DrugSafetyValidator validator = collisionValidator();
 		String question = "Is it safe to start warfarin?";
 		String answer = "Warfarin could be started with monitoring.";

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
@@ -1,0 +1,217 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The two directions {@link DrugReference#matchesOrderName} has to satisfy at once, on the real
+ * data that produced each of them. {@link HasActiveDrugWholeWordTest} pins the nested-name case
+ * this fix started from ("chlorothiazide" inside "hydrochlorothiazide"); this class pins the two
+ * live-reproduced fabrications that same nesting caused, and the localized order names that a
+ * symmetric word boundary would have silently stopped checking.
+ *
+ * <ul>
+ *   <li><b>Must not fire.</b> On the 3.7.1 standalone a patient on <b>Tiotropium</b> asked about
+ *       linezolid was told of an active <b>opium</b> order at Major severity, mechanism text and
+ *       all ("tiotr|opium"); a patient on <b>Spironolactone</b> asked about dolutegravir was told
+ *       of an active <b>iron</b> order, twice ("sp|iron|olactone"). Neither concept carries an ATC
+ *       mapping there, so the name arm alone produced both.</li>
+ *   <li><b>Must still fire.</b> This deployment's dictionary is multilingual —
+ *       {@code Aspirine Co 81mg}, {@code Aspirina}, {@code Clarithromycine Co 500mg},
+ *       {@code Simvastatine}, {@code Multivitamines et fer} are all real rows in it. Requiring a
+ *       symmetric boundary drops 135 of containment's 896 matches over that dictionary, and 68 of
+ *       the dropped are localized spellings of the very token being matched, so those patients
+ *       would silently stop being checked for interactions — a false negative dressed as noise
+ *       removal.</li>
+ * </ul>
+ *
+ * <p>Every scenario runs the real pipeline: real datasets parsed by the real sources, the real
+ * {@link DrugSafetyValidator#validate(String, String, PatientClinicalContext)}, GP reads on their
+ * no-context defaults (so the severity floor is the production {@code minor}). Each negative is
+ * paired with the positive that proves the rule it must not fire on is live, so nothing here can
+ * pass by resolving nothing.
+ */
+public class DrugSafetyOrderNameMatchingTest {
+
+	/**
+	 * A verbatim slice of the full DDInter KB (2283 drugs / 295,184 rows) carrying the rows behind
+	 * the live-reproduced collisions — linezolid x opium, dolutegravir x iron — and the
+	 * multivitamin x warfarin row the localized plural must still match. The bundled 16-drug sample
+	 * contains none of those drugs, so it cannot express any of this (same reason
+	 * {@code ddi-severity-floor-pair.json} exists).
+	 */
+	private static final String COLLISION_SLICE = "chartsearchai-test/ddi-order-name-collisions.json";
+
+	private DrugSafetyValidator collisionValidator() throws IOException {
+		try (InputStream in = DrugSafetyOrderNameMatchingTest.class.getClassLoader()
+				.getResourceAsStream(COLLISION_SLICE)) {
+			assertNotNull(in, COLLISION_SLICE + " should be on the test classpath");
+			return DrugReferenceTestSupport
+					.validator(DrugReferenceTestSupport.serviceWith(DdiDrugReferenceSource.parse(in)));
+		}
+	}
+
+	/** A validator over the real bundled DDInter sample, parsed by the real source. */
+	private DrugSafetyValidator bundledValidator() {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.ddinterService());
+	}
+
+	/**
+	 * The context shape the production builder assembles for the live probe patients: active-order
+	 * display names, no ATC codes. Deliberately no ATC — the collisions reproduced on concepts with
+	 * no ATC mapping, so the name arm is the only thing that can raise a chip here; an ATC-fed
+	 * context would let the class arm mask what is being measured.
+	 */
+	private PatientClinicalContext onOrders(String... orderNames) {
+		return DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set(orderNames), null,
+				null, null);
+	}
+
+	@Test
+	public void anInhaledTiotropiumOrderIsNotReportedAsAnActiveOpiumOrder() throws IOException {
+		DrugSafetyValidator validator = collisionValidator();
+		String question = "Is it safe to give linezolid?";
+		String answer = "Linezolid could be considered for this infection.";
+
+		// "Opium tincture" is one of this KB row's own CIEL concept names.
+		List<SafetyWarning> onOpium = validator.validate(answer, question, onOrders("Opium tincture"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onOpium, SafetyWarning.TYPE_INTERACTION,
+				"Linezolid", "active order opium", "Major"),
+				"precondition: a patient actually on opium must get the real linezolid x opium Major "
+						+ "chip, else this proves nothing, was: " + onOpium);
+
+		// Susan Young's live context: the order's concept name is the bare "Tiotropium" (no drug
+		// row on that order), and linezolid x tiotropium is an Unknown-severity row the floor
+		// filters — so ANY warning here is about a drug she is not on.
+		List<SafetyWarning> onTiotropium = validator.validate(answer, question, onOrders("Tiotropium"));
+		assertTrue(onTiotropium.isEmpty(),
+				"an inhaled tiotropium order must not be reported as an active opium order "
+						+ "(\"tiotr|opium\"), was: " + onTiotropium);
+	}
+
+	@Test
+	public void aSpironolactoneOrderIsNotReportedAsAnActiveIronOrder() throws IOException {
+		DrugSafetyValidator validator = collisionValidator();
+		String question = "Can I start dolutegravir?";
+		String answer = "Dolutegravir could be started.";
+
+		// "Iron IR 325mg" is a real drug row in this deployment's dictionary.
+		List<SafetyWarning> onIron = validator.validate(answer, question, onOrders("Iron IR 325mg"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onIron, SafetyWarning.TYPE_INTERACTION,
+				"Dolutegravir", "active order iron", "Major"),
+				"precondition: a patient actually on iron must get the real dolutegravir x iron Major "
+						+ "chip, else this proves nothing, was: " + onIron);
+
+		// Melissa Wright's live context: the bare concept name "Spironolactone", which contains
+		// "iron". The KB has no dolutegravir x spironolactone row at all, so nothing may fire.
+		List<SafetyWarning> onSpironolactone = validator.validate(answer, question,
+				onOrders("Spironolactone"));
+		assertTrue(onSpironolactone.isEmpty(),
+				"a spironolactone order must not be reported as an active iron order "
+						+ "(\"sp|iron|olactone\"), was: " + onSpironolactone);
+	}
+
+	@Test
+	public void localizedOrderNamesKeepBeingCheckedForInteractions() {
+		// Why this cannot be symmetric word matching. Every order name below is a real row in the
+		// 3.7.1 demo dictionary, which carries French and Spanish drug names throughout; under a
+		// symmetric boundary a patient on "Aspirine Co 81mg" stops being checked for aspirin
+		// interactions entirely, and the chip that disappears looks exactly like the noise this
+		// issue set out to remove.
+		DrugSafetyValidator validator = bundledValidator();
+		String warfarinQuestion = "Is it safe to start warfarin?";
+		String warfarinAnswer = "Warfarin could be started with monitoring.";
+		for (String orderName : new String[] { "Aspirine Co 81mg", "Aspirine", "Aspirina" }) {
+			List<SafetyWarning> warnings = validator.validate(warfarinAnswer, warfarinQuestion,
+					onOrders(orderName));
+			assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+					"Warfarin", "active order aspirin", "Major"),
+					"the Major warfarin x aspirin rule must still fire for the localized order name \""
+							+ orderName + "\", was: " + warnings);
+		}
+
+		List<SafetyWarning> onClarithromycine = validator.validate(
+				"Simvastatin could be continued.", "Is it safe to give her simvastatin?",
+				onOrders("Clarithromycine Co 500mg"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onClarithromycine,
+				SafetyWarning.TYPE_INTERACTION, "Simvastatin", "active order clarithromycin", "Major"),
+				"the Major simvastatin x clarithromycin rule must still fire for the French order name, "
+						+ "was: " + onClarithromycine);
+
+		List<SafetyWarning> onSimvastatine = validator.validate(
+				"Clarithromycin could be prescribed.", "Is it safe to give her clarithromycin?",
+				onOrders("Simvastatine"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onSimvastatine,
+				SafetyWarning.TYPE_INTERACTION, "Clarithromycin", "active order simvastatin", "Major"),
+				"the Major clarithromycin x simvastatin rule must still fire for the French order name, "
+						+ "was: " + onSimvastatine);
+	}
+
+	@Test
+	public void aLocalizedPluralOrderNameKeepsBeingCheckedForInteractions() throws IOException {
+		// The one legitimate name a single-letter tail allowance misses, so the bound is pinned at
+		// the value that matches it. "Multivitamines et fer" and "Multivitamin & Iron" are both real
+		// names of the same product in this dictionary (the French one as a concept name, the
+		// English one as a drug row), and the reference entry they name carries 2 Major and 8
+		// Moderate rules — including the vitamin-K versus oral-anticoagulant one below — that would
+		// otherwise stop being checked for a patient whose order shows the French spelling.
+		DrugSafetyValidator validator = collisionValidator();
+		String question = "Is it safe to start warfarin?";
+		String answer = "Warfarin could be started with monitoring.";
+
+		List<SafetyWarning> onEnglishName = validator.validate(answer, question,
+				onOrders("Multivitamin & Iron"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onEnglishName, SafetyWarning.TYPE_INTERACTION,
+				"Warfarin", "active order multivitamin", "Moderate"),
+				"precondition: the English spelling of the same product must raise the real "
+						+ "multivitamin x warfarin rule, else this proves nothing, was: " + onEnglishName);
+
+		List<SafetyWarning> onFrenchPlural = validator.validate(answer, question,
+				onOrders("Multivitamines et fer"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onFrenchPlural, SafetyWarning.TYPE_INTERACTION,
+				"Warfarin", "active order multivitamin", "Moderate"),
+				"the same rule must fire for the localized plural of the same product, was: "
+						+ onFrenchPlural);
+	}
+
+	@Test
+	public void plainOrderNamesWithADoseKeepBeingCheckedForInteractions() {
+		// The live regression controls, in the exact context shape the production builder assembles
+		// for those patients (drug row name plus order concept name).
+		DrugSafetyValidator validator = bundledValidator();
+
+		List<SafetyWarning> agnes = validator.validate("Warfarin could be started with monitoring.",
+				"Is it safe to start warfarin?", onOrders("Aspirin 81mg", "Acetylsalicylate sodium"));
+		assertTrue(DrugReferenceTestSupport.detailContains(agnes, SafetyWarning.TYPE_INTERACTION,
+				"Warfarin", "active order aspirin", "Major"),
+				"a dose-suffixed order name must still match its token, was: " + agnes);
+
+		List<SafetyWarning> mary = validator.validate("Clarithromycin could be prescribed.",
+				"Is it safe to give her clarithromycin?",
+				onOrders("Simvastatin Co 20mg", "Simvastatin"));
+		assertTrue(DrugReferenceTestSupport.detailContains(mary, SafetyWarning.TYPE_INTERACTION,
+				"Clarithromycin", "active order simvastatin", "Major"),
+				"a form-and-dose order name must still match its token, was: " + mary);
+
+		List<SafetyWarning> joshua = validator.validate("Ibuprofen could be considered for pain.",
+				"Can I give ibuprofen?", onOrders("Lisinopril 10 mg", "Lisinopril"));
+		assertTrue(DrugReferenceTestSupport.detailContains(joshua, SafetyWarning.TYPE_INTERACTION,
+				"Ibuprofen", "active order lisinopril", "Moderate"),
+				"the Moderate ibuprofen x lisinopril rule must still fire, was: " + joshua);
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
@@ -38,6 +38,18 @@ import org.junit.jupiter.api.Test;
  *       the dropped are localized spellings of the very token being matched, so those patients
  *       would silently stop being checked for interactions — a false negative dressed as noise
  *       removal.</li>
+ *   <li><b>Must not fire, at the far edge.</b> The trailing allowance those localized names need is
+ *       bounded, and the bound is pinned from both sides here: one letter short and
+ *       {@code Multivitamines et fer} stops being checked, two letters long and
+ *       {@code Heparinoids / salicylic acid} starts being read as heparin. Without the upper-edge
+ *       case a later widening of the constant reinstates exactly the fabricated Major chips this
+ *       class exists to prevent, and nothing fails.</li>
+ *   <li><b>Must not fire in prose.</b> The allowance belongs to order names alone;
+ *       {@link DrugReference#containsWord} keeps the symmetric boundary for prose. Collapsing the
+ *       two matchers into one is what made #87 unsafe, and it can be done in either direction —
+ *       the localized cases above catch a prose rule applied to order names, and this one catches
+ *       the order-name rule applied to prose, where "aspiring" would be read as a proposal of
+ *       aspirin.</li>
  * </ul>
  *
  * <p>Every scenario runs the real pipeline: real datasets parsed by the real sources, the real
@@ -187,6 +199,67 @@ public class DrugSafetyOrderNameMatchingTest {
 				"Warfarin", "active order multivitamin", "Moderate"),
 				"the same rule must fire for the localized plural of the same product, was: "
 						+ onFrenchPlural);
+	}
+
+	@Test
+	public void aLongerTailThanAnInflectionIsADifferentSubstance() throws IOException {
+		// The far edge of the same bound, so the constant is pinned from ABOVE as well as below.
+		// "Heparinoids / salicylic acid" is a real concept name in this deployment's dictionary
+		// (CIEL 104813, mapped to the salicylic-acid rows of the KB this fixture is sliced from) and
+		// it is NOT heparin — heparinoids are a separate DDInter drug. Its tail past the token is
+		// four letters, which is exactly where the measured curve turns: widening the allowance to 4
+		// re-admits this name (and "Multi-Vitamin Adult" ~ "vitamin a") and starts fabricating Major
+		// chips again, which is the defect issue #86 is about. Together with the localized-plural
+		// test above, this holds MAX_ORDER_NAME_INFLECTION_LETTERS in [2, 3] — no name in the
+		// measured corpus has a three-letter tail, so 2 versus 3 is not observable from real data
+		// and 2 is the value shipped.
+		DrugSafetyValidator validator = collisionValidator();
+		String question = "Is it safe to start warfarin?";
+		String answer = "Warfarin could be started with monitoring.";
+
+		List<SafetyWarning> onHeparin = validator.validate(answer, question,
+				onOrders("Heparin sodium 5000 units/mL"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onHeparin, SafetyWarning.TYPE_INTERACTION,
+				"Warfarin", "active order heparin", "Major"),
+				"precondition: a patient actually on heparin must get the real warfarin x heparin Major "
+						+ "chip, else this proves nothing, was: " + onHeparin);
+
+		List<SafetyWarning> onHeparinoids = validator.validate(answer, question,
+				onOrders("Heparinoids / salicylic acid"));
+		assertTrue(onHeparinoids.isEmpty(),
+				"a heparinoid order must not be reported as an active heparin order — four trailing "
+						+ "letters is a different substance, not an inflection, was: " + onHeparinoids);
+	}
+
+	@Test
+	public void anEnglishWordStartingWithADrugNameIsNotAProposalOfThatDrug() {
+		// The other way the two matchers can be collapsed into one: giving PROSE the order-name
+		// tail allowance. Prose is words, and an ordinary word that merely starts with a drug name
+		// is not that drug — measured over the full KB's 5169 aliases against the system word list,
+		// 22 of the single-word ones are one or two letters short of an English word (aspirin ~
+		// aspiring, warfarin ~ warfaring, urea ~ urease, iron ~ irony, clove ~ clover). The drugs
+		// a question or answer names are what the validator checks at all
+		// (DrugSafetyValidator.validate -> findByQuery -> matchesText), so a lenient prose rule does
+		// not mislabel an order — it invents the proposal the whole chip rests on. Widening
+		// containsWord to the order-name allowance passes every other test in this module, which is
+		// why this case exists.
+		DrugSafetyValidator validator = bundledValidator();
+		PatientClinicalContext onWarfarin = onOrders("Warfarin 5mg");
+
+		List<SafetyWarning> namingAspirin = validator.validate(
+				"Aspirin could be added for her cardiac risk.", "Is it safe to add aspirin?", onWarfarin);
+		assertTrue(DrugReferenceTestSupport.detailContains(namingAspirin, SafetyWarning.TYPE_INTERACTION,
+				"Acetylsalicylic acid (aspirin)", "active order warfarin", "Major"),
+				"precondition: naming aspirin must raise the real aspirin x warfarin Major chip for a "
+						+ "patient on warfarin, else this proves nothing, was: " + namingAspirin);
+
+		List<SafetyWarning> merelyAspiring = validator.validate(
+				"Encourage the training plan and keep her INR checks on schedule.",
+				"She is an aspiring marathon runner — any concerns with her current medicines?",
+				onWarfarin);
+		assertTrue(merelyAspiring.isEmpty(),
+				"\"aspiring\" must not put aspirin in play and fabricate a Major bleeding interaction "
+						+ "for a patient on warfarin, was: " + merelyAspiring);
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyOrderNameMatchingTest.java
@@ -62,10 +62,10 @@ public class DrugSafetyOrderNameMatchingTest {
 
 	/**
 	 * A verbatim slice of the full DDInter KB (2283 drugs / 295,184 rows) carrying the rows behind
-	 * the live-reproduced collisions — linezolid x opium, dolutegravir x iron — and the
-	 * multivitamin x warfarin row the localized plural must still match. The bundled 16-drug sample
-	 * contains none of those drugs, so it cannot express any of this (same reason
-	 * {@code ddi-severity-floor-pair.json} exists).
+	 * the live-reproduced collisions — linezolid x opium, dolutegravir x iron — the
+	 * multivitamin x warfarin row the localized plural must still match, and the warfarin x heparin
+	 * row the far-edge case needs. The bundled 16-drug sample contains none of those drugs, so it
+	 * cannot express any of this (same reason {@code ddi-severity-floor-pair.json} exists).
 	 */
 	private static final String COLLISION_SLICE = "chartsearchai-test/ddi-order-name-collisions.json";
 
@@ -205,16 +205,22 @@ public class DrugSafetyOrderNameMatchingTest {
 	public void aLongerTailThanAnInflectionIsADifferentSubstance() throws IOException {
 		// The far edge of the same bound, so the constant is pinned from ABOVE as well as below.
 		// "Heparinoids / salicylic acid" is a real concept name in this deployment's dictionary
-		// (CIEL 104813, mapped to the salicylic-acid rows of the KB this fixture is sliced from) and
-		// it is NOT heparin — heparinoids are a separate DDInter drug. Its tail past the token is
+		// (CIEL 104813; in the full KB it hangs off the three Salicylic acid rows and off nothing
+		// else, never off Heparin — the KB carries no heparinoid row at all, its class members are
+		// there under their own names, DDInter471 Danaparoid and DDInter1424 Pentosan
+		// polysulfate). A heparinoid
+		// is not heparin, so reading that order as an active heparin order fabricates a drug the
+		// patient is not on, which is this issue's defect. Its tail past the token is
 		// four letters, which is exactly where the measured curve turns: widening the allowance to 4
 		// re-admits this name (and "Multi-Vitamin Adult" ~ "vitamin a") and starts fabricating Major
 		// chips again, which is the defect issue #86 is about. Together with the localized-plural
 		// test above, this holds MAX_ORDER_NAME_INFLECTION_LETTERS in [2, 3] — no name in the
 		// measured corpus has a three-letter tail, so 2 versus 3 is not observable from real data
-		// and 2 is the value shipped. The slice carries no salicylic-acid row, so "no warning at
-		// all" below is exactly "no heparin warning" — add one and the fix is a narrower assertion
-		// here, never a wider tail allowance.
+		// and 2 is the value shipped. The assertion below can be "no warning at all" because the
+		// slice carries no salicylic-acid row, which makes it exactly "no heparin warning" — read it
+		// as fixture-scoped: against the full KB that same order legitimately matches the token
+		// "salicylic acid" (Moderate x warfarin, past the "/" word boundary). Add that row and the
+		// fix is a narrower assertion here, never a wider tail allowance.
 		DrugSafetyValidator validator = collisionValidator();
 		String question = "Is it safe to start warfarin?";
 		String answer = "Warfarin could be started with monitoring.";
@@ -237,12 +243,12 @@ public class DrugSafetyOrderNameMatchingTest {
 	public void anEnglishWordStartingWithADrugNameIsNotAProposalOfThatDrug() {
 		// The other way the two matchers can be collapsed into one: giving PROSE the order-name
 		// tail allowance. Prose is words, and an ordinary word that merely starts with a drug name
-		// is not that drug — measured over the full KB's 5169 aliases against the system word list,
-		// 22 of the single-word ones are one or two letters short of an English word (aspirin ~
-		// aspiring, warfarin ~ warfaring, urea ~ urease, iron ~ irony, clove ~ clover). The drugs
-		// a question or answer names are what the validator checks at all
-		// (DrugSafetyValidator.validate -> findByQuery -> matchesText), so a lenient prose rule does
-		// not mislabel an order — it invents the proposal the whole chip rests on. Widening
+		// is not that drug — measured over the full KB's 5169 aliases against the system word list
+		// (/usr/share/dict/words, 235,976 entries), 22 of the single-word ones are one or two letters
+		// short of an English word (aspirin ~ aspiring, warfarin ~ warfaring, urea ~ urease, iron ~
+		// irony, clove ~ clover). The drugs a question or answer names are what the validator checks
+		// at all (DrugSafetyValidator.validate -> findByQuery -> matchesText), so a lenient prose
+		// rule does not mislabel an order — it invents the proposal the whole chip rests on. Widening
 		// containsWord to the order-name allowance passes every other test in this module, which is
 		// why this case exists.
 		DrugSafetyValidator validator = bundledValidator();

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
@@ -67,4 +67,22 @@ public class HasActiveDrugWholeWordTest {
 		assertEquals(1, interactionCount(warnings, "Ibuprofen"),
 				"the whole-word token should match within a dose/form-qualified order name");
 	}
+
+	@Test
+	public void theNestedShorterDrugStillFiresOnItsOwnOrder() throws Exception {
+		// The other side of the same nested pair, so the fix is de-duplication and not suppression of
+		// the shorter name: a chlorothiazide order must still raise chlorothiazide's own rule. Without
+		// this, a matcher that simply never matched the shorter token would pass the two tests above.
+		List<SafetyWarning> warnings = validatorOverFixture().validate(
+				"Ibuprofen is a reasonable analgesic choice.",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("chlorothiazide 500 mg"),
+						null, null, null));
+
+		assertEquals(1, interactionCount(warnings, "Ibuprofen"),
+				"exactly one interaction should fire (chlorothiazide), and the longer hydrochlorothiazide "
+						+ "token must not match a chlorothiazide order either");
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Ibuprofen", "chlorothiazide"),
+				"the fired interaction should name the drug actually on the chart");
+	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
@@ -19,9 +19,16 @@ import org.junit.jupiter.api.Test;
 /**
  * Exercises {@link PatientClinicalContext#hasActiveDrug} through the real
  * {@link DrugSafetyValidator} over a fixture whose drug names are substring-nested
- * ("chlorothiazide" ⊂ "hydrochlorothiazide"). The matcher must fire on whole-word
- * matches only: an interaction token that is merely a sub-token of a longer active-order
- * name must not raise a warning naming a drug the patient is not on.
+ * ("chlorothiazide" ⊂ "hydrochlorothiazide"). An interaction token that is merely a sub-token of a
+ * longer active-order name must not raise a warning naming a drug the patient is not on.
+ *
+ * <p>The discriminating rule is the LEFT word boundary, which is all these three cases need — the
+ * class name records the whole-word fix this file was written for (issue #86), not the rule that
+ * shipped. {@link DrugReference#matchesOrderName} additionally tolerates a bounded inflectional
+ * tail, because requiring a boundary on the RIGHT too stops a patient on {@code Aspirine Co 81mg}
+ * being checked for aspirin interactions at all. That half of the contract — and the bound on it —
+ * lives in {@link DrugSafetyOrderNameMatchingTest}; do not "restore" whole-word symmetry here
+ * without reading it first.
  */
 public class HasActiveDrugWholeWordTest {
 

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.chartsearchai.reference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -91,5 +92,9 @@ public class HasActiveDrugWholeWordTest {
 		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
 				"Ibuprofen", "chlorothiazide"),
 				"the fired interaction should name the drug actually on the chart");
+		assertFalse(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Ibuprofen", "hydrochlorothiazide"),
+				"\"chlorothiazide\" is itself a substring of \"hydrochlorothiazide\", so the needle above "
+						+ "cannot tell the two rules apart on its own — the longer one must be absent");
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/HasActiveDrugWholeWordTest.java
@@ -1,0 +1,70 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises {@link PatientClinicalContext#hasActiveDrug} through the real
+ * {@link DrugSafetyValidator} over a fixture whose drug names are substring-nested
+ * ("chlorothiazide" ⊂ "hydrochlorothiazide"). The matcher must fire on whole-word
+ * matches only: an interaction token that is merely a sub-token of a longer active-order
+ * name must not raise a warning naming a drug the patient is not on.
+ */
+public class HasActiveDrugWholeWordTest {
+
+	private static final String FIXTURE = "chartsearchai-test/drug-reference-substring-nested.json";
+
+	private DrugSafetyValidator validatorOverFixture() throws Exception {
+		return DrugReferenceTestSupport.validator(
+				DrugReferenceTestSupport.serviceWith(DrugReferenceTestSupport.fixtureEntries(FIXTURE)));
+	}
+
+	private long interactionCount(List<SafetyWarning> warnings, String drug) {
+		return warnings.stream()
+				.filter(w -> SafetyWarning.TYPE_INTERACTION.equals(w.getType())
+						&& drug.equalsIgnoreCase(w.getDrug()))
+				.count();
+	}
+
+	@Test
+	public void subtokenOfLongerOrderNameDoesNotFire() throws Exception {
+		// Patient is on hydrochlorothiazide; ibuprofen interacts with BOTH hydrochlorothiazide and
+		// chlorothiazide. Only the hydrochlorothiazide rule should fire — the chlorothiazide rule
+		// must not, even though "chlorothiazide" is a substring of "hydrochlorothiazide".
+		List<SafetyWarning> warnings = validatorOverFixture().validate(
+				"Ibuprofen is a reasonable analgesic choice.",
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set("hydrochlorothiazide"),
+						null, null, null));
+
+		assertEquals(1, interactionCount(warnings, "Ibuprofen"),
+				"exactly one interaction should fire (hydrochlorothiazide), not the nested chlorothiazide");
+		assertTrue(DrugReferenceTestSupport.detailContains(warnings, SafetyWarning.TYPE_INTERACTION,
+				"Ibuprofen", "hydrochlorothiazide"),
+				"the fired interaction should name the drug actually on the chart");
+	}
+
+	@Test
+	public void wholeWordInAMultiWordOrderNameStillFires() throws Exception {
+		// Real order display names carry dose/form suffixes; a whole-word token must still match.
+		List<SafetyWarning> warnings = validatorOverFixture().validate(
+				"Ibuprofen is a reasonable analgesic choice.",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("hydrochlorothiazide 25 mg tablet"), null, null, null));
+
+		assertEquals(1, interactionCount(warnings, "Ibuprofen"),
+				"the whole-word token should match within a dose/form-qualified order name");
+	}
+}

--- a/api/src/test/resources/chartsearchai-test/ddi-order-name-collisions.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-order-name-collisions.json
@@ -2,7 +2,7 @@
  "metadata": {
   "schema_version": "1.0",
   "title": "Test fixture: real KB slice for order-name matching (issue #86)",
-  "note": "Verbatim slice of the full DDInter knowledge base (2283 drugs / 295,184 rows): the drug rows and interaction rows behind the live-verified order-name collisions — opium inside \"Tiotropium\", iron inside \"Spironolactone\" — plus the multivitamin x warfarin row a localized plural order name (\"Multivitamines et fer\") must still match. The bundled 16-drug sample contains none of these drugs. Rows and mechanism texts are unmodified; only unrelated drugs and rows were dropped.",
+  "note": "Verbatim slice of the full DDInter knowledge base (2283 drugs / 295,184 rows): the drug rows and interaction rows behind the live-verified order-name collisions — opium inside \"Tiotropium\", iron inside \"Spironolactone\" — plus the multivitamin x warfarin row a localized plural order name (\"Multivitamines et fer\") must still match, and the heparin x warfarin row that pins the far edge of the tail allowance (\"Heparinoids / salicylic acid\" is a different substance and must NOT be read as heparin). The bundled 16-drug sample contains none of these drugs. Rows and mechanism texts are unmodified; only unrelated drugs and rows were dropped.",
   "source": {
    "name": "DDInter 2.0",
    "url": "https://ddinter2.scbdd.com/",
@@ -33,6 +33,12 @@
    "text": "INTERVAL: Coadministration with medications containing polyvalent cations such as aluminum, calcium, iron, or magnesium may decrease the oral bioavailability of dolutegravir. The mechanism of interaction has not been established.",
    "categories": [
     "absorption"
+   ]
+  },
+  "851": {
+   "text": "Although therapy with heparin and oral anticoagulants often overlap in clinical practice, the potential for additive anticoagulant effects and increased risk of severe bleeding should be considered. Oral anticoagulants may prolong the activated partial thromboplastin time (aPTT) in patients receiving heparin, while heparin may prolong the International Normalized Ratio (INR) in patients receiving warfarin.",
+   "categories": [
+    "synergistic_effect"
    ]
   }
  },
@@ -219,6 +225,55 @@
    "drugbank_id": null,
    "atc": [],
    "ciel": []
+  },
+  {
+   "id": "DDInter856",
+   "name": "Heparin",
+   "rxcui": "5224",
+   "rxnorm_name": "heparin",
+   "drugbank_id": "DB01109",
+   "atc": [
+    "B01AB01",
+    "C05BA03",
+    "S01XA14"
+   ],
+   "ciel": [
+    {
+     "code": "72681",
+     "uuid": "72681AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Calcium heparin"
+    },
+    {
+     "code": "77413",
+     "uuid": "77413AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Heparin"
+    },
+    {
+     "code": "77414",
+     "uuid": "77414AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Heparin sodium"
+    },
+    {
+     "code": "77415",
+     "uuid": "77415AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Heparin sodium (beef)"
+    },
+    {
+     "code": "77416",
+     "uuid": "77416AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Heparin sodium (pork)"
+    },
+    {
+     "code": "77417",
+     "uuid": "77417AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Heparin, beef"
+    },
+    {
+     "code": "77418",
+     "uuid": "77418AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Heparin, pork"
+    }
+   ]
   }
  ],
  "interactions": [
@@ -245,6 +300,12 @@
    "DDInter975",
    "Major",
    "2248"
+  ],
+  [
+   "DDInter1951",
+   "DDInter856",
+   "Major",
+   "851"
   ]
  ]
 }

--- a/api/src/test/resources/chartsearchai-test/ddi-order-name-collisions.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-order-name-collisions.json
@@ -1,0 +1,250 @@
+{
+ "metadata": {
+  "schema_version": "1.0",
+  "title": "Test fixture: real KB slice for order-name matching (issue #86)",
+  "note": "Verbatim slice of the full DDInter knowledge base (2283 drugs / 295,184 rows): the drug rows and interaction rows behind the live-verified order-name collisions — opium inside \"Tiotropium\", iron inside \"Spironolactone\" — plus the multivitamin x warfarin row a localized plural order name (\"Multivitamines et fer\") must still match. The bundled 16-drug sample contains none of these drugs. Rows and mechanism texts are unmodified; only unrelated drugs and rows were dropped.",
+  "source": {
+   "name": "DDInter 2.0",
+   "url": "https://ddinter2.scbdd.com/",
+   "normalization": "RxNorm (NLM)",
+   "bridge": "CIEL v2026-07-20"
+  }
+ },
+ "mechanisms": {
+  "1854": {
+   "text": "Coadministration of narcotic analgesics with monoamine oxidase inhibitors (MAOIs) has been associated with rare reports of anxiety, confusion, hypotension, respiratory depression, cyanosis, and coma. The mechanism of interaction is unknown, but may involve potentiation of central nervous system (CNS) and respiratory depressant effects by MAOIs.",
+   "categories": [
+    "others"
+   ]
+  },
+  "8224": {
+   "text": "Multivitamin preparations containing vitamin K may antagonize the hypoprothrombinemic effect of oral anticoagulants in some patients.  Vitamin K1 in its active, reduced form serves as a cofactor in the generation of functional clotting factors, during which it becomes oxidized.  It is reactivated in a process that is inhibited by oral anticoagulants, thus intake of additional vitamin K through supplements or diet can reverse the action of oral anticoagulants.",
+   "categories": [
+    "antagonistic_effect"
+   ]
+  },
+  "7199": {
+   "text": "Coadministration with medications containing polyvalent cations such as aluminum, calcium, iron, or magnesium may decrease the oral bioavailability of dolutegravir.",
+   "categories": [
+    "absorption"
+   ]
+  },
+  "2248": {
+   "text": "INTERVAL: Coadministration with medications containing polyvalent cations such as aluminum, calcium, iron, or magnesium may decrease the oral bioavailability of dolutegravir. The mechanism of interaction has not been established.",
+   "categories": [
+    "absorption"
+   ]
+  }
+ },
+ "drugs": [
+  {
+   "id": "DDInter1073",
+   "name": "Linezolid",
+   "rxcui": "190376",
+   "rxnorm_name": "linezolid",
+   "drugbank_id": "DB00601",
+   "atc": [
+    "J01XX08"
+   ],
+   "ciel": [
+    {
+     "code": "78879",
+     "uuid": "78879AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Linezolid"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1344",
+   "name": "Opium",
+   "rxcui": "7676",
+   "rxnorm_name": "opium",
+   "drugbank_id": "DB11130",
+   "atc": [
+    "A07DA02",
+    "N02AA02"
+   ],
+   "ciel": [
+    {
+     "code": "103692",
+     "uuid": "103692AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Aspirin / caffeine / ipecac / opium"
+    },
+    {
+     "code": "103788",
+     "uuid": "103788AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Belladonna alkaloids / opium"
+    },
+    {
+     "code": "103798",
+     "uuid": "103798AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Belladonna extract / opium"
+    },
+    {
+     "code": "104822",
+     "uuid": "104822AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Homatropine / opium / pectin"
+    },
+    {
+     "code": "170673",
+     "uuid": "fbbb8749-c143-4e62-92ea-76e77db47f32",
+     "name": "Acetaminophen / caffeine / opium"
+    },
+    {
+     "code": "81092",
+     "uuid": "81092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Opium"
+    },
+    {
+     "code": "81094",
+     "uuid": "81094AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Opium tincture"
+    },
+    {
+     "code": "81095",
+     "uuid": "81095AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Opium, powdered"
+    }
+   ]
+  },
+  {
+   "id": "DDInter582",
+   "name": "Dolutegravir",
+   "rxcui": "1433868",
+   "rxnorm_name": "dolutegravir",
+   "drugbank_id": "DB08930",
+   "atc": [
+    "J05AJ03"
+   ],
+   "ciel": [
+    {
+     "code": "165085",
+     "uuid": "165085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Dolutegravir"
+    },
+    {
+     "code": "165606",
+     "uuid": "165606AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Abacavir / dolutegravir / lamivudine"
+    },
+    {
+     "code": "169361",
+     "uuid": "0af318f4-94a2-4dbe-9727-fb1d682e75fb",
+     "name": "Dolutegravir / lamivudine / tenofovir alafenamide"
+    },
+    {
+     "code": "170472",
+     "uuid": "72f7a185-3673-4499-a314-9487a715eabc",
+     "name": "Dolutegravir / lamivudine"
+    },
+    {
+     "code": "170548",
+     "uuid": "66e5599c-7424-4252-b357-6949b0a50459",
+     "name": "Dolutegravir / rilpivirine"
+    },
+    {
+     "code": "170670",
+     "uuid": "7e00083b-c345-4c2d-9b87-81be50eff8b1",
+     "name": "Dolutegravir / emtricitabine / tenofovir alafenamide"
+    },
+    {
+     "code": "170671",
+     "uuid": "b944c518-10b4-4a93-a928-d0e4d10a66e4",
+     "name": "Dolutegravir / lamivudine / tenofovir disoproxil"
+    }
+   ]
+  },
+  {
+   "id": "DDInter975",
+   "name": "Iron",
+   "rxcui": "90176",
+   "rxnorm_name": "iron",
+   "drugbank_id": "DB01592",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "78218",
+     "uuid": "78218AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Iron"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2187",
+   "name": "Iron (bisglycinate)",
+   "rxcui": "90176",
+   "rxnorm_name": "iron",
+   "drugbank_id": "DB01592",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "78218",
+     "uuid": "78218AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Iron"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1951",
+   "name": "Warfarin",
+   "rxcui": "11289",
+   "rxnorm_name": "warfarin",
+   "drugbank_id": "DB00682",
+   "atc": [
+    "B01AA03"
+   ],
+   "ciel": [
+    {
+     "code": "86415",
+     "uuid": "86415AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Warfarin"
+    },
+    {
+     "code": "86416",
+     "uuid": "86416AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Warfarin potassium"
+    },
+    {
+     "code": "86417",
+     "uuid": "86417AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Warfarin sodium"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2246",
+   "name": "Multivitamin",
+   "rxcui": null,
+   "rxnorm_name": null,
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": []
+  }
+ ],
+ "interactions": [
+  [
+   "DDInter1073",
+   "DDInter1344",
+   "Major",
+   "1854"
+  ],
+  [
+   "DDInter1951",
+   "DDInter2246",
+   "Moderate",
+   "8224"
+  ],
+  [
+   "DDInter2187",
+   "DDInter582",
+   "Major",
+   "7199"
+  ],
+  [
+   "DDInter582",
+   "DDInter975",
+   "Major",
+   "2248"
+  ]
+ ]
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-substring-nested.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-substring-nested.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0",
+  "source": "test fixture — substring-nested drug names",
+  "entries": [
+    {
+      "id": "ibuprofen",
+      "name": "Ibuprofen",
+      "aliases": ["ibuprofen"],
+      "atcCodes": ["M01AE01"],
+      "interactions": [
+        { "token": "hydrochlorothiazide", "atc": "C03AA03", "note": "NSAIDs may blunt the diuretic/antihypertensive effect" },
+        { "token": "chlorothiazide", "atc": "C03AA04", "note": "NSAIDs may blunt the diuretic/antihypertensive effect" }
+      ],
+      "source": "test fixture"
+    }
+  ]
+}

--- a/docs/drug-kb-demo.md
+++ b/docs/drug-kb-demo.md
@@ -329,7 +329,7 @@ Reference for authoring a custom KB (the `json` source format). The top-level fi
 
 | Field | Type | Purpose / notes |
 |-------|------|-----------------|
-| `token` | string | Substring matched (case-insensitive) against the patient's active-order drug names. |
+| `token` | string | Matched (case-insensitive) against the patient's active-order drug names by **word start**, tolerating up to two trailing letters so localized spellings still match (issue #86): `iron` matches `Iron IR 325mg` and `aspirin` matches the French `Aspirine Co 81mg`, but `iron` does **not** match `Spironolactone`. Write the token as the drug's own name, not a fragment of it. |
 | `atc` | string | ATC code matched against the active order's ATC mapping (an alternative to `token`). |
 | `note` | string | Free text appended to the interaction warning (e.g. "increased risk of GI bleeding"). |
 | `severity` | string, optional | Source-assigned rating (`Unknown`/`Minor`/`Moderate`/`Major`). **Rating a rule opts it into the severity floor** (`chartsearchai.drugSafety.minInteractionSeverity`, default `minor`): a rule rated below the floor raises no warning. Omit it (the usual case for hand-authored rules) and the rule always fires. |


### PR DESCRIPTION
Closes #86. **Supersedes #87** — this branch contains #87's commit unchanged (cherry-picked onto
current `main`, authorship preserved) plus one commit correcting the matching rule and adding the
coverage that correction needs. If this lands, #87 should be closed in favour of it.

## The defect

`PatientClinicalContext.hasActiveDrug` matched an interaction rule's drug token against the
patient's active-order display names with `drug.contains(token)`. Drug names nest, so the check
reported drugs the patient has never taken — at Major severity, mechanism text and all. Both of
these were reproduced live on the 3.7.1 standalone against `13690b1`, twice each, with neither
concept carrying an ATC mapping (so the ATC arm cannot be involved):

**Susan Young, active order `Tiotropium` (inhaled anticholinergic), "Is it safe to give linezolid?"**

```
--- safetyWarnings (1) ---
  [interaction] drug='Linezolid'
      Linezolid interacts with active order opium — Major. Coadministration of narcotic analgesics
      with monoamine oxidase inhibitors (MAOIs) has been associated with rare reports of anxiety,
      confusion, hypotension, respiratory depression, cyanosis, and coma. …
```

```
"tiotropium".contains("opium")  →  true
```

**Melissa Wright, active order `Spironolactone`, "Can I start dolutegravir?"**

```
--- safetyWarnings (2) ---
  [interaction] drug='Dolutegravir'
      Dolutegravir interacts with active order iron — Major. Coadministration with medications
      containing polyvalent cations such as aluminum, calcium, iron, or magnesium may decrease the
      oral bioavailability of dolutegravir.
  [interaction] drug='Dolutegravir'
      Dolutegravir interacts with active order iron — Major. INTERVAL: Coadministration with …
```

```
"spironolactone".contains("iron")  →  true      # sp-IRON-olactone
```

## Root cause, and why not the whole-word fix in #87

The cause is one matcher, so #87 is right that the fix belongs in shared infrastructure and right
about the half that discriminates: the **left** boundary. An alphanumeric character immediately
before the token means the token sits inside a longer word — a different molecule
(`tiotr|opium`, `sp|iron|olactone`, `nitro|glycerin`, `bud|esonide`, `hydro|chlorothiazide`,
`cipr|ofloxacin`).

Where #87 goes wrong is applying prose's **symmetric** boundary to an order name. Measured over
this deployment's real dictionary — 2531 drug and drug-concept names × the full DDInter KB's 2093
rule tokens, run through the shipped matchers themselves:

| rule | matches | known collisions leaking | known real names lost |
|---|---|---|---|
| `contains` (the defect) | 896 | 9 of 9 | 0 of 12 |
| symmetric word boundary (#87) | 761 | 0 of 9 | **9 of 12** |
| left boundary + ≤1 trailing letter | 828 | 0 of 9 | 0 of 12 |
| **left boundary + ≤2 trailing letters (this PR)** | **829** | **0 of 9** | **0 of 12** |
| left boundary + ≤3 | 829 | 0 of 9 | 0 of 12 |
| left boundary + ≤4 | 834 | 0 of 9 | 0 of 12 |
| left boundary only (unbounded tail) | 835 | 0 of 9 | 0 of 12 |

Symmetric boundaries drop 135 of containment's 896 matches, and **68 of the dropped are
legitimate**, because this dictionary is multilingual:

```
'Aspirine Co 81mg'         token='aspirin'          <- French, a real drug row here
'Aspirina'                 token='aspirin'          <- Spanish
'Amoxicilline'             token='amoxicillin'
'Clarithromycine Co 500mg' token='clarithromycin'
'Simvastatine'             token='simvastatin'
'Ondansetrona'             token='ondansetron'
'Multivitamines et fer'    token='multivitamin'
```

Under #87 a patient on `Aspirine Co 81mg` stops being checked for aspirin interactions entirely.
That trades a false positive for a false **negative** in a safety net, and it would pass review
because the removed chips look exactly like the noise we set out to remove. The two new
localized-name tests in this PR fail against #87's rule — `[]`, no chip at all — and pass here.

**Why ≤2 and not ≤1.** The tail is an empirical accommodation for inflected display names, so it
was scored across the whole corpus rather than a sample. What enters at each step: ≤1 admits 67
localized spellings (all legitimate); ≤2 admits exactly one more, the plural `Multivitamines et
fer`, whose reference entry carries 2 Major and 8 Moderate rules that would otherwise stop being
checked; ≤3 admits nothing; **≤4 is where the first false positives appear** (`Heparinoids` ~
heparin, `Multi-Vitamin Adult` ~ vitamin a). Two is therefore the far edge of the plateau on which
every legitimate name matches and no false positive has appeared — one inflectional ending, which
is what a Romance localization of an INN stem is, singular (`-e`, `-a`, `-o`) or plural (`-es`).

The alternative to a bound — normalizing inflections away on both sides — was measured on the same
corpus at 826 matches, a strict subset of this rule, and it replaces one bound with a per-language
suffix whitelist that a differently-localized deployment falls off silently. The two matches it
additionally rejects are `Aspirinn` and `Metforming`, real typo'd rows in this dictionary that a
safety net should still be checking.

Residual imprecision this rule keeps, for the record: 2 of the 829 are a nitroglycerin order
matching the token `glycerin` through its own parenthetical synonym ("glycerine trinitrate") — a
mislabel of a drug the patient is on, not a fabricated one, and shared by every rule that tolerates
an inflectional tail.

## What changed

- `DrugReference` — #87's `containsWord` (prose, symmetric) and a new `matchesOrderName`
  (active-order names, left boundary + bounded tail) now both delegate to one private
  boundary-aware scan, so the boundary rule cannot drift between them. Prose matching is
  behaviourally unchanged: 761 matches over the corpus before and after.
- `PatientClinicalContext.hasActiveDrug` — the name arm calls `matchesOrderName`. Both of its
  callers (the chip decision in `DrugSafetyValidator:391` and the prompt-promotion predicate in
  `DrugReferenceInjector:350`) reach the rule only through this method, so chips and promoted
  prose still agree by construction.
- `DdiDrugReferenceSource` — one stale comment that described the matching as substring-based.
- `HasActiveDrugWholeWordTest` — #87's file, kept as-is, plus one case it was missing: a
  `chlorothiazide` order must still raise chlorothiazide's own rule, so the fix is de-duplication
  and not suppression of the shorter name. A matcher that simply never matched the shorter token
  passed #87's two tests.
- `DrugSafetyOrderNameMatchingTest` + `ddi-order-name-collisions.json` (new) — the fabrications
  above and the localized names, over a verbatim slice of the full KB (the bundled 16-drug sample
  contains none of linezolid, opium, dolutegravir, iron or multivitamin). Every negative is paired
  with the positive that proves the rule it must not fire on is live, so none of the
  "no chip" assertions can pass by resolving nothing.

## Live verification

Standalone 3.7.1, `sourceFormat=ddinter` with the full 19MB KB, `minInteractionSeverity=minor`,
full-JVM restart onto this build, querystore retrieval confirmed alive (`hits>0`) and the
known-positive control confirmed before any absence was recorded. Chips are deterministic Java;
answer prose is not reproducible on that box (`cache_prompt` KV reuse), so every claim below is
about `safetyWarnings`.

Setup, from the capture: my omod (36,158,822 bytes) deployed at 15:04, JVM pid 94318 started
15:04:16 (fresh process holding 8081, not a `moduleaction` half-restart), `sourceFormat=ddinter`,
`drugSafety.minInteractionSeverity=minor`, `drugSafety.validateAnswers=true`, `llm.engine=local`.
Gates before any absence was recorded: `last querystoreBuild hits=75` (so charts are not empty) and
the known-positive warm control raised its chip (`warm chips=1`).

**Before** (live on `13690b1`, the pre-fix build, each reproduced twice):

```
Susan Young (Tiotropium) + "Is it safe to give linezolid?"
--- safetyWarnings (1) ---
  [interaction] drug='Linezolid'
      Linezolid interacts with active order opium — Major. Coadministration of narcotic analgesics
      with monoamine oxidase inhibitors (MAOIs) has been associated with rare reports of anxiety,
      confusion, hypotension, respiratory depression, cyanosis, and coma. …

Melissa Wright (Spironolactone) + "Can I start dolutegravir?"
--- safetyWarnings (2) ---
  [interaction] drug='Dolutegravir'
      Dolutegravir interacts with active order iron — Major. Coadministration with medications
      containing polyvalent cations such as aluminum, calcium, iron, or magnesium may decrease the
      oral bioavailability of dolutegravir.
  [interaction] drug='Dolutegravir'
      Dolutegravir interacts with active order iron — Major. INTERVAL: Coadministration with … 
```

**After** (this build, verbatim chip summary; absences confirmed on a second run each):

```
Susan/Tiotropium + linezolid                   chips=0 expected=0
Susan/Tiotropium + linezolid (rerun)           chips=0 expected=0
Melissa/Spironolactone + dolutegravir          chips=0 expected=0
Melissa/Spironolactone + dolutegravir (rerun)  chips=0 expected=0
Dorothy/Aspirine Co 81mg + warfarin            chips=1 expected=>=1 (warfarin x aspirin Major)
      [interaction] Warfarin interacts with active order aspirin — Major. Aspirin, even in small
      doses, may increase the risk of bleeding in patients on oral anticoagulants by inhibiting
      platelet aggregation, prolonging bleeding time, and inducing gastrointestinal lesions. …
Dorothy/Aspirine Co 81mg + warfarin (rerun)    chips=1 expected=>=1 (warfarin x aspirin Major)
      [interaction] Warfarin interacts with active order aspirin — Major. …
CONTROL Mary + clarithromycin                  chips=1 expected=1
      [interaction] Clarithromycin interacts with active order simvastatin — Major. …
CONTROL Agnes + warfarin                       chips=1 expected=1
      [interaction] Warfarin interacts with active order aspirin — Major. …
CONTROL Joshua + ibuprofen                     chips=2 expected=2
      [contraindication] Ibuprofen is in the same cross-reactivity group (NSAID) as the patient's
      allergy to Acetylsalicylic acid (aspirin) — possible cross-reactivity
      [interaction] Ibuprofen interacts with active order lisinopril — Moderate. …
CONTROL Mary + paracetamol                     chips=0 expected=0
```

The fifth and sixth rows are the ones that distinguish this from #87. That patient's only
aspirin-bearing string is the drug row name **`Aspirine Co 81mg`** — the order's concept name is
`Acetylsalicylate sodium`, which contains no `aspirin` token at all — so under a symmetric word
boundary the Major warfarin×aspirin chip disappears entirely. The created order was confirmed active
before the query:

```
POST /order -> created order uuid=eab3e8a9-0301-4e11-a007-74f556fd8cbf
              display='(NEW) Aspirine Co 81mg: 81.0 Milligram Oral Once daily'
GET  /order  -> count=1  {'drug': 'Aspirine Co 81mg', 'dateActivated': '2026-08-04T15:07:10.000+0300',
                          'dateStopped': None, 'autoExpireDate': None, 'voided': False}
```

All four known-good regression controls are unchanged from the documented baseline.

## Tests

`mvn clean package` (API + OMOD): **API 670 + OMOD 53 = 723 run, 0 failures, 0 errors, 34
skipped** (the 34 skipped are the LLM-requiring `PromptInjectionEvalTest`/`LlmAnswerQualityTest`, as
on `main`). Baseline `main` is 662 + 53 = 715; this adds #87's 2 tests, 5 new ones here, and 1 to
#87's file.

TDD trail, for reviewers who want to see each assertion fail first:

- against `main`'s `contains`: the two fabrication tests fail with exactly the live chips quoted
  above, and the thiazide test with 2 chips instead of 1;
- against #87's symmetric rule (`maxTrailingLetters = 0`): `HasActiveDrugWholeWordTest` passes,
  and both localized-name tests fail with `[]`;
- against ≤1: only the localized-plural test fails.

## Data created on the shared standalone

The multilingual check needs an order whose display name is localized, and no test patient had one,
so I created one inpatient drug order — `Aspirine Co 81mg`, an existing drug row in the demo
dictionary — for **Dorothy Odinga** (`71c5a6eb-b47c-4ec1-93fd-9d4a568ac724`), a spare demo patient
with no prior drug orders and no allergies. It is test data I added, not demo data.

## Not verified live

The ≤2 step (`Multivitamines et fer`) is covered by unit test only. That spelling exists in this
dictionary as a French *concept* name, not a drug row, and the REST path resolves concept names in
the English locale, so an order cannot surface it on this box without inventing dictionary rows. A
French-locale deployment produces exactly the context the unit test feeds.

## Two adjacent gaps found while measuring, deliberately not fixed here

- **Accented localizations are still unmatched, before and after this change.** The same corpus scan
  with diacritics folded out finds **78 additional matches** the matcher misses today —
  `budésonide` ~ budesonide, `dexaméthasone` ~ dexamethasone, `héparine` ~ heparin, `furosémide` ~
  furosemide, `glycérine` ~ glycerin and 73 more (224 of the 2531 names carry diacritics). This is
  pre-existing (`contains` misses them too, so nothing regresses), but it is the same class of
  false negative as the one this PR fixes and deserves its own change: folding also creates new
  collision opportunities, so it needs the kill direction measured too.
- **`hasAllergyToken`/`hasConditionToken` still use bare containment.** They match free-text allergy
  and condition text rather than order names, so they want a rule of their own, and #86 is about
  order names — flagging rather than changing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
