### PR TITLE
fix(grounding): derive the demote-only carve-out from the reference group (#122)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiConstants.java
@@ -517,18 +517,23 @@ public class ChartSearchAiConstants {
 	public static final String REFERENCE_GROUP_CHART = "chart";
 
 	/**
-	 * Wire value of a serialized reference's {@code group}: module-supplied reference prose
-	 * (a drug knowledge-base entry), not a record about this patient. Kept visible precisely
-	 * so a client can disclose that provenance rather than let it read as chart evidence —
-	 * A drug-reference citation is additionally never grounding-verified as {@code true}, being
-	 * demote-only (see {@code CitationGroundingVerifier}) — but note that gate keys on the
-	 * {@code drug_reference} resource type, not on this group, so the property does NOT extend for
-	 * free to the other injected types. It already does not hold for all of this group:
-	 * {@link #RESOURCE_TYPE_SAFETY_FINDING} is reference-group yet graded normally. And
-	 * {@link #RESOURCE_TYPE_ACTIVE_DRUG_ORDER} is injected but groups as
-	 * {@link #REFERENCE_GROUP_CHART}, so it is graded too (decided in #118: one drug asserted of
-	 * this patient has no subject roles to swap, so a passing verdict is real assurance). A client
-	 * must therefore read {@code grounded} per reference, not infer it from {@code group}.
+	 * Wire value of a serialized reference's {@code group}: module-supplied reference prose (a drug
+	 * knowledge-base entry, or a finding derived from one), not a record about this patient. Kept
+	 * visible precisely so a client can disclose that provenance rather than let it read as chart
+	 * evidence. A citation in this group is additionally never grounding-verified as {@code true},
+	 * being demote-only (see {@code CitationGroundingVerifier}) — a property of the GROUP since issue
+	 * #122, which derived that gate from {@link ChartSearchAiUtils#referenceGroup} instead of from the
+	 * {@code drug_reference} resource type. Keying it on the type is how
+	 * {@link #RESOURCE_TYPE_SAFETY_FINDING} came to be reference-group yet graded as chart evidence.
+	 *
+	 * <p>{@link #RESOURCE_TYPE_ACTIVE_DRUG_ORDER} is injected but groups as
+	 * {@link #REFERENCE_GROUP_CHART}, so it is graded normally (decided in #118: one drug asserted of
+	 * this patient has no subject roles to swap, so a passing verdict is real assurance) — "the module
+	 * injected it" is a different question from this group.
+	 *
+	 * <p>A client must still read {@code grounded} per reference rather than infer it from
+	 * {@code group}: this group only rules {@code true} out, and both {@code false} (an off-topic
+	 * citation, still worth flagging) and {@code null} (unverified) remain.
 	 */
 	public static final String REFERENCE_GROUP_REFERENCE = "reference";
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/ChartSearchAiUtils.java
@@ -75,14 +75,21 @@ public class ChartSearchAiUtils {
 	 * Classifies a cited record's resource type into the group a client renders it under:
 	 * {@link ChartSearchAiConstants#REFERENCE_GROUP_CHART} for evidence retrieved from this
 	 * patient's chart, {@link ChartSearchAiConstants#REFERENCE_GROUP_REFERENCE} for
-	 * module-supplied reference prose. This is the single entry point for the DISPLAY-GROUPING
-	 * decision: code that labels or orders references for a client must ask here rather than
+	 * module-supplied reference prose. This is the single entry point for the PROVENANCE decision:
+	 * code that labels or orders references for a client must ask here rather than
 	 * compare {@code resourceType} itself, so the split stays in one place as further kinds of
 	 * injected record are added — three exist already, and they do not all fall on the same side
-	 * (see below). (Unrelated per-type behaviour keyed off
-	 * {@link ChartSearchAiConstants#RESOURCE_TYPE_DRUG_REFERENCE} is untouched by this — the
-	 * demote-only grounding gate in {@code CitationGroundingVerifier} is its own concern and
-	 * legitimately tests the type directly.)
+	 * (see below).
+	 *
+	 * <p>Two behaviours now hang off this one classification, not just the display grouping: the
+	 * demote-only grounding carve-out in {@code CitationGroundingVerifier} is derived from it via
+	 * {@link #isGroundingDemoteOnly}. That gate used to test the {@code drug_reference} type directly,
+	 * so when {@code safety_finding} arrived (#110) it was classified here and NOT registered there,
+	 * and the module's own deterministic findings were graded as retrieved chart evidence — publishing
+	 * unstable {@code grounded} verdicts with no error anywhere (issue #122). Deriving both from one
+	 * classification is what makes that class of omission unrepresentable, and it is why editing this
+	 * method now also changes whether a type's citations can be verified. Both consequences are swept
+	 * off one enumeration in {@code ChartSearchAiReferenceGroupTest}.
 	 *
 	 * <p>The two groups are exhaustive because exactly two code paths mint a
 	 * {@code RecordMapping}: {@code PatientChartSerializer}, which passes through whatever
@@ -106,6 +113,51 @@ public class ChartSearchAiUtils {
 				|| ChartSearchAiConstants.RESOURCE_TYPE_SAFETY_FINDING.equals(resourceType)
 						? ChartSearchAiConstants.REFERENCE_GROUP_REFERENCE
 						: ChartSearchAiConstants.REFERENCE_GROUP_CHART;
+	}
+
+	/**
+	 * Whether a cited record of {@code resourceType} is DEMOTE-ONLY for citation grounding: its
+	 * verdict may render {@code false} (an off-topic citation) or {@code null} (unverified), never
+	 * {@code true}, and it never enters — nor consumes the per-answer cap of — the Tier-2 entailment
+	 * pass. True exactly for {@link ChartSearchAiConstants#REFERENCE_GROUP_REFERENCE} material: this
+	 * is a named view of {@link #referenceGroup}, not a second classification, so there is no list of
+	 * type names here to fall out of step with that one.
+	 *
+	 * <p><strong>Why module-supplied material cannot be verified.</strong> An answer sentence citing
+	 * module-rendered reference prose is typically a recitation of it, and a recitation embeds
+	 * near-identically to its source whether or not it swaps subject roles ("erythromycin decreases X"
+	 * against the record's "ivosidenib decreases X … including erythromycin"). The same lexical
+	 * containment defeats the Tier-2 judge: measured on the live pipeline, 4/4 role-swapped
+	 * recitations were judged entailed while the one faithful recitation was judged not (issue #106).
+	 * A passing verdict is therefore false assurance. A FAILING verdict still carries information — it
+	 * says the citation is not about the record at all — so the flag is kept and only the pass is
+	 * withheld. Faithfulness of reference content is checked deterministically by the
+	 * {@code DrugSafetyValidator} chips instead.
+	 *
+	 * <p><strong>It follows from provenance, not from being injected.</strong> An
+	 * {@link ChartSearchAiConstants#RESOURCE_TYPE_ACTIVE_DRUG_ORDER} record is injected yet groups as
+	 * chart evidence — one drug name asserted of this patient, carrying the real {@code Order} uuid,
+	 * with no subject roles to swap — so it is graded normally; demoting it would strip the
+	 * faithfulness check from the very record injected to stop the answer contradicting the safety
+	 * chips (#118). Conversely a {@link ChartSearchAiConstants#RESOURCE_TYPE_SAFETY_FINDING} is
+	 * patient-specific but module-derived, and its rendering ("&lt;Drug&gt; interacts with active order
+	 * &lt;Partner&gt; — Major. &lt;mechanism&gt;") is precisely the role-swappable prose above, which is why
+	 * grading it produced verdicts that tracked embedding noise rather than the finding (issue #122).
+	 *
+	 * <p><strong>The unrecognised-type fallback grades normally</strong>, following
+	 * {@link #referenceGroup}'s fail-safe, and that is deliberate in this direction too: querystore
+	 * passes through chart types this module declares no constant for ({@code drug_order},
+	 * {@code visit}, {@code encounter} …), so demoting unknown types would silently stop verifying
+	 * most real chart citations. The cost is that a module-supplied type introduced as a bare string
+	 * literal — rather than as a {@code RESOURCE_TYPE_*} constant, which
+	 * {@code ChartSearchAiReferenceGroupTest}'s sweep would catch — would be graded as chart evidence;
+	 * {@code DrugReferenceInjector}'s class javadoc warns against exactly that.
+	 *
+	 * @param resourceType the cited record's resource type, may be null
+	 * @return true when a grounding pass may only demote this record's citation
+	 */
+	public static boolean isGroundingDemoteOnly(String resourceType) {
+		return ChartSearchAiConstants.REFERENCE_GROUP_REFERENCE.equals(referenceGroup(resourceType));
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifier.java
@@ -54,8 +54,8 @@ import org.springframework.stereotype.Service;
  * <p><strong>Tier-2 (optional).</strong> When
  * {@code chartsearchai.grounding.entailment.enabled} is set, the cited references are
  * confirmed by a yes/no LLM entailment verdict that is authoritative. This is what
- * catches the subject/polarity flips cosine cannot — for chart records; drug-reference
- * citations are excepted, see below. It runs on Tier-1 passes
+ * catches the subject/polarity flips cosine cannot — for chart records; citations of
+ * module-supplied reference material are excepted, see below. It runs on Tier-1 passes
  * <em>and</em> failures — the dangerous case (a high-overlap but unsupported
  * citation) is a Tier-1 pass, so confirming only failures would miss it. References are verified
  * in a SINGLE batched call ({@link LlmProvider#entailsBatch}) — except that, under clause-scoped
@@ -78,9 +78,9 @@ import org.springframework.stereotype.Service;
  * broken or absent Tier-1 embedding model no longer blocks Tier-2 verdicts for unambiguous
  * claim sentences — previously it silently downgraded every citation to "unverified".
  *
- * <p><strong>Drug-reference citations are demote-only.</strong> An injected
- * {@code drug_reference} record
- * ({@link ChartSearchAiConstants#RESOURCE_TYPE_DRUG_REFERENCE}) is module-rendered
+ * <p><strong>Module-supplied reference citations are demote-only.</strong> A record whose
+ * resource type groups as reference material
+ * ({@link ChartSearchAiUtils#isGroundingDemoteOnly}) is module-rendered
  * reference prose, and an answer sentence citing it is typically a recitation of that
  * prose. A recitation embeds near-identically to its source whether or not it swaps
  * subject roles ("erythromycin decreases X" vs the record's "ivosidenib decreases X …
@@ -93,8 +93,18 @@ import org.springframework.stereotype.Service;
  * checked deterministically by the {@code DrugSafetyValidator} chips instead. Accepted
  * cost: under entailment mode these citations now take the lazy Tier-1 path (up to two
  * embedding passes each) that the amortized Tier-2 batch previously spared them — the
- * off-topic flag is kept mode-uniform at the price of ~one embed pair per drug-reference
+ * off-topic flag is kept mode-uniform at the price of ~one embed pair per reference
  * citation on CPU deployments.
+ *
+ * <p>Two record types are reference material today —
+ * {@link ChartSearchAiConstants#RESOURCE_TYPE_DRUG_REFERENCE}, the case #106 measured, and
+ * {@link ChartSearchAiConstants#RESOURCE_TYPE_SAFETY_FINDING}, the deterministic drug-safety join
+ * #110 injects as a citable record. The finding was graded as chart evidence until issue #122,
+ * because this carve-out named the drug-reference type instead of deriving from the group; its
+ * verdicts tracked embedding noise, and it also spent Tier-2 cap slots meant for chart claims. An
+ * injected {@link ChartSearchAiConstants#RESOURCE_TYPE_ACTIVE_DRUG_ORDER} record is NOT reference
+ * material and is graded normally — see the carve-out site in {@link #verify} for why that is
+ * right, and why "the module injected it" is the wrong test.
  *
  * <p>The verifier never throws into the search path: any failure (embedding
  * error, missing text) degrades to a {@code null} verdict — "could not verify"
@@ -185,9 +195,9 @@ public class CitationGroundingVerifier {
 	 * inline — e.g. it appeared only in the structured citations array — to the
 	 * best-matching sentence anywhere in the answer). References whose record
 	 * carries no text, or that cannot be embedded, are returned with a
-	 * {@code null} verdict ("could not verify"). Drug-reference citations are
-	 * demote-only — a cosine pass renders {@code null}, never {@code true} — see
-	 * the class javadoc.
+	 * {@code null} verdict ("could not verify"). Citations of module-supplied
+	 * reference material are demote-only — a cosine pass renders {@code null}, never
+	 * {@code true} — see the class javadoc.
 	 *
 	 * @param answer the full answer prose, with inline {@code [N]} markers
 	 * @param references the index-validated references to annotate
@@ -217,8 +227,8 @@ public class CitationGroundingVerifier {
 	 * tests can exercise the grounding logic without an OpenMRS context.
 	 *
 	 * <p>When {@code entailmentEnabled}, every reference with a resolvable claim sentence and
-	 * record text — except drug-reference citations, which never enter Tier-2 (see the class
-	 * javadoc) — is confirmed by a Tier-2 LLM entailment verdict that is authoritative
+	 * record text — except citations of module-supplied reference material, which never enter Tier-2
+	 * (see the class javadoc) — is confirmed by a Tier-2 LLM entailment verdict that is authoritative
 	 * (cosine errs in both directions, and the dangerous error — a high-overlap
 	 * but unsupported citation — is exactly the case Tier-1 cannot self-detect,
 	 * so the LLM must see Tier-1 passes too, not only failures). They are confirmed in a batched
@@ -243,28 +253,35 @@ public class CitationGroundingVerifier {
 		}
 
 		Map<Integer, String> textByIndex = new HashMap<Integer, String>();
-		// Injected drug-reference records get demote-only verdicts (see class javadoc): an answer
-		// sentence citing one is typically a recitation of module-rendered reference prose, which
-		// embeds near-identically to its source whether or not it swaps subject roles — so a
-		// passing verdict would be false assurance (issue #106).
+		// Module-supplied records get demote-only verdicts (see class javadoc): an answer sentence
+		// citing one is typically a recitation of module-rendered reference prose, which embeds
+		// near-identically to its source whether or not it swaps subject roles — so a passing
+		// verdict would be false assurance (issue #106).
 		Set<Integer> demoteOnlyIndexes = new HashSet<Integer>();
 		if (mappings != null) {
 			for (RecordMapping mapping : mappings) {
 				textByIndex.put(mapping.getIndex(), mapping.getText());
-				// Keyed on the resource type, deliberately narrower than
-				// ChartSearchAiUtils.referenceGroup: the measured justification for demote-only
-				// (#106) is about drug-reference recitations specifically. When another kind of
-				// injected record is added, decide whether it belongs here too — the client
-				// suppresses a true verdict for ALL reference-group citations, so leaving a new
-				// REFERENCE-group type out of this set would let it be verified here and hidden
-				// there. A chart-group type has no such asymmetry to resolve, which is what makes
-				// the call below straightforward rather than a trade-off.
-				// Decided for active_drug_order (#118): NOT demote-only. It is chart-group
-				// evidence, so no client hides its verdict, and the #106 hazard does not apply —
-				// that is about reference prose whose subject roles can swap while still embedding
-				// near-identically ("A interacts with B"), whereas this record is one drug name
-				// asserted of this patient, so a passing verdict is real assurance.
-				if (ChartSearchAiConstants.RESOURCE_TYPE_DRUG_REFERENCE.equals(mapping.getResourceType())) {
+				// Membership is DERIVED from the reference group (ChartSearchAiUtils.referenceGroup,
+				// read through isGroundingDemoteOnly), not from a list of type names, so
+				// "module-supplied material is demote-only" is one rule keyed off one classification
+				// and a newly injected type inherits the right side of it. It had to be remembered
+				// here once and was not: #110's safety_finding was classified as reference material
+				// and left out of this set, so the module's own deterministic findings were graded as
+				// retrieved chart evidence and published verdicts that tracked embedding noise —
+				// grounded=false on a MAJOR finding beside two byte-identical siblings at true, and
+				// one finding flipping across runs of a single probe (issue #122). What makes such an
+				// omission dangerous rather than merely wrong is an asymmetry: a client suppresses a
+				// true verdict for ALL reference-group citations, so a REFERENCE-group type missing
+				// from this set is verified here and hidden there.
+				//
+				// active_drug_order (#118) is the case that fixes the rule's SHAPE, and the reason it
+				// cannot be "everything the module injects": it is chart-group evidence, so no client
+				// hides its verdict, and the #106 hazard does not apply — that is about reference
+				// prose whose subject roles can swap while still embedding near-identically ("A
+				// interacts with B"), whereas this record is one drug name asserted of this patient,
+				// so a passing verdict is real assurance. Keyed off the group it stays graded, with
+				// nothing to remember.
+				if (ChartSearchAiUtils.isGroundingDemoteOnly(mapping.getResourceType())) {
 					demoteOnlyIndexes.add(Integer.valueOf(mapping.getIndex()));
 				}
 			}
@@ -322,9 +339,10 @@ public class CitationGroundingVerifier {
 			// Candidacy deliberately does NOT require a Tier-1 verdict: for an unambiguous claim
 			// sentence the verdict is deferred (and may never be needed), and a broken Tier-1
 			// embedder must not block the authoritative Tier-2 check it has no part in.
-			// Drug-reference citations are never candidates: the judge's "yes" is false assurance
-			// on recited reference prose (issue #106), and the skipped pair must not consume the
-			// per-answer entailment cap that chart citations rely on.
+			// Citations of module-supplied reference material are never candidates: the judge's "yes"
+			// is false assurance on recited reference prose (issue #106), and the skipped pair must
+			// not consume the per-answer entailment cap that chart citations rely on — which the
+			// safety findings were doing until issue #122, several per polypharmacy answer.
 			if (entailmentEnabled && tier1.bestSentence != null
 					&& tier1.recordText != null
 					&& !demoteOnlyIndexes.contains(Integer.valueOf(reference.getIndex()))) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -52,6 +52,12 @@ import org.springframework.stereotype.Service;
  * reflective guard in {@code ChartSearchAiReferenceGroupTest} catches a new
  * {@code RESOURCE_TYPE_*} constant, but it cannot see a bare string literal written here.
  *
+ * <p>That one classification also decides whether the citation can be grounding-verified (issue
+ * #122): reference material is demote-only, so its verdict is never {@code true}, while chart
+ * evidence is graded normally. Both consequences follow from the single provenance judgement and
+ * both are asserted by that guard — they used to be two separate registrations, and the second was
+ * missed when {@code safety_finding} was added.
+ *
  * <p>Three kinds are injected today, and they are not all module-supplied: a
  * {@code drug_reference} entry and a {@code safety_finding} present as reference material, while an
  * {@link ChartSearchAiConstants#RESOURCE_TYPE_ACTIVE_DRUG_ORDER} record is the patient's own active

--- a/api/src/test/java/org/openmrs/module/chartsearchai/ChartSearchAiReferenceGroupTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/ChartSearchAiReferenceGroupTest.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -24,7 +25,11 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Contract of {@link ChartSearchAiUtils#referenceGroup}, the single entry point deciding
- * whether a cited record renders as chart evidence or as module-supplied reference prose.
+ * whether a cited record renders as chart evidence or as module-supplied reference prose —
+ * and, since issue #122, of {@link ChartSearchAiUtils#isGroundingDemoteOnly}, the grounding
+ * rule derived from it. Both registries are swept off one enumeration of the declared
+ * {@code RESOURCE_TYPE_*} constants and one recorded set of decisions, because a new type
+ * satisfying one registry and silently missing the other is the defect #122 reported.
  *
  * <p>Deliberately a plain test rather than a {@code BaseModuleContextSensitiveTest}: the
  * classification is a pure function of the resource type and needs no OpenMRS context, so
@@ -95,9 +100,115 @@ public class ChartSearchAiReferenceGroupTest {
 	 * {@code reference} only when the content is module-supplied material rather than the
 	 * patient's record, in which case {@code referenceGroup} needs updating too, since its fallback
 	 * will not get you there.
+	 *
+	 * <p>Recording {@code reference} has a second consequence since issue #122, so decide knowing it:
+	 * the type becomes demote-only for citation grounding, i.e. its citations can be flagged but never
+	 * verified. That follows from the same provenance judgement — a cosine pass cannot check
+	 * module-rendered prose against itself — and it is asserted by the guard below.
 	 */
 	@Test
 	public void referenceGroup_everyDeclaredResourceTypeConstant_shouldHaveADecidedGroup() {
+		Map<String, String> expected = recordedGroups();
+		Map<String, String> declared = declaredResourceTypeConstants();
+
+		List<String> undecided = new ArrayList<String>();
+		for (Map.Entry<String, String> constant : declared.entrySet()) {
+			if (!expected.containsKey(constant.getKey())) {
+				undecided.add(constant.getKey());
+				continue;
+			}
+			assertEquals(expected.get(constant.getKey()),
+					ChartSearchAiUtils.referenceGroup(constant.getValue()),
+					constant.getKey() + " (\"" + constant.getValue()
+							+ "\") is grouped differently than this test records");
+		}
+		assertTrue(undecided.isEmpty(),
+				"new resource-type constant(s) " + undecided + " have no recorded reference group. "
+						+ "Decide: chart evidence, or module-injected reference material? If injected, "
+						+ "ChartSearchAiUtils.referenceGroup must be updated too — otherwise the new type "
+						+ "is silently published as chart evidence about the patient.");
+
+		// Also assert the reverse direction, so a removed or renamed constant cannot leave a dead
+		// row here quietly claiming to guard a type that no longer exists.
+		List<String> stale = new ArrayList<String>(expected.keySet());
+		stale.removeAll(declared.keySet());
+		assertTrue(stale.isEmpty(),
+				"this test records group(s) for " + stale + ", which are no longer declared in "
+						+ "ChartSearchAiConstants — drop the stale row(s).");
+	}
+
+	/**
+	 * The SECOND registry a resource type is decided in, swept off the same enumeration and the same
+	 * recorded decisions as the group guard above — issue #122.
+	 *
+	 * <p>Why this exists. Grounding treats module-supplied material as demote-only: a cosine pass
+	 * renders {@code null} (unverified), never {@code true}, because an answer sentence citing
+	 * module-rendered reference prose is typically a recitation of it and embeds near-identically to
+	 * its source whether or not it swaps subject roles (#106, measured). That carve-out named
+	 * {@code drug_reference} alone, so when #110 added {@code safety_finding} — duly recorded above as
+	 * reference material — the module's own deterministic findings were graded as if they were
+	 * retrieved chart evidence, and published unstable {@code grounded} verdicts to clinicians for two
+	 * releases. Nothing failed, because only the group registry was guarded.
+	 *
+	 * <p>So the rule is now derived from the group ({@link ChartSearchAiUtils#isGroundingDemoteOnly}),
+	 * and this test asserts it against the group each constant is RECORDED as rather than against
+	 * {@code referenceGroup}'s answer — otherwise a classifier bug would satisfy both registries at
+	 * once and this guard would agree with it.
+	 *
+	 * <p>That the verifier actually honours the rule — no {@code true} verdict, no Tier-2 call, no
+	 * entailment-cap slot — is asserted through the real verifier in
+	 * {@code CitationGroundingVerifierTest.everyDeclaredResourceTypeConstant_isGradedAccordingToItsReferenceGroup};
+	 * it lives there because the verifier's embedder seam is package-private to {@code api.impl}.
+	 */
+	@Test
+	public void everyDeclaredResourceTypeConstant_shouldBeDemoteOnlyForGroundingExactlyWhenItIsReferenceMaterial() {
+		Map<String, String> expected = recordedGroups();
+		for (Map.Entry<String, String> constant : declaredResourceTypeConstants().entrySet()) {
+			String recorded = expected.get(constant.getKey());
+			if (recorded == null) {
+				// An undecided constant is the group guard's failure to report, not this one's.
+				continue;
+			}
+			boolean referenceMaterial = ChartSearchAiConstants.REFERENCE_GROUP_REFERENCE.equals(recorded);
+			assertEquals(referenceMaterial,
+					ChartSearchAiUtils.isGroundingDemoteOnly(constant.getValue()),
+					constant.getKey() + " (\"" + constant.getValue() + "\") is recorded as " + recorded
+							+ " material, so grounding must " + (referenceMaterial ? "" : "NOT ")
+							+ "treat it as demote-only. Module-supplied material cannot be verified by a "
+							+ "cosine pass (#106); the patient's own records must be, however they reached "
+							+ "the chart (#118). Keep the two registries derived from one classification "
+							+ "rather than re-listing type names in either.");
+		}
+	}
+
+	/**
+	 * Every declared {@code RESOURCE_TYPE_*} constant as name → wire value. The ONE enumeration both
+	 * registry guards above sweep, so a newly declared constant reaches both of them or neither —
+	 * the property whose absence let #110's missing grounding registration ship (issue #122).
+	 */
+	private static Map<String, String> declaredResourceTypeConstants() {
+		Map<String, String> constants = new LinkedHashMap<String, String>();
+		for (Field field : ChartSearchAiConstants.class.getDeclaredFields()) {
+			if (!field.getName().startsWith("RESOURCE_TYPE_") || field.getType() != String.class
+					|| !Modifier.isStatic(field.getModifiers())) {
+				continue;
+			}
+			try {
+				constants.put(field.getName(), (String) field.get(null));
+			}
+			catch (IllegalAccessException e) {
+				throw new AssertionError("could not read " + field.getName(), e);
+			}
+		}
+		return constants;
+	}
+
+	/**
+	 * The group each declared resource type is RECORDED as — the single place the decision lives, read
+	 * by both registry guards above. A constant missing from here is undecided and fails the group
+	 * guard; see its javadoc for how to decide.
+	 */
+	private static Map<String, String> recordedGroups() {
 		Map<String, String> expected = new HashMap<String, String>();
 		expected.put("RESOURCE_TYPE_OBS", ChartSearchAiConstants.REFERENCE_GROUP_CHART);
 		expected.put("RESOURCE_TYPE_CONDITION", ChartSearchAiConstants.REFERENCE_GROUP_CHART);
@@ -121,41 +232,6 @@ public class ChartSearchAiReferenceGroupTest {
 		// navigable like any other chart citation. Chart evidence is what referenceGroup's fallback
 		// yields; the row is here because the decision must be recorded, not inherited by omission.
 		expected.put("RESOURCE_TYPE_ACTIVE_DRUG_ORDER", ChartSearchAiConstants.REFERENCE_GROUP_CHART);
-
-		List<String> undecided = new ArrayList<String>();
-		List<String> seen = new ArrayList<String>();
-		for (Field field : ChartSearchAiConstants.class.getDeclaredFields()) {
-			if (!field.getName().startsWith("RESOURCE_TYPE_") || field.getType() != String.class
-					|| !Modifier.isStatic(field.getModifiers())) {
-				continue;
-			}
-			seen.add(field.getName());
-			if (!expected.containsKey(field.getName())) {
-				undecided.add(field.getName());
-				continue;
-			}
-			String value;
-			try {
-				value = (String) field.get(null);
-			}
-			catch (IllegalAccessException e) {
-				throw new AssertionError("could not read " + field.getName(), e);
-			}
-			assertEquals(expected.get(field.getName()), ChartSearchAiUtils.referenceGroup(value),
-					field.getName() + " (\"" + value + "\") is grouped differently than this test records");
-		}
-		assertTrue(undecided.isEmpty(),
-				"new resource-type constant(s) " + undecided + " have no recorded reference group. "
-						+ "Decide: chart evidence, or module-injected reference material? If injected, "
-						+ "ChartSearchAiUtils.referenceGroup must be updated too — otherwise the new type "
-						+ "is silently published as chart evidence about the patient.");
-
-		// Also assert the reverse direction, so a removed or renamed constant cannot leave a dead
-		// row here quietly claiming to guard a type that no longer exists.
-		List<String> stale = new ArrayList<String>(expected.keySet());
-		stale.removeAll(seen);
-		assertTrue(stale.isEmpty(),
-				"this test records group(s) for " + stale + ", which are no longer declared in "
-						+ "ChartSearchAiConstants — drop the stale row(s).");
+		return expected;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CitationGroundingVerifierTest.java
@@ -14,6 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -24,6 +26,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.ChartSearchAiUtils;
 import org.openmrs.module.chartsearchai.api.ChartSearchService.RecordReference;
 import org.openmrs.module.chartsearchai.api.impl.CitationGroundingVerifier.TextEmbedder;
 import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
@@ -931,6 +934,129 @@ public class CitationGroundingVerifierTest {
 		assertNull(result.get(0).getGrounded());
 	}
 
+	// ---- injected safety-finding citations (issue #122): reference material, so demote-only ----
+
+	/**
+	 * The real injected safety-finding record the REAL production chain renders for the canonical
+	 * case — a patient on simvastatin asked about clarithromycin — off the bundled DDInter sample
+	 * (load → parse → validate → injectRecords → renderFinding). The whole mapping rather than only
+	 * its text, unlike {@link #realReferenceRecordText}: the record's own citation index is what an
+	 * answer sentence has to cite, and its real resource type is what the carve-out keys on.
+	 */
+	private static RecordMapping realSafetyFinding() {
+		return org.openmrs.module.chartsearchai.reference.DrugReferenceTestSupport
+				.injectedSafetyFinding("is it safe to give clarithromycin?", "simvastatin", "C10AA01");
+	}
+
+	/** The answer sentence a finding gets cited by — the model reporting the finding line it was
+	 *  handed, which is the behaviour #110 injected the record to produce. */
+	private static String findingCitingSentence(RecordMapping finding) {
+		return "Not safe — clarithromycin interacts with the patient's active simvastatin order ["
+				+ finding.getIndex() + "].";
+	}
+
+	@Test
+	public void safetyFinding_highCosinePassRendersUnverifiedNotVerified() {
+		// Issue #122. #110 injects the deterministic drug-safety join as a citable record so the answer
+		// reports a conclusion it will not re-derive; #106 had already established that module-supplied
+		// injected records are demote-only. safety_finding was never registered with that carve-out, so
+		// the module's own arithmetic was graded as if it were retrieved chart evidence — and the grade
+		// tracked embedding noise, not the finding: on the 3.7.1 standalone at 13690b1, Margaret King +
+		// voxelotor returned the MAJOR finding grounded=false beside two byte-identical Moderate
+		// siblings at true, and one finding flipped true->false across two runs of one probe.
+		//
+		// The record's prose is exactly the shape #106 measured the hazard on — "<Drug> interacts with
+		// active order <Partner> — Major. <mechanism>", reference prose whose subject roles can swap
+		// while still embedding near-identically — and the citing sentence is a recitation of it. So a
+		// cosine pass carries no faithfulness signal, and publishing it as `true` is false assurance.
+		RecordMapping finding = realSafetyFinding();
+		String sentence = findingCitingSentence(finding);
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(finding.getText(), AXIS_A); // recitation overlap -> cosine 1.0 -> would pass
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(finding.getIndex()))),
+				Arrays.asList(finding), FLOOR, TIER1_ONLY);
+
+		assertNull(result.get(0).getGrounded(),
+				"a cosine pass on the module's own deterministic finding must render unverified, "
+						+ "never verified");
+	}
+
+	@Test
+	public void safetyFinding_offTopicCitationIsStillFlagged() {
+		// Demote-only, NOT exempt-from-grounding — the alternative issue #122 asked to decide rather
+		// than default. A FALSE verdict here is not the module doubting its own arithmetic, which
+		// would indeed be a meaningless claim; it is a statement about the CITATION — the model
+		// attached the finding's number to a sentence the finding is not about. That is real,
+		// observable and worth flagging, and it is the residual signal #106 deliberately kept when it
+		// removed the passing verdict. Exempting entirely would discard it, and (since drug_reference
+		// keeps its flag) could only be done for safety_finding alone — a per-type branch in the very
+		// registry this issue exists to stop keying off type names.
+		RecordMapping finding = realSafetyFinding();
+		String sentence = "The patient's blood pressure is well controlled [" + finding.getIndex() + "].";
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(finding.getText(), AXIS_B); // orthogonal -> cosine 0.0 -> off-topic
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(finding.getIndex()))),
+				Arrays.asList(finding), FLOOR, TIER1_ONLY);
+
+		assertEquals(Boolean.FALSE, result.get(0).getGrounded(),
+				"an off-topic safety-finding citation must still be flagged");
+	}
+
+	@Test
+	public void safetyFinding_neverEntersTier2Entailment() {
+		// The judge cannot help here either: its "yes" on a recitation of module-rendered prose is the
+		// false assurance #106 measured (4/4 role-swapped recitations judged entailed, the one faithful
+		// recitation judged not). So the pair is skipped rather than discounted afterwards.
+		RecordMapping finding = realSafetyFinding();
+		String sentence = findingCitingSentence(finding);
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(finding.getText(), AXIS_A);
+		llm.verdict = Boolean.TRUE; // would falsely verify the recitation
+
+		List<RecordReference> result = verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(finding.getIndex()))),
+				Arrays.asList(finding), FLOOR, TIER2_ON);
+
+		assertEquals(0, llm.calls, "safety-finding citations must never reach the entailment LLM");
+		assertNull(result.get(0).getGrounded(), "with Tier-2 skipped, the Tier-1 pass renders unverified");
+	}
+
+	@Test
+	public void safetyFinding_doesNotConsumeTheEntailmentCapOfChartCitations() {
+		// The second half of the defect, and the one a client cannot see: these records were also
+		// spending the per-answer entailment budget that #106's rationale reserves for chart claims,
+		// and a polypharmacy answer can carry several findings. Cap-boundary pin, mirroring the
+		// drug-reference test above — the finding comes FIRST, followed by exactly cap-many chart
+		// citations, so a consumed slot pushes the LAST chart citation past the cap and leaves it on
+		// its Tier-1 verdict. Chart indexes are offset past the finding's real index so the two
+		// citation numberings cannot collide.
+		int cap = ChartSearchAiConstants.GROUNDING_ENTAILMENT_MAX_CHECKS;
+		RecordMapping finding = realSafetyFinding();
+		int base = finding.getIndex();
+		StringBuilder answer = new StringBuilder(findingCitingSentence(finding)).append(" ");
+		List<RecordReference> refs = new ArrayList<RecordReference>();
+		List<RecordMapping> maps = new ArrayList<RecordMapping>();
+		refs.add(reference(base));
+		maps.add(finding);
+		for (int i = 1; i <= cap; i++) {
+			answer.append("claim ").append(i).append(" [").append(base + i).append("]. ");
+			refs.add(reference(base + i));
+			maps.add(mapping(base + i, "record " + i));
+		}
+		llm.verdict = Boolean.TRUE;
+
+		List<RecordReference> result = verifier.verify(answer.toString(), refs, maps, FLOOR, TIER2_ON);
+
+		assertEquals(cap, llm.calls,
+				"chart citations alone fill the cap; the excluded safety-finding pair must not count");
+		assertEquals(Boolean.TRUE, result.get(cap).getGrounded(),
+				"the last chart citation must still get its Tier-2 verdict — a consumed slot would leave it FALSE");
+	}
+
 	// ---- injected active-order citations (issue #118): graded normally, NOT demote-only ----
 
 	/** A mapping typed as an injected active-order record, carrying the real {@code Order} uuid the
@@ -992,6 +1118,85 @@ public class CitationGroundingVerifierTest {
 		assertEquals(1, llm.calls, "an active-order citation must be judged by the entailment LLM");
 		assertEquals(Boolean.FALSE, result.get(0).getGrounded(),
 				"and Tier-2's verdict must be authoritative for it, overriding the Tier-1 cosine pass");
+	}
+
+	// ---- the grounding registry every resource type must be decided in (issue #122) ----
+
+	/**
+	 * Runs the REAL verifier over ONE cited record of {@code resourceType} whose text is aligned with
+	 * its citing sentence — a Tier-1 PASS, which is the only verdict the carve-out changes (a cosine
+	 * FAIL flags every type alike) — and returns the verdict published for it. Re-arms the stubs
+	 * first, so {@code llm.calls} afterwards counts this type's Tier-2 entry alone.
+	 *
+	 * <p>Synthetic record text, deliberately: the carve-out keys on the resource type, and most of
+	 * these types have no injector in this module to render real prose from. What the real prose does
+	 * under a cosine pass is asserted by the {@code realSafetyFinding} / {@code realReferenceRecordText}
+	 * tests above; this helper's subject is the type registry.
+	 */
+	private Boolean verdictForAlignedCitation(String resourceType, boolean entailmentEnabled) {
+		setUp();
+		llm.verdict = Boolean.TRUE;
+		String sentence = "The record supports this claim [4].";
+		String record = "record text for " + resourceType;
+		embeddings.register(sentence, AXIS_A);
+		embeddings.register(record, AXIS_A);
+		return verifier.verify(sentence,
+				new ArrayList<RecordReference>(Arrays.asList(reference(4))),
+				Arrays.asList(new RecordMapping(4, resourceType, "uuid-4", null, record)),
+				FLOOR, entailmentEnabled).get(0).getGrounded();
+	}
+
+	/**
+	 * The forcing function issue #122 asked for, and the reason that issue existed at all. An injected
+	 * resource type has to be registered in TWO places: {@link ChartSearchAiUtils#referenceGroup},
+	 * which a reflective sweep in {@code ChartSearchAiReferenceGroupTest} has always guarded, and the
+	 * demote-only grounding carve-out, which nothing guarded. #110 duly did the first and missed the
+	 * second, so the module's own deterministic findings were graded as retrieved chart evidence with
+	 * no error raised anywhere.
+	 *
+	 * <p>The carve-out is now DERIVED from the group
+	 * ({@link ChartSearchAiUtils#isGroundingDemoteOnly}), and this sweep is what keeps it derived:
+	 * re-hardcoding it as a list of type names still passes today — today's list and today's groups
+	 * agree — and fails the moment a fourth injected type is added, which is exactly when the omission
+	 * would otherwise ship again. Its counterpart in {@code ChartSearchAiReferenceGroupTest} asserts
+	 * the same rule against the group each constant is RECORDED as, so the two registries cannot drift
+	 * together either.
+	 *
+	 * <p>Asserts carve-out MEMBERSHIP — through the verdict the real verifier publishes and its Tier-2
+	 * entry — not the live instability that motivated the issue: those flips are embedding-driven, so
+	 * no unit test reproduces them. The chart-group half of each assertion is the positive control that
+	 * the machinery under it is working.
+	 */
+	@Test
+	public void everyDeclaredResourceTypeConstant_isGradedAccordingToItsReferenceGroup() throws Exception {
+		int swept = 0;
+		for (Field field : ChartSearchAiConstants.class.getDeclaredFields()) {
+			if (!field.getName().startsWith("RESOURCE_TYPE_") || field.getType() != String.class
+					|| !Modifier.isStatic(field.getModifiers())) {
+				continue;
+			}
+			swept++;
+			String type = (String) field.get(null);
+			String group = ChartSearchAiUtils.referenceGroup(type);
+			boolean referenceMaterial = ChartSearchAiConstants.REFERENCE_GROUP_REFERENCE.equals(group);
+			String label = field.getName() + " (\"" + type + "\", group " + group + ")";
+
+			assertEquals(referenceMaterial ? null : Boolean.TRUE,
+					verdictForAlignedCitation(type, TIER1_ONLY),
+					label + ": a cosine PASS must render " + (referenceMaterial
+							? "unverified — module-supplied material is demote-only (#106, #122)"
+							: "verified — chart evidence is graded normally, however it reached the chart"));
+
+			Boolean underEntailment = verdictForAlignedCitation(type, TIER2_ON);
+			assertEquals(referenceMaterial ? 0 : 1, llm.calls, label + ": " + (referenceMaterial
+					? "module-supplied material must not reach Tier-2, nor consume the per-answer cap "
+							+ "that chart claims rely on"
+					: "chart evidence must be judged by the entailment LLM"));
+			assertEquals(referenceMaterial ? null : Boolean.TRUE, underEntailment,
+					label + ": the entailment-mode verdict must agree with the Tier-1-only one for "
+							+ "this group — the carve-out is mode-uniform");
+		}
+		assertTrue(swept > 0, "the RESOURCE_TYPE_* sweep matched no constants, so it asserts nothing");
 	}
 
 	/** Index of the first {@code entailsBatch} call whose statement list contains {@code statement}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceTestSupport.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceTestSupport.java
@@ -101,8 +101,9 @@ public final class DrugReferenceTestSupport {
 	 * The real safety-finding record the REAL pipeline injects for {@code question} asked about a
 	 * patient on {@code activeDrug} (with ATC code {@code atcCode}) — the whole production chain,
 	 * bundled DDInter sample through {@code DrugSafetyValidator.validate} and
-	 * {@code injectRecords}/{@code renderFinding}, with the validator wired exactly as production
-	 * wires it. The third cross-package accessor, for the grounding tests.
+	 * {@code injectRecords}/{@code renderFinding}, with the real validator behind the real injector
+	 * (through the same {@code set*} seams the other helpers here use, in place of production's
+	 * autowiring). The third cross-package accessor, for the grounding tests.
 	 *
 	 * <p>Returns the {@link RecordMapping} rather than only its text because a grounding test needs
 	 * the resource type and the citation index too, and because the argument for treating this record

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceTestSupport.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceTestSupport.java
@@ -97,6 +97,34 @@ public final class DrugReferenceTestSupport {
 						"no active-order record was injected for order: " + display));
 	}
 
+	/**
+	 * The real safety-finding record the REAL pipeline injects for {@code question} asked about a
+	 * patient on {@code activeDrug} (with ATC code {@code atcCode}) — the whole production chain,
+	 * bundled DDInter sample through {@code DrugSafetyValidator.validate} and
+	 * {@code injectRecords}/{@code renderFinding}, with the validator wired exactly as production
+	 * wires it. The third cross-package accessor, for the grounding tests.
+	 *
+	 * <p>Returns the {@link RecordMapping} rather than only its text because a grounding test needs
+	 * the resource type and the citation index too, and because the argument for treating this record
+	 * as module-supplied material is an argument about what THIS prose does under a cosine pass
+	 * (issue #122) — a hand-assembled imitation of the finding line would not be testing it.
+	 *
+	 * @throws IllegalStateException when the question raises no deterministic finding, so a test
+	 *         cannot silently assert nothing
+	 */
+	public static RecordMapping injectedSafetyFinding(String question, String activeDrug, String atcCode) {
+		DrugReferenceService service = ddinterService();
+		service.setCrossReactivityGroups(bundledGroups());
+		DrugReferenceInjector injector = injector(service);
+		injector.setDrugSafetyValidator(validator(service));
+		PatientChart chart = injector.injectRecords(oneRecordChart(),
+				ctx(60, null, set(activeDrug), set(atcCode), null, null), question);
+		return chart.getMappings().stream()
+				.filter(m -> ChartSearchAiConstants.RESOURCE_TYPE_SAFETY_FINDING.equals(m.getResourceType()))
+				.findFirst().orElseThrow(() -> new IllegalStateException(
+						"no safety-finding record was injected for question: " + question));
+	}
+
 	/** The real WHO ATC sample fixture (parsed by the real {@link AtcDrugReferenceSource#parse}). */
 	static final String ATC_SAMPLE = "atc/atc-sample.tsv";
 


### PR DESCRIPTION
Fixes #122.

## The defect

#106 established that module-supplied injected records are **demote-only** for citation grounding: a cosine pass may render `null`, never `true`. The carve-out named one resource type, so when #110 made the deterministic safety finding a citable record it was classified as reference material by `ChartSearchAiUtils.referenceGroup` and never registered with the carve-out. The module's own arithmetic was then graded as if it were retrieved chart evidence.

Two consequences, both in the issue and both re-measured here on the 3.7.1 standalone:

1. The published verdict tracked embedding noise rather than the finding. A client that surfaces grounding state showed the module's own safety finding as verified or unverified nondeterministically — the chip saying **Major** beside a citation saying ungrounded, which is the chip-versus-prose divergence #110 exists to remove, reappearing one layer up.
2. The findings consumed Tier-2 entailment **cap** slots that #106's rationale reserves for chart claims — several on a polypharmacy answer.

## The fix: one rule, keyed off one definition

Not a second type name in the condition. The carve-out is now derived from the existing classifier through a named rule:

```java
// ChartSearchAiUtils
public static boolean isGroundingDemoteOnly(String resourceType) {
    return ChartSearchAiConstants.REFERENCE_GROUP_REFERENCE.equals(referenceGroup(resourceType));
}
```

`CitationGroundingVerifier` asks that instead of comparing `resourceType`. So "module-supplied material is demote-only" is one rule keyed off one classification, and the next injected type inherits the correct side of it rather than having to be remembered in a second place. The named rule (rather than an inline expression) exists because the guard that keeps the two registries in step has to read it from another package.

All three injected types land correctly, with no per-type list:

| type | group | grounding |
|---|---|---|
| `drug_reference` | `reference` | demote-only (#106) |
| `safety_finding` | `reference` | demote-only — **this fix** |
| `active_drug_order` (#118) | `chart` | graded normally, unchanged |

`active_drug_order` is deliberately untouched, and #124's reasoning for that is kept at the carve-out site: it is the patient's own active order carrying the real `Order` uuid, one drug name asserted of this patient with no subject roles to swap, so a passing verdict is real assurance. Keyed off the group it stays graded with nothing to remember. That same reasoning is what sharpens the case for this fix — a finding's text (`"<Drug> interacts with active order <Partner> — Major. <mechanism>"`) is exactly the role-swappable reference prose #106 measured the hazard on.

## The design question, decided rather than defaulted

**Demote-only, not exempt-from-grounding.** The issue notes that arguing a finding can be *demoted* seems to imply the module's own arithmetic might be unsupported by the chart, which is not a meaningful claim. That objection conflates two different things:

- A `false` verdict is **not** a claim about the finding's content. It is a claim about the **citation**: the model attached the finding's number to a sentence the finding is not about. That is real, observable and worth flagging — a Major-interaction finding cited beside "the patient's blood pressure is well controlled" is a defect a clinician should see marked. It is the same residual signal #106 deliberately kept when it withheld the passing verdict.
- Exempting entirely would discard that signal, and — because `drug_reference` keeps its flag — it could only be done for `safety_finding` alone. That means a per-type branch in exactly the registry this issue exists to stop keying off type names, re-opening the trap for the fourth type.

So: `true` is withheld (it is false assurance), `false` is kept (it is information), and the rule stays one line derived from provenance. The tests state this reasoning at the assertion that pins it.

## The guard, widened to both registries

`ChartSearchAiReferenceGroupTest` swept the group classifier; nothing swept the grounding carve-out, which is exactly why #110's registration was missed with no failure anywhere. Both are now asserted off **one** reflective enumeration of the declared `RESOURCE_TYPE_*` constants and **one** recorded set of decisions:

- `referenceGroup_everyDeclaredResourceTypeConstant_shouldHaveADecidedGroup` — unchanged assertions and messages; its inline enumeration and expectation map moved to two shared private helpers so the second guard reads the same ones.
- `everyDeclaredResourceTypeConstant_shouldBeDemoteOnlyForGroundingExactlyWhenItIsReferenceMaterial` (new) — asserts the grounding rule against the group each constant is **recorded** as, not against `referenceGroup`'s answer, so a classifier bug cannot satisfy both registries at once.
- `CitationGroundingVerifierTest.everyDeclaredResourceTypeConstant_isGradedAccordingToItsReferenceGroup` (new) — the same sweep through the **real verifier**: for every declared type, a cosine pass renders `null` for reference material and `true` for chart evidence, and reference material makes zero Tier-2 calls while chart evidence makes one. It lives there because the embedder seam is package-private to `api.impl`.

Re-hardcoding the rule as `DRUG_REFERENCE || SAFETY_FINDING` still passes today — today's list and today's groups agree — and fails the moment a fourth injected type is added, which is the moment the omission would otherwise ship again.

## Tests

TDD, through the real verifier and the real injected record. The four new `safety_finding` tests use the record the **real production chain** renders (bundled DDInter sample → `DrugSafetyValidator.validate` → `injectRecords` → `renderFinding`), reached through a new cross-package accessor beside the existing `injectedDdinterReferenceText` / `injectedActiveOrderText` ones — the argument for demote-only is an argument about what that prose does under a cosine pass, so a hand-assembled imitation would not be testing it.

RED first, on unmodified production code:

```
CitationGroundingVerifierTest.safetyFinding_highCosinePassRendersUnverifiedNotVerified
    expected: <null> but was: <true>
CitationGroundingVerifierTest.safetyFinding_neverEntersTier2Entailment
    safety-finding citations must never reach the entailment LLM ==> expected: <0> but was: <1>
CitationGroundingVerifierTest.safetyFinding_doesNotConsumeTheEntailmentCapOfChartCitations
    the last chart citation must still get its Tier-2 verdict ==> expected: <true> but was: <false>
CitationGroundingVerifierTest.everyDeclaredResourceTypeConstant_isGradedAccordingToItsReferenceGroup
    RESOURCE_TYPE_SAFETY_FINDING ("safety_finding", group reference) ==> expected: <null> but was: <true>
```

and, with the rule extracted but still keyed on the type (i.e. the pre-fix semantics), the widened guard reproduces #110's omission as a failure:

```
ChartSearchAiReferenceGroupTest.everyDeclaredResourceTypeConstant_shouldBeDemoteOnlyForGroundingExactlyWhenItIsReferenceMaterial
    RESOURCE_TYPE_SAFETY_FINDING ("safety_finding") is recorded as reference material, so grounding
    must treat it as demote-only ==> expected: <true> but was: <false>
```

`safetyFinding_offTopicCitationIsStillFlagged` passes before and after by construction — a cosine fail flags every type alike. It is there to pin the decision above, not to demonstrate the fix, and the test says so.

Mutation-checked in the other direction too: making the rule "everything the module injects is demote-only" fails 4 tests, including both new sweeps and #118's two `activeDrugOrder_*` tests.

**Not claimed:** the instability itself is embedding-driven and is not unit-testable. The unit tests assert carve-out membership — the verdict the verifier publishes and its Tier-2 entry — not a reproduction of the flips.

`mvn clean install` from the repo root, full reactor:

| | API | OMOD | total | failures | skipped |
|---|---|---|---|---|---|
| `main` @ `e73c8b0` (measured here) | 784 | 58 | 842 | 0 | 34 |
| this branch | 790 | 58 | 848 | 0 | 34 |

## Live verification

Two locked runs on the shared 3.7.1 standalone (`sourceFormat=ddinter`, full 19MB KB, `minInteractionSeverity=minor`, `chartMode=fullChart`, `llm.engine=local`), same instance, same questions: one build of `main` @ `e73c8b0`, then one of this branch. Grounding config read off the instance for both: `grounding.enabled=true`, `grounding.entailment.enabled=true`, `grounding.minCosine=0.40`, `grounding.clauseScoped=false`, `grounding.async=false`. Assertions are on the `references` array and chip counts, never on wording — answer prose is not reproducible on this box (`cache_prompt` KV reuse).

**BEFORE (`main` @ `e73c8b0`, my build) — the defect, reproduced on the control cases**

| case | cited references |
|---|---|
| Mary + clarithromycin | `#76 drug_reference reference grounded=None`, `#77 safety_finding reference grounded=True` |
| Agnes + warfarin | `#113 drug_reference reference grounded=None`, `#114 safety_finding reference grounded=True` |
| Joshua + ibuprofen | `#41 safety_finding grounded=False`, `#42 safety_finding grounded=True` |
| Mary + clarithromycin (rerun) | `#77 safety_finding reference grounded=True` |
| Mary + paracetamol (×2) | no citations, 0 chips |

5 findings cited, **4 rendered `grounded=true`**, and Joshua's two findings in one answer disagreed with each other — the issue's pattern, on the brief's own control cases. `drug_reference` was correctly `None` throughout, which is the point: the two reference-group types were being treated differently.

**AFTER (this branch)** — same instance, same six questions, and the same five finding records were cited (same citation indexes), so this is a paired comparison rather than two different answers:

| case | chips | cited references |
|---|---|---|
| Mary + clarithromycin | 1, Major ×simvastatin | `#76 drug_reference None`, `#77 safety_finding None` |
| Agnes + warfarin | 1, Major ×aspirin | `#113 drug_reference None`, `#114 safety_finding None` |
| Joshua + ibuprofen | 2 (NSAID cross-reactivity + lisinopril Moderate) | `#41 safety_finding None`, `#42 safety_finding None` |
| Mary + paracetamol | 0 | none |
| Mary + clarithromycin (rerun) | 1, Major ×simvastatin | `#1 drug_order chart False`, `#76 drug_reference None`, `#77 safety_finding None` |
| Mary + paracetamol (rerun) | 0 | none |

- **No reference-group citation renders `grounded=true`** — 5 findings cited, all `null`. The four that were `true` before are `null`; `#41`, which was `false` before (the Tier-2 judge's "no"), is now `null` via the lazy Tier-1 pass clearing the 0.40 floor. That is the demote-only contract on the wire.
- **All four regression controls unchanged**, including the 0-chip case re-run (never trust the first query after a restart for chip absence).
- **Ordinary chart grading is still alive**, which these drug-safety answers cannot show because they cite only injected records: a seventh probe ("What are her active medical conditions?", AFTER-run only) returned five `condition` citations, all with a non-null verdict, plus the `drug_order` citation above. Six graded chart citations in total. The verdict *values* there are pre-existing Tier-2 behaviour and are not touched by this change; what matters is that they are not `null`.

Not claimed from the live runs: anything about answer wording, and any conclusion from a single run — the flip-flopping this issue reports is embedding-driven, and the fix removes the verdict rather than stabilising it.

## Notes for the reviewer

- Three javadoc blocks asserted the old behaviour as a *property* and are now corrected rather than tightened: `REFERENCE_GROUP_REFERENCE` ("that gate keys on the `drug_reference` resource type … `RESOURCE_TYPE_SAFETY_FINDING` is reference-group yet graded normally"), `referenceGroup` ("the demote-only grounding gate … legitimately tests the type directly"), and the carve-out comment ("deliberately narrower than `ChartSearchAiUtils.referenceGroup`"). Every measured number and named failure mode in them is preserved; only the claims this change makes false were rewritten.
- `ChartSearchAiRestController.serializeReferences` already assumed the group-wide property — "reference-group citations never consume the entailment budget anyway (the #106 demote-only carve-out)" — when arguing its group sort cannot shift Tier-2 cap membership. That was not true for `safety_finding` before this change; it is now. No edit needed there, but the argument was resting on this fix.
- The live runs used the brief's four controls verbatim plus a rerun of the headline and of the 0-chip case; the chart-citation control was added for the AFTER run only, after the BEFORE run showed these drug-safety answers cite no chart records at all.
- One wording nit left alone deliberately: `activeDrugOrder_highCosinePassRendersVerifiedNotDemoted`'s failure message says demote-only is "scoped to drug-reference prose (#106), not to everything injected". The assertion is correct and unchanged; the parenthetical now reads narrowly, since the scope is module-supplied reference prose generally. Editing an existing test's text was out of scope for this change — flagging it instead.
