### PR TITLE
fix(drug-safety): fold diacritics when matching order names against interaction tokens

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -9,12 +9,14 @@
  */
 package org.openmrs.module.chartsearchai.reference;
 
+import java.text.Normalizer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -278,7 +280,8 @@ public class DrugReference {
 	 *         each side by a non-alphanumeric character or the string edge. Whole-word, not
 	 *         substring, so a drug name nested inside a longer one does not spuriously match
 	 *         ("chlorothiazide" is not a whole word in "hydrochlorothiazide"), while a real token
-	 *         still matches ("aspirin" in "Aspirin 81 mg"). Case-insensitive; a null or empty word
+	 *         still matches ("aspirin" in "Aspirin 81 mg"). Case-insensitive and
+	 *         diacritic-insensitive (see {@link #containsBoundedToken}); a null or empty word
 	 *         never matches. Backs {@link #matchesText} (alias-in-prose); the active-order
 	 *         counterpart is {@link #matchesOrderName}, which shares this rule's left boundary but
 	 *         not its right one — see there for why one matcher cannot serve both.
@@ -344,6 +347,45 @@ public class DrugReference {
 	 * the record: 2 of the 829 are a nitroglycerin order matching the token {@code glycerin} through
 	 * its own parenthetical synonym ("glycerine trinitrate") — a mislabel, not a fabricated drug, and
 	 * one every rule that tolerates an inflectional tail shares.
+	 *
+	 * <p><b>Diacritics (issue #129).</b> The comparison folds them — see
+	 * {@link #containsBoundedToken}, which is where the fold lives and why it lives there. DDInter's
+	 * tokens are unaccented RxNorm generics while a localized dictionary spells the same drug with
+	 * accents, so unfolded an order named {@code Budésonide} shared no substring with
+	 * {@code budesonide} at the accented character and that patient was never checked against
+	 * budesonide's interaction rules at all — the same silent absence as a false negative, arriving by
+	 * a different route. Re-measured over the same corpus with the shipped matchers:
+	 *
+	 * <pre>
+	 *   rule                            matches   nested-name collisions leaking   accented names matched
+	 *   this matcher, unfolded (#128)     829     0 of 9   (0 of 12 accented)      2 of 10
+	 *   this matcher, folded (#129)       907     0 of 9   (0 of 12 accented)     10 of 10
+	 * </pre>
+	 *
+	 * 224 of the 2531 names carry a diacritic. Folding both operands makes the change a pure
+	 * relaxation — 78 pairs added, <em>0 removed</em> — which is what let this widening be scored
+	 * against #128's kill set instead of argued about, and the kill set includes the accented
+	 * spellings, which are the ones folding could newly break: {@code nitroglycérine} folds to
+	 * {@code nitroglycerine}, i.e. {@code glycerin} plus one inflectional letter, so it becomes a
+	 * candidate for that token at the very moment {@code glycérine} legitimately does, and only the
+	 * LEFT boundary separates them.
+	 *
+	 * <p>76 of the 78 are an accented spelling of the token's own drug ({@code héparine} ~ heparin,
+	 * {@code lévofloxacine} ~ levofloxacin, {@code énoxaparine} ~ enoxaparin). The other two, for the
+	 * record, are both the PHRASE nesting no boundary rule can see rather than a new class of error:
+	 * {@code preparado de activador del plasminógeno tipo tisular} (tissue plasminogen ACTIVATOR)
+	 * matches {@code plasminogen}, that token's only match in this dictionary, inheriting
+	 * bleeding-risk rules that fit a fibrinolytic anyway; and
+	 * {@code acétaminophene,pseudo-éphédrine,…} matches {@code ephedrine} across the hyphen, which its
+	 * English twin row {@code Acetaminophen,Pseudo-ephedrine,…} already did before this change — so
+	 * the fold makes one product's two spellings agree rather than introducing that imprecision.
+	 * Both are a mislabel of a drug the patient IS on, like the {@code glycerin} case above.
+	 *
+	 * <p>Misspellings are deliberately NOT accommodated. {@code Lisoniazide} and
+	 * {@code Sprironolactone} are typo'd rows in this same dictionary; folding leaves both unmatched
+	 * (measured before and after), and it must stay that way — matching a typo means matching a name
+	 * that differs from the token by an edit, which reopens the substring hazard from the other side.
+	 * They are a data-quality problem, not a matcher problem.
 	 */
 	static boolean matchesOrderName(String orderName, String token) {
 		return containsBoundedToken(orderName, token, MAX_ORDER_NAME_INFLECTION_LETTERS);
@@ -366,13 +408,36 @@ public class DrugReference {
 	 * its token, and the {@code ddinter} and {@code atc} sources drop blank aliases at parse. A
 	 * hand-authored {@code json} KB is NOT sanitized, so a blank alias there still matches any text
 	 * carrying two adjacent spaces — pre-existing, and an authoring guard belongs in that parser.
+	 *
+	 * <p>Diacritic-insensitive on BOTH sides (issue #129), which is why the fold lives here rather
+	 * than in either named matcher: the same accented order name reaches both of them — as the
+	 * haystack when a rule token is matched against it ({@link #matchesOrderName}) and as the
+	 * haystack again when the screening arm resolves that order's own reference entry
+	 * ({@code DrugSafetyValidator.activeOrderEntries} → {@code findByQuery} → {@link #matchesText}),
+	 * and as the NEEDLE when an order name is looked for in a rendered record
+	 * ({@code PatientClinicalContext.ActiveDrugOrder.namedIn}). Folding one matcher would leave the
+	 * same patient half-checked; folding one SIDE would break that third case, whose needle is the
+	 * patient's accented name. Folding both operands also makes the change a pure relaxation —
+	 * everything that matched before still matches — which is what let the widening be measured
+	 * against #128's kill set rather than argued about.
+	 *
+	 * <p>Folding the reference side is a no-op on every shipped dataset and is not there for gain:
+	 * measured over the full DDInter KB, 0 of its 2093 rule tokens and 0 of its 5169 aliases carry a
+	 * combining mark, and no two tokens fold together. It is there because a hand-authored
+	 * {@code json} KB may carry an accented alias, and a one-sided fold would then silently stop
+	 * matching the accented order name it was written for.
 	 */
 	private static boolean containsBoundedToken(String text, String token, int maxTrailingLetters) {
-		if (text == null || token == null || token.isEmpty()) {
+		if (text == null || token == null) {
 			return false;
 		}
-		String t = text.toLowerCase(Locale.ROOT);
-		String w = token.toLowerCase(Locale.ROOT);
+		String t = foldDiacritics(text.toLowerCase(Locale.ROOT));
+		String w = foldDiacritics(token.toLowerCase(Locale.ROOT));
+		if (w.isEmpty()) {
+			// After the fold, not before: a token of nothing but combining marks folds to empty, and
+			// the empty token matches almost anything below.
+			return false;
+		}
 		int idx = t.indexOf(w);
 		while (idx >= 0) {
 			if (idx == 0 || !Character.isLetterOrDigit(t.charAt(idx - 1))) {
@@ -391,6 +456,46 @@ public class DrugReference {
 			idx = t.indexOf(w, idx + 1);
 		}
 		return false;
+	}
+
+	/** Unicode non-spacing marks — the combining accents an NFD decomposition separates out. */
+	private static final Pattern NON_SPACING_MARKS = Pattern.compile("\\p{Mn}+");
+
+	/**
+	 * @return {@code value} with its diacritics folded away — canonically decomposed (NFD) and
+	 *         stripped of combining non-spacing marks, so {@code budésonide} compares as
+	 *         {@code budesonide}. The one definition, used on both operands of
+	 *         {@link #containsBoundedToken}; never call {@link Normalizer} for this elsewhere.
+	 *
+	 *         <p>Decompose-and-strip rather than a hand-rolled character map: a map has to be
+	 *         maintained per language and silently stops folding the first accent nobody listed
+	 *         (this dictionary alone carries {@code é è ï ô û á ó}), whereas NFD is the Unicode
+	 *         standard's own answer to which marks belong to which letter.
+	 *
+	 *         <p><b>Non-Latin scripts.</b> Stripping {@code Mn} is diacritic folding for Latin,
+	 *         Greek, Cyrillic, Arabic harakat and Hebrew niqqud — all cases where the marks are
+	 *         optional pointing over an unambiguous skeleton. It is NOT lossless everywhere: in Thai
+	 *         and Lao the tone marks are {@code Mn}, and in Indic scripts the virama is, so two
+	 *         distinct words in those scripts can fold together and match each other. That is the
+	 *         same widening this fold is for, one script over, and it is bounded by the boundary rules
+	 *         around it; spacing marks ({@code Mc} — Devanagari matras and the like) are deliberately
+	 *         NOT stripped, because those carry the vowel rather than decorate it. Scripts with no
+	 *         canonical decomposition at all (CJK ideographs) are untouched, and Hangul syllables
+	 *         decompose to Jamo, which are letters and so survive the strip — both sides fold
+	 *         identically, so matching within those scripts is unchanged.
+	 *
+	 *         <p>ASCII returns unchanged without normalizing: every reference token is ASCII and so
+	 *         is most order-name text, and this runs once per (rule token, order name) pair — up to a
+	 *         few hundred rules per question — so the common path must not allocate.
+	 */
+	private static String foldDiacritics(String value) {
+		for (int i = 0; i < value.length(); i++) {
+			if (value.charAt(i) > 0x7F) {
+				return NON_SPACING_MARKS
+						.matcher(Normalizer.normalize(value, Normalizer.Form.NFD)).replaceAll("");
+			}
+		}
+		return value;
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyDiacriticOrderNameTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugSafetyDiacriticOrderNameTest.java
@@ -1,0 +1,318 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.ChartSearchAiConstants;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+
+/**
+ * Both directions of matching an interaction token against an order name whose spelling carries
+ * DIACRITICS (issue #129) — the mirror image of the over-match {@link DrugSafetyOrderNameMatchingTest}
+ * pins. DDInter's tokens are unaccented RxNorm generics, so before the fold a patient ordered
+ * {@code Budésonide} shared no substring with {@code budesonide} at the accented character and was
+ * never checked against that drug's interaction rules at all — the safety net simply absent, with
+ * nothing logged. Measured over the 3.7.1 demo dictionary (2531 drug and drug-concept names x the
+ * full KB's 2093 rule tokens), folding recovers 78 matches the raw comparison misses, and 224 of
+ * those 2531 names carry a diacritic.
+ *
+ * <ul>
+ *   <li><b>Must now fire.</b> Every accented order name below is a real row in that dictionary —
+ *       {@code Budésonide}, {@code Dexaméthasone}, {@code Héparine}, {@code glycérine},
+ *       {@code Lévofloxacine} — and each is paired here with the unaccented spelling of the SAME
+ *       product, also a real row, so the only difference between the case that fired and the case
+ *       that did not is the diacritic.</li>
+ *   <li><b>Must still not fire.</b> Folding WIDENS matching, so it can resurrect the nested-name
+ *       over-match issue #86 removed: {@code glycérine} folds to {@code glycerine}, which is
+ *       {@code glycerin} plus one inflectional letter, so it becomes matchable at the very moment
+ *       {@code nitroglycérine} becomes a candidate for the same token. The left boundary is what has
+ *       to keep rejecting the second, and the whole #128 kill set is re-asserted here for that
+ *       reason — including its three cases whose long name is itself accented
+ *       ({@code Nitroglycérine ~ glycerin}, {@code Budésonide ~ desonide},
+ *       {@code Lévofloxacine/Ciprofloxacine ~ ofloxacin}), which are the ones folding could newly
+ *       break.</li>
+ *   <li><b>Every matcher the same name reaches.</b> The fold lives in the one shared boundary scan, so
+ *       these also cover the two arms where the accented name is not a rule token's haystack: the
+ *       interaction screen, which resolves an order's own reference entry through
+ *       {@link DrugReference#matchesText}, and the chart reconciliation, where the accented name is
+ *       the NEEDLE inside a rendered record. Moving the fold into
+ *       {@link DrugReference#matchesOrderName} alone, or applying it to one side only, leaves the
+ *       other tests green and fails those two.</li>
+ *   <li><b>Not tuned for misspellings.</b> {@code Lisoniazide} and {@code Sprironolactone} are typos
+ *       in this same dictionary. They stay unmatched deliberately: accommodating them reopens the
+ *       substring hazard from the other side, and a data-quality problem is not a matcher problem.
+ *       Nothing here asserts them either way, so this class does not fossilize them.</li>
+ * </ul>
+ *
+ * <p>Every scenario runs the real pipeline: a verbatim KB slice parsed by the real
+ * {@link DdiDrugReferenceSource}, the real
+ * {@link DrugSafetyValidator#validate(String, String, PatientClinicalContext)}, GP reads on their
+ * no-context defaults (so the severity floor is the production {@code minor}, which filters the
+ * {@code Unknown} rows this slice carries verbatim). Each "must not fire" is paired with the positive
+ * that proves the rule it must not fire on is live, so nothing here can pass by resolving nothing.
+ */
+public class DrugSafetyDiacriticOrderNameTest {
+
+	/**
+	 * A verbatim slice of the full DDInter KB (2283 drugs / 295,184 rows): four subject drugs whose
+	 * rule lists carry, between them, every token of the #128 kill set above the {@code minor} floor,
+	 * plus the partners the accented names must resolve to. The bundled 16-drug sample contains none
+	 * of them, and {@code ddi-order-name-collisions.json} carries only the two collisions #128
+	 * reproduced live — same reason {@code ddi-severity-floor-pair.json} exists.
+	 */
+	private static final String DIACRITIC_SLICE = "chartsearchai-test/ddi-diacritic-order-names.json";
+
+	/** Quinapril carries 15 of this slice's rules, so one question drives most of the table. */
+	private static final String QUINAPRIL_QUESTION = "Is it safe to start quinapril?";
+
+	private static final String QUINAPRIL_ANSWER = "Quinapril could be started with monitoring.";
+
+	private DrugSafetyValidator validator() throws IOException {
+		try (InputStream in = DrugSafetyDiacriticOrderNameTest.class.getClassLoader()
+				.getResourceAsStream(DIACRITIC_SLICE)) {
+			assertNotNull(in, DIACRITIC_SLICE + " should be on the test classpath");
+			return DrugReferenceTestSupport
+					.validator(DrugReferenceTestSupport.serviceWith(DdiDrugReferenceSource.parse(in)));
+		}
+	}
+
+	/**
+	 * The context shape the production builder assembles for the live probe patients: active-order
+	 * display names, no ATC codes. Deliberately no ATC — the name arm is what diacritics break, and an
+	 * ATC-fed context would let the class arm mask it.
+	 */
+	private PatientClinicalContext onOrders(String... orderNames) {
+		return DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set(orderNames), null,
+				null, null);
+	}
+
+	private long interactionCount(List<SafetyWarning> warnings) {
+		return warnings.stream().filter(w -> SafetyWarning.TYPE_INTERACTION.equals(w.getType())).count();
+	}
+
+	@Test
+	public void anAccentedOrderNameIsStillCheckedForInteractions() throws IOException {
+		// {accented order name, unaccented spelling of the same product, the token both must match}.
+		// Every name is a real row in the 3.7.1 demo dictionary, which is bilingual by construction;
+		// the unaccented one is the precondition — it proves the rule is live and the accent is the
+		// only difference. Three of the accented forms are also INFLECTED ("héparine", "glycérine",
+		// "lévofloxacine" = the INN stem, an accent and a trailing -e), so they exercise the fold and
+		// #128's bounded tail together rather than one at a time.
+		String[][] cases = {
+				{ "Budésonide", "Budesonide & Formoterol", "budesonide" },
+				{ "Dexaméthasone", "Dexamethasone Injection vial 8mg", "dexamethasone" },
+				{ "Héparine", "Heparin sodium", "heparin" },
+				{ "glycérine", "Glycerin", "glycerin" },
+				{ "Lévofloxacine", "Levofloxacin", "levofloxacin" } };
+		DrugSafetyValidator validator = validator();
+		for (String[] c : cases) {
+			List<SafetyWarning> unaccented = validator.validate(QUINAPRIL_ANSWER, QUINAPRIL_QUESTION,
+					onOrders(c[1]));
+			assertTrue(DrugReferenceTestSupport.detailContains(unaccented,
+					SafetyWarning.TYPE_INTERACTION, "Quinapril", "active order " + c[2]),
+					"precondition: the unaccented spelling \"" + c[1] + "\" must raise the real quinapril x "
+							+ c[2] + " rule, else the accented case proves nothing, was: " + unaccented);
+
+			List<SafetyWarning> accented = validator.validate(QUINAPRIL_ANSWER, QUINAPRIL_QUESTION,
+					onOrders(c[0]));
+			assertTrue(DrugReferenceTestSupport.detailContains(accented, SafetyWarning.TYPE_INTERACTION,
+					"Quinapril", "active order " + c[2]),
+					"an order named \"" + c[0] + "\" must be checked against " + c[2]
+							+ "'s interaction rules — diacritics are a spelling of the drug, not a "
+							+ "different drug, was: " + accented);
+		}
+	}
+
+	@Test
+	public void theNestedNameOverMatchStaysDeadForAccentedNames() throws IOException {
+		// The kill direction, on the three names where folding is what newly makes the longer name a
+		// candidate for the nested token. Each asserts BOTH halves in one context: the drug the
+		// patient is actually on raises its chip, and the drug nested inside its name does not.
+		DrugSafetyValidator validator = validator();
+
+		// "nitroglycérine" folds to "nitroglycerine": glycerin + one letter, i.e. exactly the tail
+		// #128's allowance tolerates, so only the LEFT boundary ("nitro|glycerin") separates it from
+		// the "glycérine" case above, which must match. Both are real dictionary rows.
+		List<SafetyWarning> onNitroglycerine = validator.validate(QUINAPRIL_ANSWER, QUINAPRIL_QUESTION,
+				onOrders("Nitroglycérine"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onNitroglycerine,
+				SafetyWarning.TYPE_INTERACTION, "Quinapril", "active order nitroglycerin"),
+				"precondition: the folded name must raise its OWN rule, else the absence below proves "
+						+ "nothing, was: " + onNitroglycerine);
+		assertFalse(DrugReferenceTestSupport.detailContains(onNitroglycerine,
+				SafetyWarning.TYPE_INTERACTION, "Quinapril", "active order glycerin"),
+				"a nitroglycerin order must not be reported as an active glycerin order once the accent "
+						+ "is folded away, was: " + onNitroglycerine);
+
+		// "lévofloxacine" folds to "levofloxacine", which carries "ofloxacin" inside a word
+		// ("lev|ofloxacin") — the fluoroquinolone case from issue #129's own comment.
+		List<SafetyWarning> onLevofloxacine = validator.validate(QUINAPRIL_ANSWER, QUINAPRIL_QUESTION,
+				onOrders("Lévofloxacine"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onLevofloxacine,
+				SafetyWarning.TYPE_INTERACTION, "Quinapril", "active order levofloxacin"),
+				"precondition: the folded name must raise its OWN rule, was: " + onLevofloxacine);
+		assertFalse(DrugReferenceTestSupport.detailContains(onLevofloxacine,
+				SafetyWarning.TYPE_INTERACTION, "Quinapril", "active order ofloxacin"),
+				"a levofloxacin order must not be reported as an active ofloxacin order, was: "
+						+ onLevofloxacine);
+
+		// A multi-word accented row, so the nested token is not at the head of the name either:
+		// "furosémide et spironolactone" folds to "...spironolactone", which carries "iron"
+		// ("sp|iron|olactone") — the second of #128's two live-reproduced fabrications.
+		List<SafetyWarning> onFurosemideSpironolactone = validator.validate(QUINAPRIL_ANSWER,
+				QUINAPRIL_QUESTION, onOrders("Furosémide et spironolactone"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onFurosemideSpironolactone,
+				SafetyWarning.TYPE_INTERACTION, "Quinapril", "active order spironolactone", "Major"),
+				"precondition: the folded name must raise its own Major spironolactone rule, was: "
+						+ onFurosemideSpironolactone);
+		assertFalse(DrugReferenceTestSupport.detailContains(onFurosemideSpironolactone,
+				SafetyWarning.TYPE_INTERACTION, "Quinapril", "active order iron"),
+				"a spironolactone order must not be reported as an active iron order once the accent is "
+						+ "folded away, was: " + onFurosemideSpironolactone);
+
+		// "budésonide" folds to "budesonide", which carries "desonide" ("bud|esonide"). Metformin is
+		// the subject because it is metformin — not quinapril — whose rule list carries desonide
+		// (Minor, the topical-corticosteroid-versus-antidiabetic row).
+		String metforminQuestion = "Is it safe to continue her metformin?";
+		String metforminAnswer = "Metformin could be continued.";
+		List<SafetyWarning> onDesonide = validator.validate(metforminAnswer, metforminQuestion,
+				onOrders("Desonide 0.05% cream"));
+		assertTrue(DrugReferenceTestSupport.detailContains(onDesonide, SafetyWarning.TYPE_INTERACTION,
+				"Metformin", "active order desonide", "Minor"),
+				"precondition: a patient actually on desonide must get the real metformin x desonide "
+						+ "chip, else the absence below proves nothing, was: " + onDesonide);
+		List<SafetyWarning> onBudesonide = validator.validate(metforminAnswer, metforminQuestion,
+				onOrders("Budésonide"));
+		assertFalse(DrugReferenceTestSupport.detailContains(onBudesonide, SafetyWarning.TYPE_INTERACTION,
+				"Metformin", "active order desonide"),
+				"a budesonide order must not be reported as an active desonide order once the accent is "
+						+ "folded away, was: " + onBudesonide);
+	}
+
+	@Test
+	public void theIssue86KillSetStillDoesNotFire() throws IOException {
+		// The whole kill set #128 measured, re-asserted here so this widening is pinned against
+		// reintroducing the over-match. Each row is {subject drug, question, order name that CONTAINS
+		// the token, the nested token, an order name the token legitimately names}. The last column is
+		// the precondition: it proves the rule is live in this slice, so the assertion above it cannot
+		// pass by resolving nothing. Order names are dictionary rows where the dictionary has one; the
+		// nested drugs' own names come from the KB rows themselves (the demo dictionary carries no
+		// opium, desonide, oxacillin, chlorothiazide, urea or hydroxyurea row).
+		String[][] rows = {
+				{ "Quinapril", QUINAPRIL_QUESTION, "Tiotropium", "opium", "Opium tincture" },
+				{ "Quinapril", QUINAPRIL_QUESTION, "Spironolactone", "iron", "Iron IR 325mg" },
+				{ "Quinapril", QUINAPRIL_QUESTION, "Nitroglycérine", "glycerin", "Glycerin" },
+				{ "Quinapril", QUINAPRIL_QUESTION, "Hydrochlorothiazide 50mg", "chlorothiazide",
+						"Chlorothiazide" },
+				{ "Quinapril", QUINAPRIL_QUESTION, "Ciprofloxacine", "ofloxacin", "Ofloxacin" },
+				{ "Quinapril", QUINAPRIL_QUESTION, "P-aminosalicylic acid", "salicylic acid",
+						"Salicylic acid" },
+				{ "Metformin", "Is it safe to continue her metformin?", "Budésonide", "desonide",
+						"Desonide 0.05% cream" },
+				{ "Methotrexate", "Can I give methotrexate?", "Cloxacilline Co 500mg", "oxacillin",
+						"Oxacillin" },
+				{ "Lactulose", "Is it safe to give lactulose?", "Hydroxyurea 500mg", "urea", "Urea" } };
+		DrugSafetyValidator validator = validator();
+		for (String[] row : rows) {
+			String subject = row[0];
+			String answer = subject + " could be given.";
+			List<SafetyWarning> onNestingName = validator.validate(answer, row[1], onOrders(row[2]));
+			assertFalse(DrugReferenceTestSupport.detailContains(onNestingName,
+					SafetyWarning.TYPE_INTERACTION, subject, "active order " + row[3]),
+					"\"" + row[2] + "\" must not be reported as an active " + row[3] + " order, was: "
+							+ onNestingName);
+
+			List<SafetyWarning> onNestedDrug = validator.validate(answer, row[1], onOrders(row[4]));
+			assertTrue(DrugReferenceTestSupport.detailContains(onNestedDrug,
+					SafetyWarning.TYPE_INTERACTION, subject, "active order " + row[3]),
+					"precondition: a patient actually on " + row[3] + " must get the real " + subject
+							+ " x " + row[3] + " chip, else the assertion above proves nothing, was: "
+							+ onNestedDrug);
+		}
+	}
+
+	@Test
+	public void anAccentedOrderNameIsStillSubstantiatedByAnUnaccentedChartRecord() throws IOException {
+		// The third call site of the same boundary scan, and the reason the fold is applied to BOTH
+		// operands rather than to the haystack alone: PatientClinicalContext.ActiveDrugOrder.namedIn
+		// looks for the patient's own order name INSIDE a rendered chart record, so here the accented
+		// string is the NEEDLE. The divergence staged below is reachable, not hypothetical — querystore
+		// indexed the drug-order record in one locale while the safety layer read the order in another,
+		// and the same order really does read "Dexamethasone" in en and "Dexaméthasone" in fr on the
+		// 3.7.1 standalone. What a missed match costs here is not a missing chip but a spurious
+		// record: the reconciliation would call a substantiated order unrepresented and inject a
+		// second citable line for the one prescription (issue #118).
+		DrugReferenceService service;
+		try (InputStream in = DrugSafetyDiacriticOrderNameTest.class.getClassLoader()
+				.getResourceAsStream(DIACRITIC_SLICE)) {
+			assertNotNull(in, DIACRITIC_SLICE + " should be on the test classpath");
+			service = DrugReferenceTestSupport.serviceWith(DdiDrugReferenceSource.parse(in));
+		}
+		DrugReferenceInjector injector = DrugReferenceTestSupport.injector(service);
+		injector.setDrugSafetyValidator(DrugReferenceTestSupport.validator(service));
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Dexaméthasone"), null, null, null,
+				Collections.singletonList(DrugReferenceTestSupport.activeOrder(
+						"11111111-aaaa-bbbb-cccc-222222222222", "Dexaméthasone")));
+		PatientChart chart = DrugReferenceTestSupport.chartOf(DrugReferenceTestSupport.drugOrderRecord(
+				1, "a-different-order-uuid", "Dexamethasone. Dose: 4 Milligram Oral Once daily"));
+
+		PatientChart result = injector.injectRecords(chart, context, "what are her active medications?");
+
+		long injectedOrders = result.getMappings().stream()
+				.filter(m -> ChartSearchAiConstants.RESOURCE_TYPE_ACTIVE_DRUG_ORDER
+						.equals(m.getResourceType()))
+				.count();
+		assertEquals(0, injectedOrders,
+				"the chart record names this order in the other locale's spelling, so it substantiates "
+						+ "it and nothing may be injected: " + result.getText());
+	}
+
+	@Test
+	public void accentedOrderNamesAreScreenedAgainstEachOther() throws IOException {
+		// The second matcher the same accented name reaches, and the reason the fold belongs to the
+		// shared boundary scan rather than to matchesOrderName alone: when the question names no drug,
+		// DrugSafetyValidator.activeOrderEntries resolves the SUBJECTS of the screen by running each
+		// active-order name through findByQuery -> DrugReference.matchesText, where the order name is
+		// the haystack and the unaccented alias is the needle. Folding only the order-name matcher
+		// would leave a francophone patient's whole medication list invisible to the screen — the same
+		// absent safety net, one arm over.
+		DrugSafetyValidator validator = validator();
+		String screeningQuestion = "Are there any interactions between her medications?";
+
+		List<SafetyWarning> unaccented = validator.validate("", screeningQuestion,
+				onOrders("Dexamethasone Injection vial 8mg", "Levofloxacin"));
+		assertEquals(1, interactionCount(unaccented),
+				"precondition: the unaccented spellings must raise exactly one chip for the real "
+						+ "dexamethasone x levofloxacin Major pair, was: " + unaccented);
+		assertTrue(DrugReferenceTestSupport.detailContains(unaccented, SafetyWarning.TYPE_INTERACTION,
+				"Dexamethasone", "active order levofloxacin", "Major"),
+				"precondition: that chip is the tendon-rupture pair, was: " + unaccented);
+
+		List<SafetyWarning> accented = validator.validate("", screeningQuestion,
+				onOrders("Dexaméthasone", "Lévofloxacine"));
+		assertEquals(1, interactionCount(accented),
+				"the same two drugs, spelled as this dictionary spells them in French, must raise the "
+						+ "same single chip, was: " + accented);
+		assertTrue(DrugReferenceTestSupport.detailContains(accented, SafetyWarning.TYPE_INTERACTION,
+				"Dexamethasone", "active order levofloxacin", "Major"),
+				"the screened pair must be the same Major tendon-rupture pair, was: " + accented);
+	}
+}

--- a/api/src/test/resources/chartsearchai-test/ddi-diacritic-order-names.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-diacritic-order-names.json
@@ -1,0 +1,1415 @@
+{
+  "mechanisms": {
+    "5099": {
+      "text": "The chronic use or abuse of laxatives may potentiate the pharmacologic effects of diuretics. Laxatives can cause significant losses of fluid and electrolytes, including sodium, potassium, magnesium and zinc, and these effects may be additive to those of diuretics.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    },
+    "-1": {
+      "text": null,
+      "categories": []
+    },
+    "3422": {
+      "text": "INTERVAL: Administration of quinapril with some oral medications may significantly decrease their absorption and may result in subtherapeutic serum concentrations. The proposed mechanism is chelation of the drug by the magnesium hydroxide excipient in quinapril tablets.",
+      "categories": [
+        "absorption"
+      ]
+    },
+    "3536": {
+      "text": "Concomitant administration of corticosteroids may potentiate the risk of tendinitis and tendon rupture associated with fluoroquinolone treatment. The mechanism is unknown. Tendinitis and tendon rupture have most frequently involved the Achilles tendon, although cases involving the rotator cuff (the shoulder), the hand, the biceps, and the thumb have also been reported. Some have required surgical repair or resulted in prolonged disability. Tendon rupture can occur during or up to several months after completion of fluoroquinolone therapy.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    },
+    "3606": {
+      "text": "The efficacy of insulin and other antidiabetic agents may be diminished by topical corticosteroids, particularly during prolonged or indiscriminate use. Corticosteroids can raise blood glucose level by antagonizing the action and suppressing the secretion of insulin, which results in inhibition of peripheral glucose uptake and increased gluconeogenesis. The duration of administration Close clinical monitoring of glycemic control is recommended if topical corticosteroids are administered chronically and/or to large areas in diabetic patients.",
+      "categories": [
+        "antagonistic_effect"
+      ]
+    },
+    "1024": {
+      "text": "Concomitant use of large doses of penicillins may elevate serum methotrexate concentrations. The mechanism may involve competitive inhibition of renal tubular secretion of methotrexate.",
+      "categories": [
+        "excretion"
+      ]
+    },
+    "4469": {
+      "text": "Angiotensin converting enzyme (ACE) inhibitors may enhance the vasodilatory and hypotensive effects of nitroglycerin. Data have also shown that captopril can prevent nitrate tolerance. ACE inhibitors can decrease systemic vascular resistance and cardiac work, further enhancing the effectiveness of nitroglycerin.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    },
+    "4965": {
+      "text": "Many psychotherapeutic and CNS-active agents (e.g., anxiolytics, sedatives, hypnotics, antidepressants, antipsychotics, opioids, alcohol, muscle relaxants) exhibit hypotensive effects, especially during initiation of therapy and dose escalation. Coadministration with antihypertensives and other hypotensive agents, in particular vasodilators and alpha-blockers, may result in additive effects on blood pressure and orthostasis.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    },
+    "599": {
+      "text": "Concomitant use of angiotensin converting enzyme (ACE) inhibitors and potassium-sparing diuretics may increase the risk of hyperkalemia. Inhibition of ACE results in decreased aldosterone secretion, which can lead to increases in serum potassium that may be additive with that induced by potassium-sparing diuretics. ACE inhibitors may also cause deterioration of renal function in patients with chronic heart failure, and the risk is increased if they are sodium-depleted or dehydrated after excessive diuresis.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    },
+    "7680": {
+      "text": "Nonsteroidal anti-inflammatory drugs (NSAIDs) may attenuate the antihypertensive effects of ACE inhibitors.  The proposed mechanism is NSAID-induced inhibition of renal prostaglandin synthesis, which results in unopposed pressor activity producing hypertension.  In addition, NSAIDs can cause fluid retention, which also affects blood pressure.  Some NSAIDs may also alter the pharmacokinetics of certain ACE inhibitors.",
+      "categories": [
+        "antagonistic_effect"
+      ]
+    },
+    "8050": {
+      "text": "Administration of quinapril with some oral medications may significantly decrease their absorption and may result in subtherapeutic serum concentrations.  The proposed mechanism is chelation of the drug by the magnesium hydroxide excipient in quinapril tablets.",
+      "categories": [
+        "absorption"
+      ]
+    },
+    "619": {
+      "text": "Corticosteroids may antagonize the effects of antihypertensive medications by inducing sodium and fluid retention. These effects may be more common with the natural corticosteroids (cortisone, hydrocortisone) because they have greater mineralocorticoid activity. Conversely, some calcium channel blockers such as diltiazem and verapamil may increase corticosteroid plasma levels and effects by inhibiting their clearance via CYP450 3A4 metabolism.",
+      "categories": [
+        "antagonistic_effect",
+        "metabolism"
+      ]
+    },
+    "2948": {
+      "text": "Although they are frequently combined in clinical practice, diuretics and angiotensin converting enzyme (ACE) inhibitors may have additive effects. Coadministration makes hypotension and hypovolemia more likely than does either drug alone. Some ACE inhibitors may attenuate the increase in the urinary excretion of sodium caused by some loop diuretics. Some patients on diuretics, especially those on dialysis or a dietary salt restriction, may experience acute hypotension with lightheadedness and dizziness after receiving the first dose of the ACE inhibitor. In addition, ACE inhibitors may cause renal insufficiency or acute renal failure in patients with sodium depletion or renal artery stenosis.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    },
+    "3443": {
+      "text": "The concomitant use of angiotensin converting enzyme (ACE) inhibitors or angiotensin receptor blockers (ARBs) and heparin or low molecular weight heparins may increase the risk of hyperkalemia. ACE inhibitors, ARBs, and some heparins individually have been associated with increased potassium levels or hyperkalemia.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    }
+  },
+  "drugs": [
+    {
+      "id": "DDInter1554",
+      "name": "Quinapril",
+      "rxcui": "35208",
+      "rxnorm_name": "quinapril",
+      "drugbank_id": "DB00881",
+      "atc": [
+        "C09AA06"
+      ],
+      "ciel": [
+        {
+          "code": "104840",
+          "uuid": "104840AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / quinapril"
+        },
+        {
+          "code": "83003",
+          "uuid": "83003AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Quinapril"
+        },
+        {
+          "code": "83004",
+          "uuid": "83004AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Quinapril hydrochloride"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1164",
+      "name": "Metformin",
+      "rxcui": "6809",
+      "rxnorm_name": "metformin",
+      "drugbank_id": "DB00331",
+      "atc": [
+        "A10BA02"
+      ],
+      "ciel": [
+        {
+          "code": "104722",
+          "uuid": "104722AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Glipizide / metformin"
+        },
+        {
+          "code": "104747",
+          "uuid": "104747AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Glyburide / metformin"
+        },
+        {
+          "code": "105054",
+          "uuid": "105054AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Metformin / pioglitazone"
+        },
+        {
+          "code": "105055",
+          "uuid": "105055AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Metformin / ropinirole"
+        },
+        {
+          "code": "105056",
+          "uuid": "105056AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Metformin / rosiglitazone"
+        },
+        {
+          "code": "165456",
+          "uuid": "165456AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Linagliptin / metformin"
+        },
+        {
+          "code": "165463",
+          "uuid": "165463AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Metformin / sitagliptin"
+        },
+        {
+          "code": "167910",
+          "uuid": "36b587d7-38c2-467f-ab5c-2b1426e482a3",
+          "name": "Alogliptin / metformin"
+        },
+        {
+          "code": "167912",
+          "uuid": "229af724-b07a-4954-b5cc-209e01c6cdd7",
+          "name": "Canagliflozin / metformin"
+        },
+        {
+          "code": "167922",
+          "uuid": "07f8df29-e291-4113-aa7f-2f0b65a6d6b8",
+          "name": "Empagliflozin / linagliptin / metformin"
+        },
+        {
+          "code": "167923",
+          "uuid": "1672d9f0-f214-422f-995e-a534b9f7a782",
+          "name": "Empagliflozin / metformin"
+        },
+        {
+          "code": "167924",
+          "uuid": "24d51a45-730f-4077-81e1-dc494d0e8257",
+          "name": "Ertugliflozin / metformin"
+        },
+        {
+          "code": "167926",
+          "uuid": "a7ceb840-0e35-41b1-bc8c-e6fac84e06b9",
+          "name": "Metformin / repaglinide"
+        },
+        {
+          "code": "167927",
+          "uuid": "e6d393f4-7bc6-4614-a4e6-ae95fdbc3c42",
+          "name": "Metformin / saxagliptin"
+        },
+        {
+          "code": "167981",
+          "uuid": "62ea33ca-e91b-4710-afa3-430c258115c7",
+          "name": "Metformin / vildagliptin"
+        },
+        {
+          "code": "167982",
+          "uuid": "895cea55-ec68-4892-91c9-fc90b1a38987",
+          "name": "Metformin / remogliflozin etabonate / vildagliptin"
+        },
+        {
+          "code": "168009",
+          "uuid": "caa3c8be-cb6c-4626-b272-eaaa6551d85d",
+          "name": "Glimepiride / metformin"
+        },
+        {
+          "code": "170534",
+          "uuid": "49b805a0-d177-4243-9206-72fcedeeed64",
+          "name": "Dapagliflozin / metformin / sitagliptin"
+        },
+        {
+          "code": "79651",
+          "uuid": "79651AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Metformin"
+        },
+        {
+          "code": "79652",
+          "uuid": "79652AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Metformin hydrochloride"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1174",
+      "name": "Methotrexate",
+      "rxcui": "6851",
+      "rxnorm_name": "methotrexate",
+      "drugbank_id": "DB00563",
+      "atc": [
+        "L01BA01",
+        "L04AX03"
+      ],
+      "ciel": [
+        {
+          "code": "79700",
+          "uuid": "79700AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Methotrexate"
+        },
+        {
+          "code": "79701",
+          "uuid": "79701AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Methotrexate, sodium salt"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1018",
+      "name": "Lactulose",
+      "rxcui": "6218",
+      "rxnorm_name": "lactulose",
+      "drugbank_id": "DB00581",
+      "atc": [
+        "A06AD11"
+      ],
+      "ciel": [
+        {
+          "code": "78632",
+          "uuid": "78632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Lactulose"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1344",
+      "name": "Opium",
+      "rxcui": "7676",
+      "rxnorm_name": "opium",
+      "drugbank_id": "DB11130",
+      "atc": [
+        "A07DA02",
+        "N02AA02"
+      ],
+      "ciel": [
+        {
+          "code": "103692",
+          "uuid": "103692AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Aspirin / caffeine / ipecac / opium"
+        },
+        {
+          "code": "103788",
+          "uuid": "103788AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Belladonna alkaloids / opium"
+        },
+        {
+          "code": "103798",
+          "uuid": "103798AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Belladonna extract / opium"
+        },
+        {
+          "code": "104822",
+          "uuid": "104822AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Homatropine / opium / pectin"
+        },
+        {
+          "code": "170673",
+          "uuid": "fbbb8749-c143-4e62-92ea-76e77db47f32",
+          "name": "Acetaminophen / caffeine / opium"
+        },
+        {
+          "code": "81092",
+          "uuid": "81092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Opium"
+        },
+        {
+          "code": "81094",
+          "uuid": "81094AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Opium tincture"
+        },
+        {
+          "code": "81095",
+          "uuid": "81095AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Opium, powdered"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1815",
+      "name": "Tiotropium",
+      "rxcui": "69120",
+      "rxnorm_name": "tiotropium",
+      "drugbank_id": "DB01409",
+      "atc": [],
+      "ciel": [
+        {
+          "code": "85157",
+          "uuid": "85157AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Tiotropium"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2187",
+      "name": "Iron (bisglycinate)",
+      "rxcui": "90176",
+      "rxnorm_name": "iron",
+      "drugbank_id": "DB01592",
+      "atc": [],
+      "ciel": [
+        {
+          "code": "78218",
+          "uuid": "78218AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Iron"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1707",
+      "name": "Spironolactone",
+      "rxcui": "9997",
+      "rxnorm_name": "spironolactone",
+      "drugbank_id": "DB00421",
+      "atc": [
+        "C03DA01"
+      ],
+      "ciel": [
+        {
+          "code": "104694",
+          "uuid": "104694AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Furosemide / spironolactone"
+        },
+        {
+          "code": "104842",
+          "uuid": "104842AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / spironolactone"
+        },
+        {
+          "code": "104871",
+          "uuid": "104871AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydroflumethiazide / spironolactone"
+        },
+        {
+          "code": "84239",
+          "uuid": "84239AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Spironolactone"
+        }
+      ]
+    },
+    {
+      "id": "DDInter832",
+      "name": "Glycerin",
+      "rxcui": "4910",
+      "rxnorm_name": "glycerin",
+      "drugbank_id": "DB09462",
+      "atc": [
+        "A06AG04",
+        "A06AX01"
+      ],
+      "ciel": [
+        {
+          "code": "104439",
+          "uuid": "104439AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dextran 70 / glycerol / hypromellose"
+        },
+        {
+          "code": "77073",
+          "uuid": "77073AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Glycerol"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1304",
+      "name": "Nitroglycerin",
+      "rxcui": "4917",
+      "rxnorm_name": "nitroglycerin",
+      "drugbank_id": "DB00727",
+      "atc": [
+        "C01DA02",
+        "C05AE01"
+      ],
+      "ciel": [
+        {
+          "code": "80704",
+          "uuid": "80704AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Nitroglycerin"
+        }
+      ]
+    },
+    {
+      "id": "DDInter246",
+      "name": "Budesonide",
+      "rxcui": "19831",
+      "rxnorm_name": "budesonide",
+      "drugbank_id": "DB01222",
+      "atc": [
+        "A07EA06",
+        "D07AC09",
+        "R01AD05",
+        "R03BA02"
+      ],
+      "ciel": [
+        {
+          "code": "103955",
+          "uuid": "103955AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Budesonide / formoterol"
+        },
+        {
+          "code": "72484",
+          "uuid": "72484AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Budesonide"
+        }
+      ]
+    },
+    {
+      "id": "DDInter509",
+      "name": "Desonide (topical)",
+      "rxcui": "3254",
+      "rxnorm_name": "desonide",
+      "drugbank_id": null,
+      "atc": [
+        "D07AB08",
+        "S01BA11"
+      ],
+      "ciel": [
+        {
+          "code": "103308",
+          "uuid": "103308AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acetic acid / desonide"
+        },
+        {
+          "code": "74562",
+          "uuid": "74562AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Desonide"
+        }
+      ]
+    },
+    {
+      "id": "DDInter360",
+      "name": "Chlorothiazide",
+      "rxcui": "2396",
+      "rxnorm_name": "chlorothiazide",
+      "drugbank_id": "DB00880",
+      "atc": [
+        "C03AA04"
+      ],
+      "ciel": [
+        {
+          "code": "104197",
+          "uuid": "104197AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorothiazide / methyldopa"
+        },
+        {
+          "code": "104198",
+          "uuid": "104198AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorothiazide / reserpine"
+        },
+        {
+          "code": "73308",
+          "uuid": "73308AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorothiazide"
+        },
+        {
+          "code": "73309",
+          "uuid": "73309AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorothiazide sodium"
+        }
+      ]
+    },
+    {
+      "id": "DDInter883",
+      "name": "Hydrochlorothiazide",
+      "rxcui": "5487",
+      "rxnorm_name": "hydrochlorothiazide",
+      "drugbank_id": "DB00999",
+      "atc": [
+        "C03AA03"
+      ],
+      "ciel": [
+        {
+          "code": "103168",
+          "uuid": "103168AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acebutolol / hydrochlorothiazide"
+        },
+        {
+          "code": "103541",
+          "uuid": "103541AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Amiloride / hydrochlorothiazide"
+        },
+        {
+          "code": "103542",
+          "uuid": "103542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Amiloride / hydrochlorothiazide / timolol"
+        },
+        {
+          "code": "103801",
+          "uuid": "103801AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benazepril / hydrochlorothiazide"
+        },
+        {
+          "code": "103920",
+          "uuid": "103920AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bisoprolol / hydrochlorothiazide"
+        },
+        {
+          "code": "104098",
+          "uuid": "104098AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Candesartan / hydrochlorothiazide"
+        },
+        {
+          "code": "104109",
+          "uuid": "104109AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Captopril / hydrochlorothiazide"
+        },
+        {
+          "code": "104418",
+          "uuid": "104418AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Deserpidine / hydrochlorothiazide"
+        },
+        {
+          "code": "104569",
+          "uuid": "104569AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Enalapril / hydrochlorothiazide"
+        },
+        {
+          "code": "104589",
+          "uuid": "104589AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Eprosartan / hydrochlorothiazide"
+        },
+        {
+          "code": "104688",
+          "uuid": "104688AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Fosinopril / hydrochlorothiazide"
+        },
+        {
+          "code": "104801",
+          "uuid": "104801AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Guanethidine / hydrochlorothiazide"
+        },
+        {
+          "code": "104827",
+          "uuid": "104827AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydralazine / hydrochlorothiazide"
+        },
+        {
+          "code": "104828",
+          "uuid": "104828AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydralazine / hydrochlorothiazide / reserpine"
+        },
+        {
+          "code": "104831",
+          "uuid": "104831AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / irbesartan"
+        },
+        {
+          "code": "104832",
+          "uuid": "104832AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / labetalol"
+        },
+        {
+          "code": "104833",
+          "uuid": "104833AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / lisinopril"
+        },
+        {
+          "code": "104834",
+          "uuid": "104834AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / losartan"
+        },
+        {
+          "code": "104835",
+          "uuid": "104835AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / methyldopa"
+        },
+        {
+          "code": "104836",
+          "uuid": "104836AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / metoprolol"
+        },
+        {
+          "code": "104837",
+          "uuid": "104837AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / moexipril"
+        },
+        {
+          "code": "104838",
+          "uuid": "104838AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / olmesartan medoxomil"
+        },
+        {
+          "code": "104839",
+          "uuid": "104839AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / propranolol"
+        },
+        {
+          "code": "104840",
+          "uuid": "104840AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / quinapril"
+        },
+        {
+          "code": "104841",
+          "uuid": "104841AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / reserpine"
+        },
+        {
+          "code": "104842",
+          "uuid": "104842AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / spironolactone"
+        },
+        {
+          "code": "104843",
+          "uuid": "104843AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / telmisartan"
+        },
+        {
+          "code": "104844",
+          "uuid": "104844AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / timolol"
+        },
+        {
+          "code": "104845",
+          "uuid": "104845AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / triamterene"
+        },
+        {
+          "code": "104846",
+          "uuid": "104846AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide / valsartan"
+        },
+        {
+          "code": "161184",
+          "uuid": "161184AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Atenolol / hydrochlorothiazide"
+        },
+        {
+          "code": "167989",
+          "uuid": "7095e460-415c-440a-8743-a756f64eebed",
+          "name": "Hydrochlorothiazide / ramipril"
+        },
+        {
+          "code": "168335",
+          "uuid": "faefe433-529e-4ef0-9ddd-95da883ae99f",
+          "name": "Amlodipine / hydrochlorothiazide"
+        },
+        {
+          "code": "170164",
+          "uuid": "633796ea-4cea-427a-96b0-6e1d661bf633",
+          "name": "Amlodipine / hydrochlorothiazide / olmesartan"
+        },
+        {
+          "code": "170701",
+          "uuid": "f77778a3-9f7b-4115-83e6-73150ba94e28",
+          "name": "Amlodipine / hydrochlorothiazide / losartan"
+        },
+        {
+          "code": "77696",
+          "uuid": "77696AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrochlorothiazide"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1325",
+      "name": "Ofloxacin",
+      "rxcui": "7623",
+      "rxnorm_name": "ofloxacin",
+      "drugbank_id": "DB01165",
+      "atc": [
+        "J01MA01",
+        "S01AE01",
+        "S02AA16"
+      ],
+      "ciel": [
+        {
+          "code": "168006",
+          "uuid": "fd1213d8-47c1-4360-9556-fba245772aec",
+          "name": "Ofloxacin / ornidazole"
+        },
+        {
+          "code": "81022",
+          "uuid": "81022AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ofloxacin"
+        }
+      ]
+    },
+    {
+      "id": "DDInter384",
+      "name": "Ciprofloxacin",
+      "rxcui": "2551",
+      "rxnorm_name": "ciprofloxacin",
+      "drugbank_id": "DB00537",
+      "atc": [
+        "J01MA02",
+        "S01AE03",
+        "S02AA15",
+        "S03AA07"
+      ],
+      "ciel": [
+        {
+          "code": "104317",
+          "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / dexamethasone"
+        },
+        {
+          "code": "104318",
+          "uuid": "104318AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / hydrocortisone"
+        },
+        {
+          "code": "73449",
+          "uuid": "73449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin"
+        },
+        {
+          "code": "73450",
+          "uuid": "73450AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin hydrochloride"
+        },
+        {
+          "code": "73451",
+          "uuid": "73451AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin lactate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1055",
+      "name": "Levofloxacin",
+      "rxcui": "82122",
+      "rxnorm_name": "levofloxacin",
+      "drugbank_id": "DB01137",
+      "atc": [
+        "J01MA12",
+        "S01AE05"
+      ],
+      "ciel": [
+        {
+          "code": "167977",
+          "uuid": "2d7b158c-5f97-449b-b0e9-46f75c82a42f",
+          "name": "Amoxicillin / Esomeprazole / Levofloxacin combination kit"
+        },
+        {
+          "code": "167978",
+          "uuid": "cb933181-fd92-4725-91d5-2e851c9eb0b5",
+          "name": "Clarithromycin / Esomeprazole / Levofloxacin combination kit"
+        },
+        {
+          "code": "78788",
+          "uuid": "78788AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Levofloxacin"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1354",
+      "name": "Oxacillin",
+      "rxcui": "7773",
+      "rxnorm_name": "oxacillin",
+      "drugbank_id": "DB00713",
+      "atc": [
+        "J01CF04"
+      ],
+      "ciel": [
+        {
+          "code": "81284",
+          "uuid": "81284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Oxacillin"
+        },
+        {
+          "code": "81285",
+          "uuid": "81285AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Oxacillin sodium"
+        }
+      ]
+    },
+    {
+      "id": "DDInter418",
+      "name": "Cloxacillin",
+      "rxcui": "2625",
+      "rxnorm_name": "cloxacillin",
+      "drugbank_id": "DB01147",
+      "atc": [
+        "J01CF02"
+      ],
+      "ciel": [
+        {
+          "code": "294",
+          "uuid": "294AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ampicillin and cloxacillin"
+        },
+        {
+          "code": "73628",
+          "uuid": "73628AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cloxacillin"
+        },
+        {
+          "code": "73629",
+          "uuid": "73629AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cloxacillin sodium"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2085",
+      "name": "Salicylic acid",
+      "rxcui": "9525",
+      "rxnorm_name": "salicylic acid",
+      "drugbank_id": "DB00936",
+      "atc": [
+        "D01AE12",
+        "S01BC08"
+      ],
+      "ciel": [
+        {
+          "code": "103162",
+          "uuid": "103162AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "4-aminobenzoic acid / magnesium"
+        },
+        {
+          "code": "103164",
+          "uuid": "103164AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "4-aminobenzoic acid / salicylic acid"
+        },
+        {
+          "code": "103302",
+          "uuid": "103302AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acetaminophen / salicylic acid"
+        },
+        {
+          "code": "103311",
+          "uuid": "103311AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acetic acid / salicylic acid"
+        },
+        {
+          "code": "103589",
+          "uuid": "103589AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Anthralin / coal tar / salicylic acid"
+        },
+        {
+          "code": "103590",
+          "uuid": "103590AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Anthralin / salicylic acid"
+        },
+        {
+          "code": "103591",
+          "uuid": "103591AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Anthraquinone glycoside / salicylic acid"
+        },
+        {
+          "code": "103756",
+          "uuid": "103756AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Attapulgite / salicylic acid"
+        },
+        {
+          "code": "103757",
+          "uuid": "103757AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Attapulgite / salicylic acid / sulfur, colloidal"
+        },
+        {
+          "code": "103825",
+          "uuid": "103825AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzalkonium / salicylic acid"
+        },
+        {
+          "code": "103845",
+          "uuid": "103845AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzocaine / coal tar / salicylic acid"
+        },
+        {
+          "code": "103878",
+          "uuid": "103878AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzoic acid / salicylic acid"
+        },
+        {
+          "code": "103907",
+          "uuid": "103907AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Betamethasone / salicylic acid"
+        },
+        {
+          "code": "103973",
+          "uuid": "103973AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Caffeine / pheniramine / phenylephrine / salicylic acid"
+        },
+        {
+          "code": "103976",
+          "uuid": "103976AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Caffeine / salicylamide / salicylic acid"
+        },
+        {
+          "code": "104099",
+          "uuid": "104099AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cantharidin / podophyllin / salicylic acid"
+        },
+        {
+          "code": "104346",
+          "uuid": "104346AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Coal tar / menthol / salicylic acid"
+        },
+        {
+          "code": "104350",
+          "uuid": "104350AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Coal tar / salicylic acid"
+        },
+        {
+          "code": "104351",
+          "uuid": "104351AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Coal tar / salicylic acid / sulfur"
+        },
+        {
+          "code": "104352",
+          "uuid": "104352AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Coal tar / salicylic acid / sulfur, colloidal"
+        },
+        {
+          "code": "104390",
+          "uuid": "104390AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Colloidal oatmeal / salicylic acid"
+        },
+        {
+          "code": "104618",
+          "uuid": "104618AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ethanol / salicylic acid"
+        },
+        {
+          "code": "104813",
+          "uuid": "104813AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Heparinoids / salicylic acid"
+        },
+        {
+          "code": "104866",
+          "uuid": "104866AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sodium thiosulfate"
+        },
+        {
+          "code": "104867",
+          "uuid": "104867AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sulfur"
+        },
+        {
+          "code": "105050",
+          "uuid": "105050AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Mercury, ammoniated / salicylic acid"
+        },
+        {
+          "code": "105170",
+          "uuid": "105170AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Phenyltoloxamine / salicylic acid"
+        },
+        {
+          "code": "105181",
+          "uuid": "105181AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Podophyllin / salicylic acid"
+        },
+        {
+          "code": "105233",
+          "uuid": "105233AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pyrithione / salicylic acid"
+        },
+        {
+          "code": "105245",
+          "uuid": "105245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / sulfur"
+        },
+        {
+          "code": "105246",
+          "uuid": "105246AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / sulfur, colloidal"
+        },
+        {
+          "code": "105247",
+          "uuid": "105247AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / trichloroacetaldehyde"
+        },
+        {
+          "code": "105248",
+          "uuid": "105248AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / undecylenate"
+        },
+        {
+          "code": "105249",
+          "uuid": "105249AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / urea"
+        },
+        {
+          "code": "105250",
+          "uuid": "105250AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / zinc oxide"
+        },
+        {
+          "code": "105251",
+          "uuid": "105251AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / zinc pyrithione"
+        },
+        {
+          "code": "284",
+          "uuid": "284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Whitfield ointment"
+        },
+        {
+          "code": "79245",
+          "uuid": "79245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Magnesium salicylate tetrahydrate"
+        },
+        {
+          "code": "82373",
+          "uuid": "82373AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Potassium salicylate"
+        },
+        {
+          "code": "83644",
+          "uuid": "83644AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylate"
+        },
+        {
+          "code": "83645",
+          "uuid": "83645AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid"
+        },
+        {
+          "code": "84102",
+          "uuid": "84102AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Sodium salicylate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter894",
+      "name": "Hydroxyurea",
+      "rxcui": "5552",
+      "rxnorm_name": "hydroxyurea",
+      "drugbank_id": "DB01005",
+      "atc": [
+        "L01XX05"
+      ],
+      "ciel": [
+        {
+          "code": "77795",
+          "uuid": "77795AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydroxyurea"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1903",
+      "name": "Urea",
+      "rxcui": "11002",
+      "rxnorm_name": "urea",
+      "drugbank_id": "DB03904",
+      "atc": [
+        "B05BC02",
+        "D02AE01"
+      ],
+      "ciel": [
+        {
+          "code": "103595",
+          "uuid": "103595AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Antipyrine / benzocaine / urea"
+        },
+        {
+          "code": "104189",
+          "uuid": "104189AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorophyll / papain / urea"
+        },
+        {
+          "code": "104192",
+          "uuid": "104192AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorophyllin copper complex / papain / urea"
+        },
+        {
+          "code": "104403",
+          "uuid": "104403AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cysteine / inositol / methionine / sodium propionate / urea"
+        },
+        {
+          "code": "105127",
+          "uuid": "105127AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Papain / urea"
+        },
+        {
+          "code": "105249",
+          "uuid": "105249AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Salicylic acid / urea"
+        },
+        {
+          "code": "105299",
+          "uuid": "105299AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Triamcinolone / urea"
+        },
+        {
+          "code": "70002",
+          "uuid": "70002AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "[13c] urea"
+        },
+        {
+          "code": "85950",
+          "uuid": "85950AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Urea"
+        }
+      ]
+    },
+    {
+      "id": "DDInter513",
+      "name": "Dexamethasone",
+      "rxcui": "3264",
+      "rxnorm_name": "dexamethasone",
+      "drugbank_id": "DB01234",
+      "atc": [
+        "A01AC02",
+        "C05AA09",
+        "D07AB19",
+        "D07XB05",
+        "D10AA03",
+        "H02AB02",
+        "R01AD03",
+        "S01BA01",
+        "S01CB01",
+        "S02BA06",
+        "S03BA01"
+      ],
+      "ciel": [
+        {
+          "code": "104317",
+          "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / dexamethasone"
+        },
+        {
+          "code": "104422",
+          "uuid": "104422AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / hypromellose"
+        },
+        {
+          "code": "104423",
+          "uuid": "104423AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / lidocaine"
+        },
+        {
+          "code": "104424",
+          "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / neomycin"
+        },
+        {
+          "code": "104425",
+          "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / neomycin / polymyxin B"
+        },
+        {
+          "code": "104426",
+          "uuid": "104426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / tobramycin"
+        },
+        {
+          "code": "104427",
+          "uuid": "104427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / tramazoline"
+        },
+        {
+          "code": "168548",
+          "uuid": "f5c7c86c-2b95-42d4-95f2-6d9e8949f39e",
+          "name": "Dexamethasone / gentamicin"
+        },
+        {
+          "code": "170697",
+          "uuid": "d2a620d9-138d-4125-a84a-7ddbf3b2ee45",
+          "name": "Dexamethasone / framycetin"
+        },
+        {
+          "code": "74609",
+          "uuid": "74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone"
+        },
+        {
+          "code": "74610",
+          "uuid": "74610AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone acetate"
+        },
+        {
+          "code": "74612",
+          "uuid": "74612AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone isonicotinate"
+        },
+        {
+          "code": "74613",
+          "uuid": "74613AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone phosphate"
+        },
+        {
+          "code": "74614",
+          "uuid": "74614AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone sodium phosphate"
+        },
+        {
+          "code": "74615",
+          "uuid": "74615AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone trimethyl acetate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter856",
+      "name": "Heparin",
+      "rxcui": "5224",
+      "rxnorm_name": "heparin",
+      "drugbank_id": "DB01109",
+      "atc": [
+        "B01AB01",
+        "C05BA03",
+        "S01XA14"
+      ],
+      "ciel": [
+        {
+          "code": "72681",
+          "uuid": "72681AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Calcium heparin"
+        },
+        {
+          "code": "77413",
+          "uuid": "77413AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Heparin"
+        },
+        {
+          "code": "77414",
+          "uuid": "77414AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Heparin sodium"
+        },
+        {
+          "code": "77415",
+          "uuid": "77415AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Heparin sodium (beef)"
+        },
+        {
+          "code": "77416",
+          "uuid": "77416AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Heparin sodium (pork)"
+        },
+        {
+          "code": "77417",
+          "uuid": "77417AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Heparin, beef"
+        },
+        {
+          "code": "77418",
+          "uuid": "77418AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Heparin, pork"
+        }
+      ]
+    }
+  ],
+  "interactions": [
+    [
+      "DDInter1018",
+      "DDInter1903",
+      "Moderate",
+      "5099"
+    ],
+    [
+      "DDInter1018",
+      "DDInter894",
+      "Unknown",
+      "-1"
+    ],
+    [
+      "DDInter1055",
+      "DDInter1554",
+      "Moderate",
+      "3422"
+    ],
+    [
+      "DDInter1055",
+      "DDInter513",
+      "Major",
+      "3536"
+    ],
+    [
+      "DDInter1164",
+      "DDInter246",
+      "Unknown",
+      "-1"
+    ],
+    [
+      "DDInter1164",
+      "DDInter509",
+      "Minor",
+      "3606"
+    ],
+    [
+      "DDInter1174",
+      "DDInter1354",
+      "Major",
+      "1024"
+    ],
+    [
+      "DDInter1174",
+      "DDInter418",
+      "Major",
+      "1024"
+    ],
+    [
+      "DDInter1304",
+      "DDInter1554",
+      "Moderate",
+      "4469"
+    ],
+    [
+      "DDInter1325",
+      "DDInter1554",
+      "Moderate",
+      "3422"
+    ],
+    [
+      "DDInter1344",
+      "DDInter1554",
+      "Moderate",
+      "4965"
+    ],
+    [
+      "DDInter1554",
+      "DDInter1707",
+      "Major",
+      "599"
+    ],
+    [
+      "DDInter1554",
+      "DDInter1815",
+      "Unknown",
+      "-1"
+    ],
+    [
+      "DDInter1554",
+      "DDInter2085",
+      "Moderate",
+      "7680"
+    ],
+    [
+      "DDInter1554",
+      "DDInter2187",
+      "Moderate",
+      "8050"
+    ],
+    [
+      "DDInter1554",
+      "DDInter246",
+      "Moderate",
+      "619"
+    ],
+    [
+      "DDInter1554",
+      "DDInter360",
+      "Moderate",
+      "2948"
+    ],
+    [
+      "DDInter1554",
+      "DDInter384",
+      "Moderate",
+      "3422"
+    ],
+    [
+      "DDInter1554",
+      "DDInter513",
+      "Moderate",
+      "619"
+    ],
+    [
+      "DDInter1554",
+      "DDInter832",
+      "Moderate",
+      "2948"
+    ],
+    [
+      "DDInter1554",
+      "DDInter856",
+      "Moderate",
+      "3443"
+    ],
+    [
+      "DDInter1554",
+      "DDInter883",
+      "Moderate",
+      "2948"
+    ]
+  ]
+}


### PR DESCRIPTION
Closes #129.

## The defect

`DrugReference.matchesOrderName` compared raw lowercased strings, and DDInter's rule tokens are
unaccented RxNorm generics. So an order named **`Budésonide`** shares no substring with
**`budesonide`** at the accented character, and the patient is **never checked against that drug's
interaction rules at all** — no chip, no prose, no WARN. **224 of the 3.7.1 demo dictionary's 2531**
drug and drug-concept names carry a diacritic, and that dictionary is bilingual by construction, so
this is a first-class deployment shape rather than exotic input.

Reproduced live on the 3.7.1 standalone against `e73c8b0` (this branch with only the matcher change
reverted, full-JVM restart, `sourceFormat=ddinter` on the full 19MB KB, `minInteractionSeverity=minor`,
querystore retrieval gated alive at `hits=75` and the known-positive control confirmed first). One
patient, **one** active drug order, one question — the only thing that changes between the runs is the
locale in which that order's concept name resolves, i.e. whether the name carries its accent:

```
order: (NEW) Dexamethasone: 4.0 Milligram Oral Once daily   concept 'Dexamethasone'   [locale en]
Q: "Is it safe to give him levofloxacin?"
--- safetyWarnings (1) ---
  [interaction] drug='Levofloxacin'
      Levofloxacin interacts with active order dexamethasone — Major. Concomitant administration of
      corticosteroids may potentiate the risk of tendinitis and tendon rupture associated with
      fluoroquinolone treatment. …

order: (NEW) Dexaméthasone: 4.0 Milligramme Oral Une fois par jour   concept 'Dexaméthasone'  [locale fr]
Q: "Is it safe to give him levofloxacin?"
--- safetyWarnings (0) ---
--- references (0) ---
answer: "The records do not address the safety of giving Levofloxacin."      (twice, 12s and 10s)

order: back to 'Dexamethasone'                                               [locale en again]
--- safetyWarnings (1) ---   ← the Major chip returns, so the absence is the accent and nothing else
```

Note what disappears with the chip: `references (0)`, so the pre-answer safety finding (#110) is gone
too and the model has nothing to ground on — hence the abstention. The whole net is absent, silently.

## Root cause and where the fold lives

The fold goes in `containsBoundedToken` — the one private boundary scan #128 introduced — applied to
**both operands**. That is a decision with three parts, and each was the alternative to something
worse:

**Why not `matchesOrderName` alone.** The same accented order name reaches BOTH named matchers. It
is the haystack when a rule token is matched against it (`matchesOrderName`), and it is the haystack
again when the interaction-screening arm resolves the subjects of the screen — `DrugSafetyValidator
.activeOrderEntries` → `DrugReferenceService.findByQuery(orderName)` → `matchesText` → `containsWord`.
Folding only the order-name matcher would leave a francophone patient's medication list invisible to
the screen: the same absent safety net, one arm over. `DrugSafetyDiacriticOrderNameTest
.accentedOrderNamesAreScreenedAgainstEachOther` is that arm, and it fails with `[]` if the fold is
moved into `matchesOrderName`.

**Why both operands, given that the reference side needs no folding.** Measured over the full
DDInter KB: **0 of 2093 rule tokens and 0 of 5169 aliases carry a combining mark**, and no two tokens
fold together — so folding the reference side adds nothing on shipped data, exactly as #129 says. It
is there for two other reasons. First, one of the three call sites has the operands the other way
round: `ActiveDrugOrder.namedIn` looks for the patient's own (possibly accented) order name inside a
rendered record, so a one-sided fold would *break* it. Second, folding a pair rather than a side is
what makes the change a **pure relaxation** — everything that matched before still matches — which is
what let the widening be scored against #128's kill set instead of argued about.

**Why not at ingest.** Folding order names in `PatientClinicalContextBuilder` is cheaper per query
(once per order rather than once per rule token), and it was rejected for three reasons:

- it puts the rule outside the matcher it protects, so every context not built by that builder — the
  null-patient early return, the derived contexts `activeOrdersOtherThan` assembles, and every test —
  silently loses it, and the required test (`validate(...)` with an order named `Budésonide`) would
  then only pass by folding in the test, i.e. by reimplementing pipeline logic in test code;
- `PatientClinicalContext` carries the order names that also identify orders for the reconciliation
  and for record text, so folding at ingest would either de-accent what a clinician is shown or
  require a second, unfolded name set beside the folded one;
- the cost it saves is not there: over the 10.6M folded matcher calls the corpus sweep below makes
  (2 matchers × 5.3M pairs), the fold moved wall time from 1.5s to 3.1s — ≈0.15 µs per call, so a
  `validate()` at the KB's worst case (a 900-rule subject × 3 order names) adds well under a
  millisecond against a multi-second answer. ASCII short-circuits without normalizing at all.

`java.text.Normalizer` NFD + strip of `\p{Mn}`, not a character map: a map has to be maintained per
language and silently stops folding the first accent nobody listed. What that does to non-Latin
scripts is documented on the method — it is standard folding for Latin/Greek/Cyrillic/Arabic
harakat/Hebrew niqqud; in Thai, Lao and Indic scripts the tone marks and virama are also `Mn`, so two
distinct words there can fold together (a widening of the same kind, bounded by the same boundary
rules); spacing marks (`Mc`, Devanagari matras) are deliberately **not** stripped because they carry
the vowel rather than decorate it; CJK is untouched and Hangul decomposes to Jamo, which are letters
and survive the strip, so both sides fold identically.

## Both directions, measured

Corpus: the 3.7.1 demo dictionary's **2531** drug + drug-concept names × the full KB's **2093** rule
tokens = 5.3M pairs, run through the **shipped matchers themselves** — once with `e73c8b0`'s
`DrugReference` ahead of the build on the classpath, once with this branch's — so no row below comes
from a replica of the rule.

| rule | matches | #128 kill set leaking | accented kill set leaking | #128 keep set lost | accented names matched |
|---|---|---|---|---|---|
| `contains` (pre-#128) | 896 | 9 of 9 † | — | 0 of 13 † | — |
| `matchesOrderName`, unfolded (`main`) | 829 | **0 of 9** | **0 of 12** | **0 of 13** | 2 of 10 |
| `matchesOrderName`, folded (this PR) | **907** | **0 of 9** | **0 of 12** | **0 of 13** | **10 of 10** |
| `matchesText` (symmetric), unfolded | 761 | n/a ‡ | — | — | — |
| `matchesText` (symmetric), folded | 814 | n/a ‡ | — | — | — |

† The `contains` match count is measured here; its kill/keep columns are #128's, and follow trivially
(every kill and keep pair is a substring containment). ‡ A symmetric boundary rejects a token nested
inside a word by construction, which is what #128 measured it for; the prose rule's exposure is the
opposite one (a real name it stops matching), which is why it is not the rule used on order names.

The `matchesText` rows are the same corpus with the order name as the **haystack** — i.e. exactly the
`findByQuery(orderName)` call the screening arm makes — so they measure the second arm this fix
reaches, not prose in general. #128 pinned that rule at 761 and it is still 761 unfolded; the fold
adds 53 there, 0 removed.

- **kill set** = #128's nine nested-name collisions (`opium`⊂Tiotropium, `iron`⊂Spironolactone,
  `glycerin`⊂Nitroglycerin, `desonide`⊂Budesonide, `chlorothiazide`⊂Hydrochlorothiazide,
  `ofloxacin`⊂Ciprofloxacin, `oxacillin`⊂Cloxacilline, `salicylic acid`⊂P-aminosalicylic acid,
  `urea`⊂Hydroxyurea).
- **accented kill set** = the same nine in the accented spellings this dictionary actually carries
  (`poudre de tiotropium`, `furosémide et spironolactone`, `nitroglycérine`, `budésonide`,
  `budésonide et formotérol`, `hydrochlorothiazide 50mg`, `ciprofloxacine`, `lévofloxacine`,
  `cloxacilline co 500mg`, `acide benzoïque et salicylique`, `p-aminosalicylic acid`,
  `hydroxyurée 500mg`) — these are the ones folding could newly break, and they are why the fold had
  to be measured rather than reasoned about.
- **keep set** = #128's localized forms (`Aspirine Co 81mg`, `Aspirina`, `Amoxicilline`,
  `Ampicilline`, `Atorvastatine`, `Clarithromycine Co 500mg`, `Cloxacilline Co 500mg`,
  `Neomycine creme 5m/g`, `Ondansetrona`, `Multivitamines et fer`, plus the plain
  `Aspirin 81mg`/`Simvastatin Co 20mg`/`Lisinopril 10 mg`).

**78 pairs added, 0 removed** — the relaxation is one-directional over the whole corpus, for both
matchers (prose: 53 added, 0 removed).

**Every one of the 78 was inspected, not just counted.** 76 are an accented spelling of the token's
own drug (`héparine` ~ heparin, `dexaméthasone` ~ dexamethasone, `lévofloxacine` ~ levofloxacin,
`énoxaparine` ~ enoxaparin, `griséofulvine co 500mg` ~ griseofulvin, `nitrofurantoïne` ~
nitrofurantoin …). The other two are the **phrase** nesting no boundary rule can see, and both are a
mislabel of a drug the patient IS on rather than a fabricated one — the same residual class #128
recorded for `glycerin` matching a nitroglycerin order:

- `preparado de activador del plasminógeno tipo tisular` (tissue plasminogen **activator**) matches
  `plasminogen`. It is that token's only match in this dictionary, and the rules it inherits are
  bleeding-risk rules that fit a fibrinolytic anyway.
- `acétaminophene,pseudo-éphédrine,dextrométorphane,chlorphéniramine` matches `ephedrine` across the
  hyphen — which its **English twin row** `Acetaminophen,Pseudo-ephedrine,Dextrometorphan,
  Chlorpheniramine` already did on `main`. The fold makes one product's two spellings agree; it does
  not introduce the imprecision.

**Misspellings are deliberately not accommodated.** `Lisoniazide` and `Sprironolactone` are typo'd
rows in this same dictionary; both are unmatched before and after (measured), and they should stay
that way — matching a name that differs from the token by an edit reopens the substring hazard from
the other side. They are a data-quality problem. (`Aspirinn` and `Metforming` do match, before and
after, through #128's deliberate inflection tail; unchanged here.)

## Tests

`DrugSafetyDiacriticOrderNameTest` (new, 5 tests) — every case through the real
`DrugSafetyValidator.validate(answer, question, context)` over `ddi-diacritic-order-names.json`, a
**verbatim** 24-drug / 22-row slice of the full KB (four subject drugs whose rule lists carry, between
them, every kill-set token above the `minor` floor). GP reads on their no-context defaults, so the
severity floor is the production `minor` and the slice's `Unknown` rows are filtered exactly as in
production.

1. `anAccentedOrderNameIsStillCheckedForInteractions` — `Budésonide`, `Dexaméthasone`, `Héparine`,
   `glycérine`, `Lévofloxacine`, each paired with the **unaccented spelling of the same product**
   from the same dictionary, so the accent is the only difference between the case that fired and the
   case that did not. Three of the five are accented **and** inflected.
2. `theNestedNameOverMatchStaysDeadForAccentedNames` — the four cases where the fold is what newly
   makes the longer name a candidate: `Nitroglycérine` must raise nitroglycerin and **not** glycerin,
   `Lévofloxacine` levofloxacin and **not** ofloxacin, `Furosémide et spironolactone` spironolactone
   and **not** iron, `Budésonide` **not** desonide. `glycérine` ~ glycerin and `nitroglycérine` ~
   glycerin differ by exactly the left boundary, which is the case #129 flagged as most likely to
   regress.
3. `theIssue86KillSetStillDoesNotFire` — all nine of #128's collisions, each with the paired positive
   that proves the rule it must not fire on is live in this slice.
4. `anAccentedOrderNameIsStillSubstantiatedByAnUnaccentedChartRecord` — the reconciliation call site
   (#118), through the real `DrugReferenceInjector.injectRecords`, where the accented name is the
   **needle** inside a rendered drug-order record. This is the one that pins "both operands", and the
   cost of getting it wrong is a spurious second citable record for one prescription, not a missing
   chip. The locale divergence it stages is the one verified live below.
5. `accentedOrderNamesAreScreenedAgainstEachOther` — the screening arm (#113), which resolves the
   subjects of the screen by running each order name through `findByQuery`/`matchesText`: two
   accented orders (`Dexaméthasone`, `Lévofloxacine`) must raise the one Major tendon-rupture pair,
   with the unaccented spellings as the precondition.

TDD trail, against `main`'s matcher: tests 1, 2, 4 and 5 fail — three of them with `[]`, no chips at
all, which is the defect's signature — and test 3 passes, since it exists to pin what must not change.

Each load-bearing property of the fix is pinned by a distinct failing mutation:

| mutation | tests that fail |
|---|---|
| fold moved into `matchesOrderName` alone | 5 (screening) and 4 (reconciliation) |
| fold applied to the haystack only | 4 (reconciliation) |
| no fold (`main`) | 1, 2, 4, 5 |

Full reactor: **API 789 + OMOD 58 = 847 run, 0 failures, 0 errors, 34 skipped** (`main` is
784 + 58 = 842; the 34 skipped are the LLM-requiring
`PromptInjectionEvalTest`/`LlmAnswerQualityTest`, as on `main`).

## Live verification

Two full runs on the 3.7.1 standalone, each a full-JVM restart onto a freshly built omod (never a
`moduleaction` half-restart), `sourceFormat=ddinter` with the full 19MB KB,
`minInteractionSeverity=minor`, `drugSafety.validateAnswers=true`, `llm.engine=local`. Both runs gated
before anything was recorded: `last querystoreBuild hits=75` (charts are not empty) and the
known-positive warm control raising its chip (`warm chips=1`). Chips are deterministic Java; answer
prose is not reproducible on that box (`cache_prompt` KV reuse), so every claim here is about
`safetyWarnings`, and each accented case was run twice.

**Run 1 — `e73c8b0`'s matcher (the defect), quoted in full at the top of this description.**
**Run 2 — this branch.** Same patient, same single order, same question:

| case | order name the builder reads | run 1 (`main`) | run 2 (this PR) |
|---|---|---|---|
| locale `en` | `Dexamethasone` | 1 chip, Major × dexamethasone | 1 chip, Major × dexamethasone |
| locale `fr` | `Dexaméthasone` | **0 chips**, `references (0)` | **1 chip, Major × dexamethasone** |
| locale `fr`, rerun | `Dexaméthasone` | **0 chips** | **1 chip** |
| locale `en` again | `Dexamethasone` | 1 chip | 1 chip |

On run 2 the answer for the accented order also comes back with the interaction stated and the safety
finding cited, where run 1 abstained with nothing to read:

```
Q: "Is it safe to give him levofloxacin?"    order: (NEW) Dexaméthasone: 4.0 Milligramme Oral …
answer: "No — Levofloxacin should not be given: Levofloxacin interacts with active order
         dexamethasone, a Major finding, as concomitant administration of corticosteroids may
         potentiate the risk of tendinitis and tendon rupture [184]."
--- safetyWarnings (1) --- [interaction] drug='Levofloxacin'
      Levofloxacin interacts with active order dexamethasone — Major. …
--- references (1) --- #184 type=safety_finding group=reference grounded=True
```

Which lever was used, since #128's constraint applies: the REST order path resolves **concept** names
in the English locale, and only **3 of this dictionary's drug rows** carry a diacritic in their own
name (`Griséofulvine Co 500mg`, `Griséofulvine Sirop 125mg`, `Alpha Métyl Dopa Co 250mg`) — all three
hanging off concepts whose name carries the **unaccented** spelling, which would match with or without
the fold and so prove nothing. So this uses the other option #129 names: the order is created on the
`Dexamethasone` concept with no drug row, and the **locale is set explicitly** (admin
`defaultLocale` user property + the `default_locale` GP, both restored on exit), which is what makes
the same order read `Dexamethasone` in `en` and `Dexaméthasone` in `fr`. That concept carries **no ATC
mapping**, so `findByActiveOrders` and the class arm are inert and only the name arm can raise the
chip.

The four documented regression controls, both runs, unchanged:

| patient | question | expected | run 1 | run 2 |
|---|---|---|---|---|
| Mary Smith | clarithromycin | 1 Major × simvastatin | ✅ | ✅ |
| Agnes Adams | warfarin | 1 Major × aspirin | ✅ | ✅ |
| Joshua Johnson | ibuprofen | 2 (NSAID contra + lisinopril Moderate) | ✅ | ✅ |
| Mary Smith | paracetamol | 0 chips | ✅ | ✅ |

## The alias-set gap in #129's comment: split out, not folded in

#129's comment records a second, unrelated gap — `Acetylsalicylic acid` never matched `aspirin`
(that string does not occur in it), matched `salicylic acid` (the wrong drug, 432 rules) before #128,
and matches nothing after — and asks whether to fix it here. **Filed separately as #136.**
Three reasons:

1. The issue's own comment says it "deserves its own issue rather than being folded in here", and
   nothing measured since contradicts that.
2. Both changes widen matching, so combining them makes the kill-direction measurement
   non-attributable: with two widenings in one diff, a resurrected over-match cannot be assigned to
   the fold or to the alias set, and #128 exists precisely because that attribution was needed.
3. It is not the same *shape* of change. Diacritics are a property of the comparison, so they belong
   in the shared scan. The alias set is a property of the rule → entry **resolution**, which
   `PatientClinicalContext` (a pure value object with no service access) cannot reach: the aliases
   have to be resolved by `DrugSafetyValidator`/`DrugReferenceService` and passed in, keeping the chip
   decision and `DrugReferenceInjector`'s promotion predicate agreeing. That is a design change with
   its own kill direction (the alias corpus is 5169 strings against 2093 tokens, and many are
   combination-product names), not a line in this matcher.

## Adjacent gaps found while measuring, deliberately not fixed

- **Accented free-text allergy and condition text is still unmatched.** `hasAllergyToken` /
  `hasConditionToken` use bare containment on a different corpus, which #128 already flagged as
  wanting a rule of its own; the fold does not reach them, so an allergy recorded as `Pénicilline`
  still matches no `penicillin` contraindication token. Same class, different corpus, needs its own
  measurement.
- **`DrugSafetyValidator.identifies` compares a rule token to an entry's aliases by exact equality**,
  deliberately (issue #130's phrase-nesting finding). It is unfolded, which is a no-op on shipped
  data by the same measurement above (0 accented tokens, 0 accented aliases) — but it is the one
  reference-side comparison that a hand-authored accented KB would leave inconsistent with the folded
  matcher. Recorded, not changed: folding it needs the alias corpus measured, which is the issue
  above.

## Data created / changed on the shared standalone

- One inpatient drug order for **Richard Jones** (`a39e82e7-c7ea-489d-80d2-eb6c4450111b`, a spare
  demo patient with no drug orders and not one of the regression controls): a **concept-only** order
  on `Dexamethasone` (`74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`), so the concept name is the order's
  only name and the name arm alone can raise a chip. That concept carries **no ATC mapping**, so
  `findByActiveOrders` and the class arm are inert for it. Test data I added, not demo data.
- The admin user's `defaultLocale` user property and the `default_locale` GP were flipped to `fr` for
  the accented probes and **restored to `en`** by the probe script's exit trap (verified in the
  capture). Both runs left them at `en`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
