### PR TITLE
fix(drug-safety): one contraindication chip per substance, not per reference row (#145)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
@@ -190,6 +190,15 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 					&& rxcuiCounts.get(row.rxcui) == 1;
 			ref.setId(uniqueRxcui ? row.rxcui : row.id);
 			ref.setName(row.name);
+			// The substance this row is a route/formulation of, ALWAYS — unlike the chip-label synonym
+			// below, which is deliberately withheld when the display name already contains it. That is
+			// what makes it usable as an identity: it is the field the route variants sharing one RxCUI
+			// agree on ("Dexamethasone", "Dexamethasone (nasal)", … all publish "dexamethasone"), and
+			// the safety chips group on it so one substance is one finding (issue #145, see
+			// DrugReference.substanceKey). Not the RxCUI itself, though it partitions this KB's entries
+			// identically: setId above already spends the RxCUI on entry identity, where a shared one is
+			// precisely what it must NOT be.
+			ref.setSubstanceName(row.rxnormName);
 			// Chip-label synonym (never renaming): when the DDInter display name diverges from
 			// the RxNorm generic the question and chart use ("Acetylsalicylic acid" vs
 			// "aspirin"), carry the generic so safety chips can show both vocabularies. A name

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -118,8 +118,11 @@ public class DrugReference {
 
 	/**
 	 * @return the reference data's own canonical name for the SUBSTANCE this entry is a row of — the
-	 *         DDInter {@code rxnorm_name} — or null for a source that publishes none (the curated
-	 *         {@code json} file and the {@code atc} adapter). Unlike {@link #getGenericName()}, which
+	 *         DDInter {@code rxnorm_name} — or null for a source that publishes none: the {@code atc}
+	 *         adapter, which has no such field, and the shipped curated {@code json} dataset, whose
+	 *         entries carry none. Null there is the dataset's silence, not a schema ban — the curated
+	 *         schema binds this class directly, so a hand-authored file that sets this field opts into
+	 *         the grouping below. Unlike {@link #getGenericName()}, which
 	 *         is a chip-label synonym and is deliberately null whenever the display name already
 	 *         contains it, this is set whether or not the two agree: it is an identity, not a label,
 	 *         and it is exactly the field that is EQUAL across a substance's route/formulation rows
@@ -168,11 +171,15 @@ public class DrugReference {
 	 *       {@code Atropine}/{@code Hyoscyamine} — each of them the {@code enalapril}/{@code enalaprilat}
 	 *       shape issue #121 decided must stay two chips. The stem separates every one of them.</li>
 	 * </ul>
-	 * Neither half works alone: the stem alone merges 9 groups the substance name keeps apart, 8 of
-	 * them different substances sharing one stem ({@code Manganese (chloride)}/{@code (sulfate)},
+	 * Neither half works alone. Where one stem covers two substances the stem alone merges them and the
+	 * substance name is what refuses: {@code Varicella Zoster Vaccine (Recombinant)} against
+	 * {@code (live/attenuated)} — a distinction that decides whether an immunocompromised patient may
+	 * have it at all — and likewise {@code Manganese (chloride)}/{@code (sulfate)},
 	 * {@code Dextran (-1)}/{@code (low molecular weight)}, {@code Insulin human}/{@code (isophane)},
-	 * {@code Iron}/{@code (polysaccharide)}, {@code Typhoid vaccine (live)}/{@code (inactivated)} …).
-	 * Together the two reduce those 332 entries to 177 substances.
+	 * {@code Insulin lispro}/{@code (protamine)}, {@code Iron}/{@code (polysaccharide)}. A few more
+	 * one-stem groups are kept apart because a row publishes NO substance name rather than a differing
+	 * one ({@code Typhoid vaccine (live)}/{@code (inactivated)}) — that is the null-key fallback below,
+	 * not this comparison. Together the two reduce those 332 entries to 177 substances.
 	 *
 	 * <p>Conservative where it cannot tell, in BOTH directions. A name that extends the family's stem
 	 * by a WORD rather than a qualifier ({@code Hydrocortisone butyrate}, {@code Estrone sulfate},

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -139,9 +139,9 @@ public class DrugReference {
 
 	/** A trailing parenthesized qualifier on a display name — the route or formulation a DDInter row
 	 *  is distinguished from its siblings by ({@code Dexamethasone (nasal)},
-	 *  {@code Amphotericin B (lipid complex)}, {@code Tozinameran (5y-11y)}). Anchored at the END, so
-	 *  a parenthetical in the middle of a name is left alone; applied repeatedly by
-	 *  {@link #displayStem} for the handful of names carrying two. */
+	 *  {@code Amphotericin B (lipid complex)}, {@code Tozinameran (5y-11y)}). Anchored at the END, so a
+	 *  parenthetical in the middle of a name is left alone. {@link #displayStem} applies it repeatedly,
+	 *  so a name carrying more than one trailing qualifier reduces fully rather than partly. */
 	private static final Pattern TRAILING_QUALIFIER = Pattern.compile("\\s*\\([^()]*\\)\\s*$");
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -159,8 +159,8 @@ public class DrugReference {
 	 *       partitions those entries identically, so this is the dataset's substance identity rather
 	 *       than a spelling coincidence.</li>
 	 *   <li>The <b>display stem</b> — the name with trailing qualifiers removed — as a VETO on that
-	 *       claim, because the claim over-merges. 21 of those 142 families hold rows that are
-	 *       genuinely different substances: {@code Omeprazole}/{@code Esomeprazole} (one
+	 *       claim, because the claim over-merges. Among those 142 families sit pairs of genuinely
+	 *       different substances: {@code Omeprazole}/{@code Esomeprazole} (one
 	 *       {@code rxnorm_name}, one {@code rxcui}, one ATC code),
 	 *       {@code Amphetamine}/{@code Dextroamphetamine}, {@code Fenfluramine}/{@code Dexfenfluramine},
 	 *       {@code Gabapentin}/{@code Gabapentin enacarbil}, {@code Netupitant}/{@code Fosnetupitant},
@@ -168,16 +168,19 @@ public class DrugReference {
 	 *       {@code Atropine}/{@code Hyoscyamine} — each of them the {@code enalapril}/{@code enalaprilat}
 	 *       shape issue #121 decided must stay two chips. The stem separates every one of them.</li>
 	 * </ul>
-	 * Neither half works alone: the stem alone merges 9 groups the substance name keeps apart
-	 * ({@code Manganese (chloride)}/{@code (sulfate)}, {@code Dextran (-1)}/{@code (low molecular
-	 * weight)}, {@code Insulin human}/{@code (isophane)}, {@code Iron}/{@code (polysaccharide)},
-	 * {@code Typhoid vaccine (live)}/{@code (inactivated)} …), which are different substances sharing
-	 * one stem. Together they reduce those 332 entries to 177 substances.
+	 * Neither half works alone: the stem alone merges 9 groups the substance name keeps apart, 8 of
+	 * them different substances sharing one stem ({@code Manganese (chloride)}/{@code (sulfate)},
+	 * {@code Dextran (-1)}/{@code (low molecular weight)}, {@code Insulin human}/{@code (isophane)},
+	 * {@code Iron}/{@code (polysaccharide)}, {@code Typhoid vaccine (live)}/{@code (inactivated)} …).
+	 * Together the two reduce those 332 entries to 177 substances.
 	 *
-	 * <p>Conservative where it cannot tell: a name that extends the family's stem by a WORD rather
-	 * than a qualifier ({@code Hydrocortisone butyrate}, {@code Estrone sulfate},
-	 * {@code Procaine benzylpenicillin}) keeps its own key and so its own chip. Over-reporting one
-	 * chip is the safe direction for a non-blocking advisory; dropping a real one is not.
+	 * <p>Conservative where it cannot tell, in BOTH directions. A name that extends the family's stem
+	 * by a WORD rather than a qualifier ({@code Hydrocortisone butyrate}, {@code Estrone sulfate},
+	 * {@code Procaine benzylpenicillin}) keeps its own key and so its own chip, and 21 of the 142
+	 * families are left entirely unmerged for that reason — some of which the KB is in fact naming one
+	 * substance two ways ({@code Thallous Chloride}/{@code Thallous chloride tl-201},
+	 * {@code Typhoid vaccine (live)}/{@code Typhoid vaccine live}). Over-reporting one chip is the safe
+	 * direction for a non-blocking advisory; dropping a real one is not.
 	 *
 	 * @return an opaque key, equal exactly for two entries this module treats as one substance
 	 */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.chartsearchai.reference;
 
 import java.text.Normalizer;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -43,6 +44,10 @@ public class DrugReference {
 
 	/** Diverging everyday generic name, or null — see {@link #getGenericName()}. */
 	private String genericName;
+
+	/** The reference data's own canonical name for the SUBSTANCE, or null — see
+	 *  {@link #getSubstanceName()}. */
+	private String substanceName;
 
 	private String drugClass;
 
@@ -109,6 +114,93 @@ public class DrugReference {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	/**
+	 * @return the reference data's own canonical name for the SUBSTANCE this entry is a row of — the
+	 *         DDInter {@code rxnorm_name} — or null for a source that publishes none (the curated
+	 *         {@code json} file and the {@code atc} adapter). Unlike {@link #getGenericName()}, which
+	 *         is a chip-label synonym and is deliberately null whenever the display name already
+	 *         contains it, this is set whether or not the two agree: it is an identity, not a label,
+	 *         and it is exactly the field that is EQUAL across a substance's route/formulation rows
+	 *         ({@code Dexamethasone}, {@code Dexamethasone (nasal)}, … all publish
+	 *         {@code dexamethasone}). Consumed by {@link #substanceKey()}.
+	 */
+	public String getSubstanceName() {
+		return substanceName;
+	}
+
+	public void setSubstanceName(String substanceName) {
+		this.substanceName = substanceName;
+	}
+
+	/** A trailing parenthesized qualifier on a display name — the route or formulation a DDInter row
+	 *  is distinguished from its siblings by ({@code Dexamethasone (nasal)},
+	 *  {@code Amphotericin B (lipid complex)}, {@code Tozinameran (5y-11y)}). Anchored at the END, so
+	 *  a parenthetical in the middle of a name is left alone; applied repeatedly by
+	 *  {@link #displayStem} for the handful of names carrying two. */
+	private static final Pattern TRAILING_QUALIFIER = Pattern.compile("\\s*\\([^()]*\\)\\s*$");
+
+	/**
+	 * The substance-level identity of this entry, or {@code null} when the loaded source publishes no
+	 * substance name and this entry can therefore only stand for itself.
+	 *
+	 * <p><b>What it is for.</b> One substance is filed as several rows, so one clinician-facing string
+	 * resolves several entries and a per-entry safety chip becomes several chips for one clinical fact
+	 * (issue #145 on the contraindication arms; #115/#121 solved the partner side of the same problem
+	 * for interactions). This is the key those chips group on. It is deliberately NOT
+	 * {@link #displayLabel()}: grouping on a rendered label is the mistake issue #148 had to undo.
+	 *
+	 * <p><b>Two components, each load-bearing, both measured over the shipped 19 MB KB (2283 entries;
+	 * re-measure before relying on the figures).</b>
+	 * <ul>
+	 *   <li>{@link #getSubstanceName()} — the data's own claim that two rows are one substance. 142
+	 *       values are shared by more than one entry, across 332 entries, and the {@code rxcui}
+	 *       partitions those entries identically, so this is the dataset's substance identity rather
+	 *       than a spelling coincidence.</li>
+	 *   <li>The <b>display stem</b> — the name with trailing qualifiers removed — as a VETO on that
+	 *       claim, because the claim over-merges. 21 of those 142 families hold rows that are
+	 *       genuinely different substances: {@code Omeprazole}/{@code Esomeprazole} (one
+	 *       {@code rxnorm_name}, one {@code rxcui}, one ATC code),
+	 *       {@code Amphetamine}/{@code Dextroamphetamine}, {@code Fenfluramine}/{@code Dexfenfluramine},
+	 *       {@code Gabapentin}/{@code Gabapentin enacarbil}, {@code Netupitant}/{@code Fosnetupitant},
+	 *       {@code Ketoconazole}/{@code Levoketoconazole}, {@code Fenofibrate}/{@code Fenofibric acid},
+	 *       {@code Atropine}/{@code Hyoscyamine} — each of them the {@code enalapril}/{@code enalaprilat}
+	 *       shape issue #121 decided must stay two chips. The stem separates every one of them.</li>
+	 * </ul>
+	 * Neither half works alone: the stem alone merges 9 groups the substance name keeps apart
+	 * ({@code Manganese (chloride)}/{@code (sulfate)}, {@code Dextran (-1)}/{@code (low molecular
+	 * weight)}, {@code Insulin human}/{@code (isophane)}, {@code Iron}/{@code (polysaccharide)},
+	 * {@code Typhoid vaccine (live)}/{@code (inactivated)} …), which are different substances sharing
+	 * one stem. Together they reduce those 332 entries to 177 substances.
+	 *
+	 * <p>Conservative where it cannot tell: a name that extends the family's stem by a WORD rather
+	 * than a qualifier ({@code Hydrocortisone butyrate}, {@code Estrone sulfate},
+	 * {@code Procaine benzylpenicillin}) keeps its own key and so its own chip. Over-reporting one
+	 * chip is the safe direction for a non-blocking advisory; dropping a real one is not.
+	 *
+	 * @return an opaque key, equal exactly for two entries this module treats as one substance
+	 */
+	Object substanceKey() {
+		String substance = normalizeName(substanceName);
+		if (substance == null) {
+			return null;
+		}
+		return Arrays.asList(substance, displayStem());
+	}
+
+	/** @return {@link #getName()} with any trailing parenthesized qualifier(s) removed, normalized by
+	 *          {@link #normalizeName} — the empty string when the name is blank or is nothing but a
+	 *          qualifier, which keeps the key total. */
+	private String displayStem() {
+		String stem = name == null ? "" : name;
+		String previous;
+		do {
+			previous = stem;
+			stem = TRAILING_QUALIFIER.matcher(stem).replaceFirst("");
+		} while (!stem.equals(previous));
+		String normalized = normalizeName(stem);
+		return normalized == null ? "" : normalized;
 	}
 
 	public String getDrugClass() {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -183,11 +183,10 @@ public class DrugReference {
 	 *
 	 * <p>Conservative where it cannot tell, in BOTH directions. A name that extends the family's stem
 	 * by a WORD rather than a qualifier ({@code Hydrocortisone butyrate}, {@code Estrone sulfate},
-	 * {@code Procaine benzylpenicillin}) keeps its own key and so its own chip, and 21 of the 142
-	 * families are left entirely unmerged for that reason — some of which the KB is in fact naming one
-	 * substance two ways ({@code Thallous Chloride}/{@code Thallous chloride tl-201},
-	 * {@code Typhoid vaccine (live)}/{@code Typhoid vaccine live}). Over-reporting one chip is the safe
-	 * direction for a non-blocking advisory; dropping a real one is not.
+	 * {@code Procaine benzylpenicillin}) keeps its own key and so its own chip — including where the KB
+	 * is in fact naming one substance two ways ({@code Thallous Chloride}/{@code Thallous chloride
+	 * tl-201}, {@code Typhoid vaccine (live)}/{@code Typhoid vaccine live}). Over-reporting one chip is
+	 * the safe direction for a non-blocking advisory; dropping a real one is not.
 	 *
 	 * @return an opaque key, equal exactly for two entries this module treats as one substance
 	 */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.chartsearchai.reference;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -70,7 +71,11 @@ import org.springframework.stereotype.Service;
  *       condition: by a hand-authored rule, by being the same drug as — or sharing an ATC
  *       chemical subgroup with — a recorded allergy (cross-reactivity reasoning), or —
  *       failing both — by sharing a curated {@link CrossReactivityGroup} with the allergy
- *       (cross-branch cross-reactivity). These same two checks additionally run over the patient's
+ *       (cross-branch cross-reactivity). One warning per (SUBSTANCE, recorded finding), not per
+ *       reference row: a dataset that files one substance as several route or formulation rows put
+ *       every one of them in play from one clinician-facing word, and each raised its own chip — the
+ *       siblings of the row the allergy resolved to reporting the substance as cross-reactive with
+ *       itself ({@link ContraindicationChips}, issue #145). These same two checks additionally run over the patient's
  *       OWN ACTIVE ORDERS, whatever the question and the answer name — "is the patient allergic to
  *       something they are taking?" is a fact about their chart, and the drug-in-play framing above
  *       could not ask it (see {@link #addActiveOrderContraindications}, issue #143).</li>
@@ -303,10 +308,17 @@ public class DrugSafetyValidator {
 		// prose, or prose with no chip, which is the exact defect the shared floor exists to prevent.
 		int severityFloor = configuredSeverityFloor();
 
+		// One ledger for every contraindication chip this pass raises, across BOTH arms and both of
+		// their call sites (the drug-in-play loop below and the order-driven arm after it) — see
+		// ContraindicationChips. It has to span them: one substance's route variants can arrive as
+		// several drugs in play, as several entries of one active order, or as some of each, and a
+		// collapse living inside one arm would still let the other emit the siblings.
+		ContraindicationChips contraindications = new ContraindicationChips(warnings);
+
 		for (DrugReference ref : inPlay) {
 			if (warnContra) {
-				addContraindications(warnings, ref, context);
-				addAllergyContraindications(warnings, ref, context);
+				addContraindications(contraindications, ref, context);
+				addAllergyContraindications(contraindications, ref, context);
 			}
 			if (warnInteractions) {
 				// One call, not one per arm: the rule arm and the class arm can both raise a chip about
@@ -327,7 +339,7 @@ public class DrugSafetyValidator {
 		// list rather than a finding AGAINST her records, they are the two that grow quadratically, and
 		// they are the two a cap can truncate (maxPairChips, #131).
 		if (warnContra) {
-			addActiveOrderContraindications(warnings, inPlay, context, orderEntries);
+			addActiveOrderContraindications(contraindications, inPlay, context, orderEntries);
 		}
 		// LAST, so the patient's own findings lead: a chip about their allergy or their active order
 		// is a fact about them, and outranks a reference lookup about a pair they may not be on.
@@ -566,7 +578,120 @@ public class DrugSafetyValidator {
 		return false;
 	}
 
-	private void addContraindications(List<SafetyWarning> warnings, DrugReference ref,
+	/**
+	 * Every contraindication chip one {@code validate} pass raises: <b>at most one per (substance,
+	 * recorded finding)</b>, whatever arm reaches it and however many reference rows the loaded
+	 * dataset files that substance as (issue #145).
+	 *
+	 * <p><b>The defect.</b> Both contraindication arms are keyed on a subject ENTRY, and DDInter files
+	 * one substance as several route/formulation rows. One clinician-facing string resolves all of them
+	 * — {@link DrugReferenceService#findByQuery} and {@link DrugReferenceService#findByDrugName} return
+	 * every entry whose aliases match — so one clinical fact became one chip per row. Measured live on
+	 * the 3.7.1 standalone: a recorded dexamethasone allergy asked about dexamethasone gave FOUR chips,
+	 * and only the row {@link DrugReferenceService#lookupByToken} resolved the allergy to matched by
+	 * identity, so the other three fell through to the class comparison and reported the substance as
+	 * cross-reactive with the patient's allergy to <em>itself</em> ("Dexamethasone (nasal) is in the
+	 * same ATC class (A01AC) as the patient's allergy to Dexamethasone"). Since issue #110 every chip
+	 * is also injected as a citable pre-answer record, so each duplicate reached the prompt as well.
+	 *
+	 * <p><b>Why a ledger rather than a filter over the finished chip list.</b> Three reasons, and the
+	 * first is the decisive one. (1) The sibling's chip is not merely a duplicate, it is WRONG — the
+	 * true statement about that substance is the identity one — so the collapse has to choose which
+	 * relationship survives, and by the time only rendered text is left the reasons are gone. (2) Those
+	 * chips differ in text (each names its own route), so {@link #chipIdentity}'s exact-repeat key
+	 * cannot see them; recognising "differs only in a route qualifier" from the strings alone means
+	 * pattern-matching a display label, which is the mistake issue #148 had to undo. (3) The two arms
+	 * run at two call sites — the drug-in-play loop and {@link #addActiveOrderContraindications} — and
+	 * a collapse inside either one leaves the other emitting the siblings, which is Sarah Taylor's live
+	 * shape (one hydrocortisone order, four rows, four chips, question naming no drug).
+	 *
+	 * <p><b>The key.</b> {@code (subject substance, recorded finding)}. The subject side is
+	 * {@link DrugReference#substanceKey()}, which is where the measurement behind it lives and why it
+	 * is not simply the dataset's substance name; an entry from a source publishing none keys on its
+	 * own identity, so nothing collapses for the curated {@code json} or the {@code atc} adapter. The
+	 * finding side is what the arm actually compared — the resolved allergen ENTRY for the allergy arm,
+	 * and the curated rule's own {@code (type, token)} for the rule arm. Those are two key spaces on
+	 * purpose: the rule arm's token is free text that may name a class ({@code nsaid},
+	 * {@code aminoglycoside}) rather than a drug, so resolving it to an entry to make the two arms
+	 * comparable would collapse a class-level rule into an identity chip. A curated rule and an
+	 * identity match about ONE allergy therefore still raise two chips — that is issue #146, which is
+	 * filed separately and which {@code ActiveOrderContraindicationTest} currently pins at two.
+	 *
+	 * <p><b>Which chip survives.</b> The most specific relationship, since that is this arm's analogue
+	 * of "the highest severity wins" — a contraindication chip carries no severity, and what it can
+	 * under-report is the STRENGTH of the claim: identity ("the patient has a recorded allergy to X")
+	 * over a shared ATC class over a shared curated group. Ties keep the incumbent, so a group of
+	 * equally-related rows is reported as the dataset's first row, exactly as
+	 * {@link #bestRulePerPartner} keeps its first. The surviving chip is written back into the position
+	 * the group's first candidate took, so no client sees the chip sequence reshuffle when a later,
+	 * stronger row replaces an earlier one.
+	 *
+	 * <p><b>One honest limit.</b> On the shipped resolution semantics the strongest candidate is always
+	 * the group's FIRST: {@code lookupByToken} resolves an allergy to the EARLIEST matching entry,
+	 * every row of a substance carries that substance's name among its aliases, and both subject sets
+	 * are iterated in dataset order — so the identity match belongs to the earliest row of its own
+	 * group. The replacement branch is therefore not reachable through the production path today and no
+	 * test pins it; it is written this way because the ordering coincidence is a property of
+	 * {@code lookupByToken}, not of this ledger, and a first-wins ledger would silently start dropping
+	 * identity chips the moment that changed.
+	 */
+	private static final class ContraindicationChips {
+
+		/** A recorded allergy to this very substance — needs no ATC code and outranks both class
+		 *  comparisons (the precedence {@link #addAllergyContraindications} already applies per
+		 *  allergen, extended across the rows of one substance). */
+		static final int IDENTITY = 3;
+
+		/** A shared ATC level-4 chemical subgroup with the allergen. */
+		static final int SAME_CLASS = 2;
+
+		/** A shared curated {@link CrossReactivityGroup} with the allergen — the fallback the class
+		 *  comparison takes when no subgroup is shared, and so the least specific of the three. */
+		static final int SAME_GROUP = 1;
+
+		/** A curated contraindication rule. Its own key space, so this rank never competes with the
+		 *  three above; it exists so every call reads alike. */
+		static final int CURATED_RULE = 1;
+
+		private final List<SafetyWarning> warnings;
+
+		private final Map<List<Object>, Integer> positions = new LinkedHashMap<List<Object>, Integer>();
+
+		private final Map<List<Object>, Integer> relationships = new LinkedHashMap<List<Object>, Integer>();
+
+		ContraindicationChips(List<SafetyWarning> warnings) {
+			this.warnings = warnings;
+		}
+
+		/**
+		 * Raise {@code chip} for {@code subject} about {@code finding}, unless a chip for that pair is
+		 * already raised — in which case the more specific {@code relationship} wins, in place.
+		 */
+		void add(DrugReference subject, Object finding, int relationship, SafetyWarning chip) {
+			List<Object> key = Arrays.asList(subjectKey(subject), finding);
+			Integer at = positions.get(key);
+			if (at == null) {
+				positions.put(key, Integer.valueOf(warnings.size()));
+				relationships.put(key, Integer.valueOf(relationship));
+				warnings.add(chip);
+				return;
+			}
+			if (relationship > relationships.get(key).intValue()) {
+				warnings.set(at.intValue(), chip);
+				relationships.put(key, Integer.valueOf(relationship));
+			}
+		}
+
+		/** @return the substance {@code subject} stands for, else {@code subject} itself. The two are
+		 *          different types — a {@link List} and a {@link DrugReference} — so the two key spaces
+		 *          cannot collide, the same argument {@link #bestRulePerPartner} makes about its own. */
+		private static Object subjectKey(DrugReference subject) {
+			Object substance = subject.substanceKey();
+			return substance != null ? substance : subject;
+		}
+	}
+
+	private void addContraindications(ContraindicationChips chips, DrugReference ref,
 			PatientClinicalContext context) {
 		if (context == null) {
 			return;
@@ -582,9 +707,14 @@ public class DrugSafetyValidator {
 				against = "active condition";
 			}
 			if (hit) {
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
-						ref.displayLabel() + " is contraindicated by an " + against + ": "
-								+ ChartSearchAiUtils.firstNonBlank(c.getNote(), c.getToken())));
+				// The rule as the two tests above compared it — type case-insensitively, token through
+				// hasAllergyToken/hasConditionToken, which lower-case — so the key says what the match
+				// said, and two rows differing only in case cannot chip twice.
+				chips.add(ref, Arrays.asList("rule", DrugReference.normalizeName(c.getType()),
+						DrugReference.normalizeName(c.getToken())), ContraindicationChips.CURATED_RULE,
+						new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
+								ref.displayLabel() + " is contraindicated by an " + against + ": "
+										+ ChartSearchAiUtils.firstNonBlank(c.getNote(), c.getToken())));
 			}
 		}
 	}
@@ -1653,7 +1783,11 @@ public class DrugSafetyValidator {
 	 *         issue #88 is likewise not this key's to catch: {@link #addInteractionWarnings} correlates
 	 *         a rule against the class arm's own finding about the same order, which is a comparison of
 	 *         REASONS rather than of rendered text, and approximating it here on a text key would
-	 *         collapse two chips whose wording happens to agree. NUL-separated because the fields are
+	 *         collapse two chips whose wording happens to agree. Nor is the route-variant duplication of
+	 *         issue #145 this key's to catch, for the opposite reason: those chips each name their own
+	 *         route, so they are not exact repeats at all, and recognising them from the strings would
+	 *         mean pattern-matching a display label — {@link ContraindicationChips} groups them on
+	 *         substance identity instead. NUL-separated because the fields are
 	 *         clinical prose carrying spaces, colons and dashes of their own, so any printable
 	 *         delimiter would let two distinct triples key alike.
 	 */
@@ -1757,10 +1891,13 @@ public class DrugSafetyValidator {
 	 * {@code ref} (a recorded allergy to the very drug being checked), shares {@code ref}'s ATC level-4
 	 * subgroup (cross-reactivity), or — failing both — shares a curated {@link CrossReactivityGroup}
 	 * (cross-<em>branch</em> cross-reactivity, e.g. aspirin vs an ibuprofen allergy, which ATC's tree
-	 * cannot express). One warning per resolved allergen: the most specific match wins, and several
-	 * aliases of one allergy warn once. The two class comparisons need only ATC codes, which is how an
-	 * authoritative classification source carrying no rules ({@link AtcDrugReferenceSource}) still
-	 * produces allergy reasoning.
+	 * cannot express). At most one warning per (SUBSTANCE, resolved allergen): the most specific match
+	 * wins, several aliases of one allergy warn once ({@code seenAllergens} below), and the several
+	 * reference rows one substance is filed as warn once between them
+	 * ({@link ContraindicationChips}, issue #145 — the ledger this arm adds to rather than appending to
+	 * the chip list, and the reason it takes one). The two class comparisons need only ATC codes, which
+	 * is how an authoritative classification source carrying no rules ({@link AtcDrugReferenceSource})
+	 * still produces allergy reasoning.
 	 *
 	 * <p><b>Identity is not classification (issue #135).</b> The three comparisons were all gated on
 	 * one early return taken when {@code ref} had neither an ATC subgroup nor a curated group. That
@@ -1832,7 +1969,7 @@ public class DrugSafetyValidator {
 	 * play before this arm sees it (issue #105, {@link #isEchoOfCitedRecord}) — the 444 measurement is
 	 * of the question-driven path, which is never echo-scoped.
 	 */
-	private void addAllergyContraindications(List<SafetyWarning> warnings, DrugReference ref,
+	private void addAllergyContraindications(ContraindicationChips chips, DrugReference ref,
 			PatientClinicalContext context) {
 		if (context == null) {
 			return;
@@ -1847,8 +1984,9 @@ public class DrugSafetyValidator {
 				continue;
 			}
 			if (allergen == ref) {
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
-						"The patient has a recorded allergy to " + ref.displayLabel() + "."));
+				chips.add(ref, allergen, ContraindicationChips.IDENTITY,
+						new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
+								"The patient has a recorded allergy to " + ref.displayLabel() + "."));
 				continue;
 			}
 			if (refClasses.isEmpty() && refGroups.isEmpty()) {
@@ -1860,18 +1998,20 @@ public class DrugSafetyValidator {
 			}
 			String shared = sharedClass(refClasses, allergen);
 			if (shared != null) {
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
-						ref.displayLabel() + " is in the same ATC class (" + shared
-								+ ") as the patient's allergy to " + allergen.displayLabel()
-								+ " — possible cross-reactivity"));
+				chips.add(ref, allergen, ContraindicationChips.SAME_CLASS,
+						new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
+								ref.displayLabel() + " is in the same ATC class (" + shared
+										+ ") as the patient's allergy to " + allergen.displayLabel()
+										+ " — possible cross-reactivity"));
 				continue;
 			}
 			CrossReactivityGroup group = CrossReactivityGroup.sharedGroup(refGroups, allergen);
 			if (group != null) {
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
-						ref.displayLabel() + " is in the same cross-reactivity group (" + group.getName()
-								+ ") as the patient's allergy to " + allergen.displayLabel()
-								+ " — possible cross-reactivity"));
+				chips.add(ref, allergen, ContraindicationChips.SAME_GROUP,
+						new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
+								ref.displayLabel() + " is in the same cross-reactivity group ("
+										+ group.getName() + ") as the patient's allergy to "
+										+ allergen.displayLabel() + " — possible cross-reactivity"));
 			}
 		}
 	}
@@ -1920,8 +2060,10 @@ public class DrugSafetyValidator {
 	 * taking?" is a fact about their chart, not about the wording of a query, and gating a
 	 * contraindication on the question's wording is what produced this defect. What bounds the arm
 	 * instead is the chart: it can only fire where an allergy or condition record and an active order
-	 * point at the same drug, and the two arms it delegates to bound it further — one chip per resolved
-	 * allergen ({@code seenAllergens}), one per matching curated rule. That is a bound in the patient's
+	 * point at the same drug, and the two arms it delegates to bound it further — one chip per
+	 * (substance, resolved allergen) and one per (substance, matching curated rule), through the same
+	 * {@link ContraindicationChips} ledger the drug-in-play call site uses, which is what stops one
+	 * order that resolves several reference rows raising a chip per row (issue #145). That is a bound in the patient's
 	 * own records, the same kind every other contraindication chip has and the reason the pairwise arms
 	 * need {@link #maxPairChips()} while this one does not: nothing here is quadratic in a list the
 	 * module does not choose.
@@ -1954,7 +2096,7 @@ public class DrugSafetyValidator {
 	 * entry is mislabelled here exactly as it is on the question path (see
 	 * {@link #addAllergyContraindications}'s measured coverage bound).
 	 */
-	private void addActiveOrderContraindications(List<SafetyWarning> warnings, Set<DrugReference> inPlay,
+	private void addActiveOrderContraindications(ContraindicationChips chips, Set<DrugReference> inPlay,
 			PatientClinicalContext context, List<DrugReference> orderEntries) {
 		if (context == null
 				|| (context.getAllergyTokens().isEmpty() && context.getConditionTokens().isEmpty())) {
@@ -1964,8 +2106,8 @@ public class DrugSafetyValidator {
 			if (inPlay.contains(ref)) {
 				continue;
 			}
-			addContraindications(warnings, ref, context);
-			addAllergyContraindications(warnings, ref, context);
+			addContraindications(chips, ref, context);
+			addAllergyContraindications(chips, ref, context);
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -608,14 +608,14 @@ public class DrugSafetyValidator {
 	 * <p><b>The key.</b> {@code (subject substance, recorded finding)}. The subject side is
 	 * {@link DrugReference#substanceKey()}, which is where the measurement behind it lives and why it
 	 * is not simply the dataset's substance name; an entry from a source publishing none keys on its
-	 * own identity, so nothing collapses for the curated {@code json} or the {@code atc} adapter. The
-	 * finding side is what the arm actually compared — the resolved allergen ENTRY for the allergy arm,
-	 * and the curated rule's own {@code (type, token)} for the rule arm. Those are two key spaces on
-	 * purpose: the rule arm's token is free text that may name a class ({@code nsaid},
-	 * {@code aminoglycoside}) rather than a drug, so resolving it to an entry to make the two arms
-	 * comparable would collapse a class-level rule into an identity chip. A curated rule and an
-	 * identity match about ONE allergy therefore still raise two chips — that is issue #146, which is
-	 * filed separately and which {@code ActiveOrderContraindicationTest} currently pins at two.
+	 * own identity, so nothing collapses for the {@code atc} adapter or the shipped curated
+	 * {@code json} dataset. The finding side is what the arm actually compared — the resolved allergen
+	 * ENTRY for the allergy arm, and the curated rule's own {@code (type, token)} for the rule arm.
+	 * Those are two key spaces on purpose: the rule arm's token is free text that may name a class
+	 * ({@code nsaid}, {@code aminoglycoside}) rather than a drug, so resolving it to an entry to make
+	 * the two arms comparable would collapse a class-level rule into an identity chip. A curated rule
+	 * and an identity match about ONE allergy therefore still raise two chips — that is issue #146,
+	 * filed separately, which {@code ActiveOrderContraindicationTest} currently pins at two.
 	 *
 	 * <p><b>Which chip survives.</b> The most specific relationship, since that is this arm's analogue
 	 * of "the highest severity wins" — a contraindication chip carries no severity, and what it can
@@ -626,14 +626,19 @@ public class DrugSafetyValidator {
 	 * the group's first candidate took, so no client sees the chip sequence reshuffle when a later,
 	 * stronger row replaces an earlier one.
 	 *
-	 * <p><b>One honest limit.</b> On the shipped resolution semantics the strongest candidate is always
-	 * the group's FIRST: {@code lookupByToken} resolves an allergy to the EARLIEST matching entry,
-	 * every row of a substance carries that substance's name among its aliases, and both subject sets
-	 * are iterated in dataset order — so the identity match belongs to the earliest row of its own
-	 * group. The replacement branch is therefore not reachable through the production path today and no
-	 * test pins it; it is written this way because the ordering coincidence is a property of
-	 * {@code lookupByToken}, not of this ledger, and a first-wins ledger would silently start dropping
-	 * identity chips the moment that changed.
+	 * <p><b>Why replacing an incumbent is not dead code.</b> It is tempting to read this ledger as
+	 * first-wins, and on the dexamethasone family the two would agree: {@code lookupByToken} resolves an
+	 * allergy to the EARLIEST matching entry, every dexamethasone row carries the bare substance name
+	 * among its aliases, and both subject sets are iterated in dataset order — so there the identity
+	 * match IS the group's first candidate. That premise does not hold generally. Where no alias of a
+	 * row is the bare substance name, the allergy skips that row and resolves a LATER member of its own
+	 * group, and the earlier members raise their class chips first: {@code Tozinameran} behind the
+	 * {@code Pfizer-BioNTech} presentations, {@code Insulin aspart (aspart)},
+	 * {@code Iobenguane (I-131)}. First-wins answers those with the vacuous "in the same ATC class as
+	 * your allergy to &lt;this same substance&gt;" chip this ledger exists to remove, which is what
+	 * {@code ContraindicationRouteVariantTest.theIdentityChipSurvivesWhenTheAllergenRowIsNotItsGroupsFirst}
+	 * pins. How many groups the shipped KB reaches it through is a property of that dataset — measure it
+	 * rather than trusting a number here.
 	 */
 	private static final class ContraindicationChips {
 

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -75,10 +75,11 @@ import org.springframework.stereotype.Service;
  *       reference row: a dataset that files one substance as several route or formulation rows put
  *       every one of them in play from one clinician-facing word, and each raised its own chip — the
  *       siblings of the row the allergy resolved to reporting the substance as cross-reactive with
- *       itself ({@link ContraindicationChips}, issue #145). These same two checks additionally run over the patient's
- *       OWN ACTIVE ORDERS, whatever the question and the answer name — "is the patient allergic to
- *       something they are taking?" is a fact about their chart, and the drug-in-play framing above
- *       could not ask it (see {@link #addActiveOrderContraindications}, issue #143).</li>
+ *       itself ({@link ContraindicationChips}, issue #145). These same two checks additionally run
+ *       over the patient's OWN ACTIVE ORDERS, whatever the question and the answer name — "is the
+ *       patient allergic to something they are taking?" is a fact about their chart, and the
+ *       drug-in-play framing above could not ask it (see
+ *       {@link #addActiveOrderContraindications}, issue #143).</li>
  * </ul>
  *
  * <p>The rule-based checks fire on the entry's own curated {@code interactions}/
@@ -666,11 +667,26 @@ public class DrugSafetyValidator {
 		 *  three above; it exists so every call reads alike. */
 		static final int CURATED_RULE = 1;
 
+		/** A chip already raised for one key: where it sits in {@code warnings}, and how specific the
+		 *  relationship behind it is. ONE entry rather than two maps keyed alike, so the position and the
+		 *  rank cannot desync — a position with no rank beside it would throw inside a {@code validate}
+		 *  whose callers catch {@link RuntimeException} and return nothing, i.e. it would silently drop
+		 *  every chip on the request rather than the one it mishandled. */
+		private static final class Raised {
+
+			private final int position;
+
+			private int relationship;
+
+			Raised(int position, int relationship) {
+				this.position = position;
+				this.relationship = relationship;
+			}
+		}
+
 		private final List<SafetyWarning> warnings;
 
-		private final Map<List<Object>, Integer> positions = new LinkedHashMap<List<Object>, Integer>();
-
-		private final Map<List<Object>, Integer> relationships = new LinkedHashMap<List<Object>, Integer>();
+		private final Map<List<Object>, Raised> raised = new LinkedHashMap<List<Object>, Raised>();
 
 		ContraindicationChips(List<SafetyWarning> warnings) {
 			this.warnings = warnings;
@@ -682,16 +698,15 @@ public class DrugSafetyValidator {
 		 */
 		void add(DrugReference subject, Object finding, int relationship, SafetyWarning chip) {
 			List<Object> key = Arrays.asList(subjectKey(subject), finding);
-			Integer at = positions.get(key);
-			if (at == null) {
-				positions.put(key, Integer.valueOf(warnings.size()));
-				relationships.put(key, Integer.valueOf(relationship));
+			Raised already = raised.get(key);
+			if (already == null) {
+				raised.put(key, new Raised(warnings.size(), relationship));
 				warnings.add(chip);
 				return;
 			}
-			if (relationship > relationships.get(key).intValue()) {
-				warnings.set(at.intValue(), chip);
-				relationships.put(key, Integer.valueOf(relationship));
+			if (relationship > already.relationship) {
+				warnings.set(already.position, chip);
+				already.relationship = relationship;
 			}
 		}
 
@@ -2076,10 +2091,10 @@ public class DrugSafetyValidator {
 	 * point at the same drug, and the two arms it delegates to bound it further — one chip per
 	 * (substance, resolved allergen) and one per (substance, matching curated rule), through the same
 	 * {@link ContraindicationChips} ledger the drug-in-play call site uses, which is what stops one
-	 * order that resolves several reference rows raising a chip per row (issue #145). That is a bound in the patient's
-	 * own records, the same kind every other contraindication chip has and the reason the pairwise arms
-	 * need {@link #maxPairChips()} while this one does not: nothing here is quadratic in a list the
-	 * module does not choose.
+		 * order that resolves several reference rows raising a chip per row (issue #145). That is a bound
+	 * in the patient's own records, the same kind every other contraindication chip has and the reason
+	 * the pairwise arms need {@link #maxPairChips()} while this one does not: nothing here is quadratic
+	 * in a list the module does not choose.
 	 *
 	 * <p><b>The precondition.</b> With neither allergy nor condition tokens recorded both arms are
 	 * provably no-ops — every branch of {@link #addContraindications} requires

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -626,6 +626,14 @@ public class DrugSafetyValidator {
 	 * the group's first candidate took, so no client sees the chip sequence reshuffle when a later,
 	 * stronger row replaces an earlier one.
 	 *
+	 * <p>Resolving a tie by position is lossless rather than merely tidier, and that rests on the rows
+	 * of one substance publishing the SAME ATC codes — which the shipped KB does for every group this
+	 * key merges, and which is the thing to re-measure before widening the key, since the class chip
+	 * names a code and a divergent row's code would be dropped unheard. Curated-group membership needs
+	 * no separate check: {@link CrossReactivityGroup#groupsOf} is a pure function of those same codes,
+	 * so equal codes are equal membership. What is left for a tie to choose between is then only the
+	 * route qualifier in the subject's own label.
+	 *
 	 * <p><b>Why replacing an incumbent is not dead code.</b> It is tempting to read this ledger as
 	 * first-wins, and on the dexamethasone family the two would agree: {@code lookupByToken} resolves an
 	 * allergy to the EARLIEST matching entry, every dexamethasone row carries the bare substance name

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -672,13 +672,13 @@ public class DrugSafetyValidator {
 		 *  rank cannot desync — a position with no rank beside it would throw inside a {@code validate}
 		 *  whose callers catch {@link RuntimeException} and return nothing, i.e. it would silently drop
 		 *  every chip on the request rather than the one it mishandled. */
-		private static final class Raised {
+		private static final class RaisedChip {
 
 			private final int position;
 
 			private int relationship;
 
-			Raised(int position, int relationship) {
+			RaisedChip(int position, int relationship) {
 				this.position = position;
 				this.relationship = relationship;
 			}
@@ -686,7 +686,7 @@ public class DrugSafetyValidator {
 
 		private final List<SafetyWarning> warnings;
 
-		private final Map<List<Object>, Raised> raised = new LinkedHashMap<List<Object>, Raised>();
+		private final Map<List<Object>, RaisedChip> raised = new LinkedHashMap<List<Object>, RaisedChip>();
 
 		ContraindicationChips(List<SafetyWarning> warnings) {
 			this.warnings = warnings;
@@ -698,9 +698,9 @@ public class DrugSafetyValidator {
 		 */
 		void add(DrugReference subject, Object finding, int relationship, SafetyWarning chip) {
 			List<Object> key = Arrays.asList(subjectKey(subject), finding);
-			Raised already = raised.get(key);
+			RaisedChip already = raised.get(key);
 			if (already == null) {
-				raised.put(key, new Raised(warnings.size(), relationship));
+				raised.put(key, new RaisedChip(warnings.size(), relationship));
 				warnings.add(chip);
 				return;
 			}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -12,6 +12,7 @@ package org.openmrs.module.chartsearchai.reference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,9 +62,10 @@ public class ContraindicationRouteVariantTest {
 	 * ({@code Omeprazole} + {@code Esomeprazole}) with a third PPI to be allergic to
 	 * ({@code Pantoprazole}, {@code A02BC02}, so the shared level-4 subgroup is {@code A02BC}), and
 	 * the four {@code hydrocortisone} rows with {@code Dexamethasone} to be allergic to (both carry
-	 * {@code A01AC}). Its {@code interactions} array is empty, deliberately: this file asserts
-	 * contraindication chip COUNTS, and an interaction chip in the same list would have to be filtered
-	 * out of every assertion here.
+	 * {@code A01AC}), and the five {@code Tozinameran} rows — the group whose allergen row is not its
+	 * first, because only the bare row carries the bare substance name as an alias. Its
+	 * {@code interactions} array is empty, deliberately: this file asserts contraindication chip COUNTS,
+	 * and an interaction chip in the same list would have to be filtered out of every assertion here.
 	 */
 	private static final String FIXTURE = "chartsearchai-test/ddi-contra-route-variants.json";
 
@@ -219,10 +221,10 @@ public class ContraindicationRouteVariantTest {
 
 		DrugReference allergen = service.lookupByToken("Tozinameran");
 		assertNotNull(allergen, "the allergy must resolve to one of the rows");
-		assertEquals(inPlay.get(3), allergen,
+		assertSame(inPlay.get(3), allergen,
 				"and the allergen is the FOURTH: this KB gives each presentation row only its own "
-						+ "qualified name, so the bare substance name skips them — was: "
-						+ (allergen == null ? "null" : allergen.getName()));
+						+ "qualified name as an alias, so the bare substance name skips them — was: "
+						+ allergen.getName());
 		assertEquals(allergen.substanceKey(), inPlay.get(0).substanceKey(),
 				"while all of them are still one substance to the collapse");
 	}
@@ -231,12 +233,13 @@ public class ContraindicationRouteVariantTest {
 	public void theIdentityChipSurvivesWhenTheAllergenRowIsNotItsGroupsFirst() throws IOException {
 		// The collapse must keep the most specific relationship even when the weaker candidate is raised
 		// FIRST — an incumbent chip has to be REPLACED, not merely suppressed. Reachable on the shipped
-		// KB, not a hypothetical: measured through this same entry point over the full 19 MB dataset, 10
-		// of its 121 collapsed groups contain a row whose own name resolves an allergy to a LATER member
-		// of the group (`Tozinameran`, `Insulin aspart (aspart)`, `Iobenguane (I-131)`, …). A first-wins
-		// ledger answers this case with "Tozinameran (12y+) … is in the same ATC class (J07BN) as the
-		// patient's allergy to Tozinameran" — the vacuous self-cross-reactivity issue #145 exists to
-		// remove, kept instead of removed.
+		// KB, not a hypothetical: where a row carries only its own qualified name as an alias and not the
+		// bare substance name, lookupByToken's earliest-match rule skips it and the allergy resolves a
+		// LATER member of the same collapsed group, so the earlier members chip first. `Tozinameran`,
+		// `Insulin aspart (aspart)` and `Iobenguane (I-131)` were each verified this way through
+		// validate() over the full 19 MB KB. A first-wins ledger answers this case with "Tozinameran
+		// (12y+) … is in the same ATC class (J07BN) as the patient's allergy to Tozinameran" — the
+		// vacuous self-cross-reactivity issue #145 exists to remove, kept instead of removed.
 		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
 				"Is it safe to give the Pfizer-BioNTech COVID-19 vaccine?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -251,6 +251,28 @@ public class ContraindicationRouteVariantTest {
 	}
 
 	@Test
+	public void oneLedgerSpansBothCallSitesRatherThanOnePerArm() throws IOException {
+		// The decisive reason this is a ledger and not a filter: the two arms run at TWO call sites, so a
+		// collapse living inside either one leaves the other emitting the siblings. Here both call sites
+		// raise a candidate for the SAME (substance, allergen) key and neither is redundant with the
+		// other — the question resolves the (12y+) presentation and the bare row, the active order
+		// resolves the (5y-11y) presentation, which no question word reaches. A ledger per call site
+		// answers this with two chips; the tests above cannot see the difference, because in each of them
+		// one call site supplies the whole group.
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
+				"Is it safe to give Tozinameran (12y+)?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Tozinameran (5y-11y)"), null,
+						DrugReferenceTestSupport.set("Tozinameran"), null));
+
+		assertEquals(1, warnings.size(),
+				"a question-driven chip and an order-driven one about one substance are one chip, was: "
+						+ warnings);
+		assertEquals("The patient has a recorded allergy to Tozinameran (sars-cov-2 (covid-19) vaccine,"
+				+ " mrna spike protein).", warnings.get(0).getDetail());
+	}
+
+	@Test
 	public void oneSubstanceStillReportsEveryRecordedFindingSeparately() throws IOException {
 		// The other half of the key: the RECORDED FINDING is in it, so the collapse is per (substance,
 		// finding) and never per substance. Two allergies about one substance are two clinical facts and

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -11,7 +11,9 @@ package org.openmrs.module.chartsearchai.reference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.IOException;
@@ -62,12 +64,19 @@ public class ContraindicationRouteVariantTest {
 	 * ({@code Omeprazole} + {@code Esomeprazole}) with a third PPI to be allergic to
 	 * ({@code Pantoprazole}, {@code A02BC02}, so the shared level-4 subgroup is {@code A02BC}), and
 	 * the four {@code hydrocortisone} rows with {@code Dexamethasone} to be allergic to (both carry
-	 * {@code A01AC}), and the five {@code Tozinameran} rows — the group whose allergen row is not its
+	 * {@code A01AC}), plus the five {@code Tozinameran} rows — the group whose allergen row is not its
 	 * first, because only the bare row carries the bare substance name as an alias. Its
 	 * {@code interactions} array is empty, deliberately: this file asserts contraindication chip COUNTS,
 	 * and an interaction chip in the same list would have to be filtered out of every assertion here.
 	 */
 	private static final String FIXTURE = "chartsearchai-test/ddi-contra-route-variants.json";
+
+	/** One curated entry carrying the same contraindication rule twice, differing only in the CASE of
+	 *  its type and token — the ledger's other key space, on the source that publishes no substance
+	 *  name. Curated schema, so it is parsed by {@link JsonDrugReferenceSource} rather than the DDInter
+	 *  parser above. */
+	private static final String DUPLICATE_RULE_FIXTURE =
+			"chartsearchai-test/drug-reference-duplicate-rule-tokens.json";
 
 	/** A question that resolves no reference drug and is not an interaction screen, so the only arm
 	 *  that can chip is the order-driven one ({@code addActiveOrderContraindications}). */
@@ -161,6 +170,25 @@ public class ContraindicationRouteVariantTest {
 				"the surviving variant chip is the dataset's first row, named by displayLabel()");
 		assertEquals("Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy"
 				+ " to Dexamethasone — possible cross-reactivity", warnings.get(1).getDetail());
+	}
+
+	/**
+	 * The must-not-collapse case below is a test of the display-stem VETO only while its two rows
+	 * genuinely share the reference data's substance name. Pinned separately, because a fixture
+	 * regenerated with differing {@code rxnorm_name}s would leave that case passing 2-for-2 on the
+	 * substance name alone — and the stem half, which a mutation sweep showed drops real chips when
+	 * removed, would then be exercised by nothing.
+	 */
+	@Test
+	public void theTwoPpiRowsShareTheSubstanceNameTheStemHasToVeto() throws IOException {
+		List<DrugReference> ppis = fixtureService(FIXTURE).findByQuery("Is it safe to give esomeprazole?");
+
+		assertEquals(2, ppis.size(), "was: " + names(ppis));
+		assertEquals(DrugReference.normalizeName(ppis.get(0).getSubstanceName()),
+				DrugReference.normalizeName(ppis.get(1).getSubstanceName()),
+				"the two rows must share ONE substance name, or the stem is not what keeps them apart");
+		assertNotEquals(ppis.get(0).substanceKey(), ppis.get(1).substanceKey(),
+				"while the combined key still separates them");
 	}
 
 	@Test
@@ -316,6 +344,47 @@ public class ContraindicationRouteVariantTest {
 
 		assertEquals(1, findings.size(),
 				"one chip is one citable record, not one per route variant, was: " + findings);
+	}
+
+	@Test
+	public void oneCuratedRuleAuthoredTwiceRaisesOneChip() throws IOException {
+		// The ledger's OTHER key space, and the one source that publishes no substance name at all: a
+		// curated entry keys on its own identity, so nothing about it collapses across rows — but its
+		// rules still key on (type, token) NORMALIZED the way the arm compared them, so one rule authored
+		// twice in different case is one chip rather than two. Pre-fix both were appended unconditionally.
+		//
+		// The cost this pins: ties keep the incumbent, so the second rule's NOTE is dropped. That is the
+		// right call for a re-spelling of one rule and a lossy one for two genuinely different notes
+		// under one token; the latter is authoring pathology no shipped dataset contains, and is
+		// reported rather than designed around here.
+		DrugReferenceService service = DrugReferenceTestSupport
+				.serviceWith(DrugReferenceTestSupport.fixtureEntries(DUPLICATE_RULE_FIXTURE));
+		service.setCrossReactivityGroups(DrugReferenceTestSupport.bundledGroups());
+		DrugReference ibuprofen = service.lookupByToken("Ibuprofen");
+		assertNotNull(ibuprofen, "precondition: the fixture entry must resolve");
+		assertNull(ibuprofen.substanceKey(),
+				"precondition: a curated entry publishes no substance name, so it keys on itself");
+		assertEquals(2, ibuprofen.getContraindications().size(),
+				"precondition: the fixture must really carry the rule twice");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(service).validate("",
+				"Is ibuprofen safe for her?", DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("ibuprofen"), null));
+
+		assertEquals(2, warnings.size(),
+				"the rule collapses to one chip, and the identity chip beside it is issue #146's separate "
+						+ "key space — deliberately NOT collapsed with it, was: " + warnings);
+		List<String> ruleChips = new ArrayList<String>();
+		for (SafetyWarning warning : warnings) {
+			if (warning.getDetail().contains("is contraindicated by an")) {
+				ruleChips.add(warning.getDetail());
+			}
+		}
+		assertEquals(1, ruleChips.size(), "one rule is one chip however it is spelled, was: " + ruleChips);
+		assertEquals("Ibuprofen is contraindicated by an active allergy: documented ibuprofen allergy",
+				ruleChips.get(0), "and the incumbent survives");
+		assertFalse(warnings.toString().contains("avoid all NSAIDs"),
+				"so the re-spelling's own note is the one dropped, was: " + warnings);
 	}
 
 	private static List<String> names(List<DrugReference> entries) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -290,10 +291,22 @@ public class ContraindicationRouteVariantTest {
 		// resolves the (5y-11y) presentation, which no question word reaches. A ledger per call site
 		// answers this with two chips; the tests above cannot see the difference, because in each of them
 		// one call site supplies the whole group.
-		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
-				"Is it safe to give Tozinameran (12y+)?",
-				DrugReferenceTestSupport.ctx(60, null,
-						DrugReferenceTestSupport.set("Tozinameran (5y-11y)"), null,
+		String question = "Is it safe to give Tozinameran (12y+)?";
+		String order = "Tozinameran (5y-11y)";
+		DrugReferenceService service = fixtureService(FIXTURE);
+		// The premise, through the production resolvers: without it the order arm could stop reaching a
+		// row of its own and this would pass on the question arm's collapse alone, testing nothing.
+		List<DrugReference> fromQuestion = service.findByQuery(question);
+		List<DrugReference> orderOnly = new ArrayList<DrugReference>(service.findByDrugName(order));
+		orderOnly.removeAll(fromQuestion);
+		assertEquals(1, orderOnly.size(),
+				"the order must resolve exactly one row no question word reaches, was: "
+						+ names(orderOnly));
+		assertEquals(orderOnly.get(0).substanceKey(), fromQuestion.get(0).substanceKey(),
+				"and it must be the same substance, or the two call sites share no key");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(service).validate("", question,
+				DrugReferenceTestSupport.ctx(60, null, DrugReferenceTestSupport.set(order), null,
 						DrugReferenceTestSupport.set("Tozinameran"), null));
 
 		assertEquals(1, warnings.size(),
@@ -366,10 +379,16 @@ public class ContraindicationRouteVariantTest {
 				"precondition: a curated entry publishes no substance name, so it keys on itself");
 		assertEquals(2, ibuprofen.getContraindications().size(),
 				"precondition: the fixture must really carry the rule twice");
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null, null, null,
+				DrugReferenceTestSupport.set("ibuprofen"), null);
+		for (DrugReference.Contraindication rule : ibuprofen.getContraindications()) {
+			assertTrue(context.hasAllergyToken(rule.getToken()),
+					"precondition: BOTH spellings must MATCH the recorded allergy, or the collapse is "
+							+ "not what makes this one chip — unmatched: " + rule.getToken());
+		}
 
-		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(service).validate("",
-				"Is ibuprofen safe for her?", DrugReferenceTestSupport.ctx(60, null, null, null,
-						DrugReferenceTestSupport.set("ibuprofen"), null));
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(service)
+				.validate("", "Is ibuprofen safe for her?", context);
 
 		assertEquals(2, warnings.size(),
 				"the rule collapses to one chip, and the identity chip beside it is issue #146's separate "

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -1,0 +1,243 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * One substance, one contraindication chip — however many rows the reference data files it as
+ * (issue #145).
+ *
+ * <p><b>The defect.</b> Both contraindication arms are keyed on a subject ENTRY, and DDInter files
+ * one substance as several route/formulation rows. One clinician-facing string resolves all of them
+ * ({@code findByQuery} and {@code findByDrugName} return every entry whose aliases match), so one
+ * clinical fact became one chip per row. Worse than duplication: only the row
+ * {@link DrugReferenceService#lookupByToken} resolves the allergy to matched by IDENTITY, so its
+ * siblings fell through to the class comparison and the patient was told a substance is
+ * cross-reactive with their allergy to <em>itself</em> — measured live on the 3.7.1 standalone, a
+ * dexamethasone allergy asked about dexamethasone gave 1 identity chip plus 3
+ * "Dexamethasone (nasal/ophthalmic/topical) is in the same ATC class (A01AC) as the patient's allergy
+ * to Dexamethasone" chips. Since issue #110 every chip is also injected as a citable pre-answer
+ * record, so each duplicate reached the prompt too.
+ *
+ * <p><b>What the grouping key has to get right</b>, and why {@code rxnorm_name} equality alone is not
+ * it. The reference data's own substance name (equivalently its {@code rxcui} — measured over the
+ * shipped 19 MB KB, the two partition the 2283 entries identically: 142 families, 332 entries) is
+ * what the route variants share, but it is also shared by pairs of genuinely DIFFERENT substances:
+ * {@code Omeprazole}/{@code Esomeprazole} (both {@code rxnorm_name=esomeprazole},
+ * {@code rxcui=283742}, both {@code A02BC05}), {@code Amphetamine}/{@code Dextroamphetamine},
+ * {@code Fenfluramine}/{@code Dexfenfluramine}, {@code Gabapentin}/{@code Gabapentin enacarbil},
+ * {@code Netupitant}/{@code Fosnetupitant}, {@code Ketoconazole}/{@code Levoketoconazole},
+ * {@code Fenofibrate}/{@code Fenofibric acid}, {@code Atropine}/{@code Hyoscyamine} — every one of
+ * them the {@code enalapril}/{@code enalaprilat} shape issue #121 decided must stay two chips. So the
+ * key is the substance name AND the display-name stem (the name with trailing parenthesized
+ * qualifiers removed): see {@link DrugReference#substanceKey()}, which records the measurement for
+ * both halves.
+ *
+ * <p>Both shapes are asserted here against slices taken verbatim from the shipped KB, through the
+ * real {@link DdiDrugReferenceSource} parser and the real {@link DrugSafetyValidator#validate}
+ * entry points.
+ */
+public class ContraindicationRouteVariantTest {
+
+	/**
+	 * Verbatim KB rows, in KB order: the two PPI entries the KB files under one substance name
+	 * ({@code Omeprazole} + {@code Esomeprazole}) with a third PPI to be allergic to
+	 * ({@code Pantoprazole}, {@code A02BC02}, so the shared level-4 subgroup is {@code A02BC}), and
+	 * the four {@code hydrocortisone} rows with {@code Dexamethasone} to be allergic to (both carry
+	 * {@code A01AC}). Its {@code interactions} array is empty, deliberately: this file asserts
+	 * contraindication chip COUNTS, and an interaction chip in the same list would have to be filtered
+	 * out of every assertion here.
+	 */
+	private static final String FIXTURE = "chartsearchai-test/ddi-contra-route-variants.json";
+
+	/** A question that resolves no reference drug and is not an interaction screen, so the only arm
+	 *  that can chip is the order-driven one ({@code addActiveOrderContraindications}). */
+	private static final String NO_DRUG_QUESTION = "What are her current medications?";
+
+	@Test
+	public void theFixturesReallyCarryTheTwoShapesUnderTest() throws IOException {
+		// Preconditions, through the production matchers the validator itself uses. Without these the
+		// cases below could pass while resolving one entry each — i.e. while testing nothing.
+		DrugReferenceService ppi = fixtureService(FIXTURE);
+		List<DrugReference> esomeprazole = ppi.findByQuery("Is it safe to give esomeprazole?");
+		assertEquals(2, esomeprazole.size(),
+				"one PPI word must resolve BOTH rows the KB files under it, was: " + names(esomeprazole));
+		assertEquals(esomeprazole.get(0).normalizedAtcCodes(), esomeprazole.get(1).normalizedAtcCodes(),
+				"and their ATC codes must be identical, so no class comparison can tell them apart");
+		assertFalse(esomeprazole.get(0).displayLabel().equals(esomeprazole.get(1).displayLabel()),
+				"while their labels differ — they are two substances, not two routes of one");
+
+		List<DrugReference> hydrocortisone = ppi.findByQuery("Is hydrocortisone safe for her?");
+		assertEquals(4, hydrocortisone.size(),
+				"one order word must resolve all four hydrocortisone rows, was: " + names(hydrocortisone));
+
+		DrugReferenceService variants = fixtureService(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS);
+		List<DrugReference> dexamethasone = variants.findByQuery("Is it safe to give dexamethasone?");
+		assertEquals(4, dexamethasone.size(),
+				"and one question word must resolve all four dexamethasone rows, was: "
+						+ names(dexamethasone));
+		DrugReference allergen = variants.lookupByToken("Dexamethasone");
+		assertNotNull(allergen, "the allergy must resolve to one of them");
+		assertEquals("Dexamethasone", allergen.displayLabel(),
+				"and it is the base row, so the identity chip is the one that must survive");
+	}
+
+	@Test
+	public void anAllergyToADrugFiledAsFourRouteVariantsRaisesOneChip() throws IOException {
+		// THE case, and Richard Jones's live shape: a recorded dexamethasone allergy, asked about
+		// dexamethasone. Four rows are in play; three of them are not the row the allergy resolved to,
+		// so before this fix they each reported the substance as cross-reactive with itself.
+		List<SafetyWarning> warnings = fixtureValidator(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS)
+				.validate("", "Is it safe to give dexamethasone?",
+						DrugReferenceTestSupport.ctx(60, null, null, null,
+								DrugReferenceTestSupport.set("Dexamethasone"), null));
+
+		assertEquals(1, warnings.size(),
+				"four route variants of one substance are one clinical fact, was: " + warnings);
+		assertEquals(SafetyWarning.TYPE_CONTRAINDICATION, warnings.get(0).getType());
+		assertEquals("Dexamethasone", warnings.get(0).getDrug());
+		assertEquals("The patient has a recorded allergy to Dexamethasone.", warnings.get(0).getDetail(),
+				"and the surviving chip is the IDENTITY one — the strongest statement about the "
+						+ "substance, not a sibling's cross-reactivity hedge");
+	}
+
+	@Test
+	public void noSurvivingChipReportsASubstanceAsCrossReactiveWithItself() throws IOException {
+		// The same call, asserted on content rather than on count: whatever the collapse keeps, nothing
+		// may say "X is in the same ATC class as the patient's allergy to X". A collapse that merely
+		// picked one of the four chips at random would satisfy the count above and fail this.
+		List<SafetyWarning> warnings = fixtureValidator(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS)
+				.validate("", "Is it safe to give dexamethasone?",
+						DrugReferenceTestSupport.ctx(60, null, null, null,
+								DrugReferenceTestSupport.set("Dexamethasone"), null));
+
+		for (SafetyWarning warning : warnings) {
+			assertFalse(warning.getDetail().contains("same ATC class")
+					&& warning.getDetail().contains("allergy to Dexamethasone"),
+					"a dexamethasone row must not be reported as cross-reactive with the patient's "
+							+ "dexamethasone allergy: " + warning.getDetail());
+		}
+	}
+
+	@Test
+	public void routeVariantsOfOneActiveOrderRaiseOneChipPerSubstance() throws IOException {
+		// Sarah Taylor's live shape, on the ORDER-DRIVEN arm (issue #143's), which the question-driven
+		// arm's collapse cannot reach: the patient is on one hydrocortisone order and allergic to
+		// dexamethasone, and the question names no drug at all. Four rows resolve from that one order
+		// name and all four share subgroup A01AC with the allergen, so before this fix it was four
+		// chips.
+		//
+		// TWO chips, not one: `Hydrocortisone butyrate` is an ester whose display name is not the
+		// family stem plus a qualifier, so the key deliberately keeps it separate — the conservative
+		// direction, and the same refusal that keeps Omeprazole and Esomeprazole apart below.
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", NO_DRUG_QUESTION,
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Hydrocortisone Injection vial 100mg"), null,
+						DrugReferenceTestSupport.set("Dexamethasone"), null));
+
+		assertEquals(2, warnings.size(),
+				"three route variants collapse and the ester stays its own chip, was: " + warnings);
+		assertEquals("Hydrocortisone is in the same ATC class (A01AC) as the patient's allergy to"
+				+ " Dexamethasone — possible cross-reactivity", warnings.get(0).getDetail(),
+				"the surviving variant chip is the dataset's first row, named by displayLabel()");
+		assertEquals("Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy"
+				+ " to Dexamethasone — possible cross-reactivity", warnings.get(1).getDetail());
+	}
+
+	@Test
+	public void twoDistinctSubstancesTheKbFilesUnderOneSubstanceNameStayTwoChips() throws IOException {
+		// The must-NOT-collapse case, and the sharp edge of the whole key: Omeprazole and Esomeprazole
+		// carry the same rxnorm_name, the same RxCUI and the same single ATC code, so every key made of
+		// reference-data identity alone merges them — and they are two substances, exactly as
+		// enalapril and enalaprilat are (issue #121). One PPI word puts both in play, and a Pantoprazole
+		// allergy is class-related to both, so a merging key would drop one of two real chips.
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
+				"Is it safe to give esomeprazole?", DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Pantoprazole"), null));
+
+		assertEquals(2, warnings.size(),
+				"two distinct substances sharing one substance name keep their own chips, was: "
+						+ warnings);
+		assertEquals("Omeprazole is in the same ATC class (A02BC) as the patient's allergy to"
+				+ " Pantoprazole — possible cross-reactivity", warnings.get(0).getDetail());
+		assertEquals("Esomeprazole is in the same ATC class (A02BC) as the patient's allergy to"
+				+ " Pantoprazole — possible cross-reactivity", warnings.get(1).getDetail());
+	}
+
+	@Test
+	public void aPrescribedRouteVariantFamilyTheyAreAllergicToRaisesOneChip() throws IOException {
+		// Richard Jones exactly: the dexamethasone allergy AND a dexamethasone order, asked about
+		// dexamethasone. The four rows are in play, so the order-driven arm skips them all and the
+		// question-driven arm owns the finding — one chip, and the identity one. Both arms feeding one
+		// ledger is what makes this hold: a collapse living inside a single arm would still emit the
+		// order arm's chips beside the question arm's.
+		List<SafetyWarning> warnings = fixtureValidator(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS)
+				.validate("", "Is it safe to give dexamethasone?",
+						DrugReferenceTestSupport.ctx(60, null,
+								DrugReferenceTestSupport.set("Dexamethasone: 4.0 Milligram Oral Once daily"),
+								null, DrugReferenceTestSupport.set("Dexamethasone"), null));
+
+		assertEquals(1, warnings.size(), "one substance, one chip, whichever arm reaches it, was: "
+				+ warnings);
+		assertEquals("The patient has a recorded allergy to Dexamethasone.",
+				warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void eachCollapsedChipIsInjectedIntoThePromptExactlyOnce() throws IOException {
+		// The other half of a chip (issue #110): every chip is injected as a numbered, citable
+		// safety-finding record, so N duplicate chips were N near-identical records in the context
+		// window as well. Real injector wired to the real validator, so the record count follows the
+		// chips rather than being asserted separately.
+		DrugReferenceService service = fixtureService(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS);
+		DrugReferenceInjector injector = DrugReferenceTestSupport.injector(service);
+		injector.setDrugSafetyValidator(DrugReferenceTestSupport.validator(service));
+
+		List<?> findings = DrugReferenceTestSupport.injectedFindings(injector.injectRecords(
+				DrugReferenceTestSupport.oneRecordChart(),
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Dexamethasone"), null),
+				"Is it safe to give dexamethasone?"));
+
+		assertEquals(1, findings.size(),
+				"one chip is one citable record, not one per route variant, was: " + findings);
+	}
+
+	private static List<String> names(List<DrugReference> entries) {
+		List<String> out = new ArrayList<String>();
+		for (DrugReference entry : entries) {
+			out.add(entry.getName());
+		}
+		return out;
+	}
+
+	/** The real fixture entries behind a service carrying the real curated cross-reactivity groups —
+	 *  so the class comparisons run against the shipped curated data, not against groups a test
+	 *  pinned empty. */
+	private static DrugReferenceService fixtureService(String fixture) throws IOException {
+		DrugReferenceService service = DrugReferenceTestSupport
+				.serviceWith(DrugReferenceTestSupport.ddiFixtureEntries(fixture));
+		service.setCrossReactivityGroups(DrugReferenceTestSupport.bundledGroups());
+		return service;
+	}
+
+	private static DrugSafetyValidator fixtureValidator(String fixture) throws IOException {
+		return DrugReferenceTestSupport.validator(fixtureService(fixture));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -87,10 +87,11 @@ public class ContraindicationRouteVariantTest {
 	public void theFixturesReallyCarryTheTwoShapesUnderTest() throws IOException {
 		// Preconditions, through the production matchers the validator itself uses. Without these the
 		// cases below could pass while resolving one entry each — i.e. while testing nothing.
-		DrugReferenceService ppi = fixtureService(FIXTURE);
+		DrugReferenceService ppi = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
 		List<DrugReference> esomeprazole = ppi.findByQuery("Is it safe to give esomeprazole?");
 		assertEquals(2, esomeprazole.size(),
-				"one PPI word must resolve BOTH rows the KB files under it, was: " + names(esomeprazole));
+				"one PPI word must resolve BOTH rows the KB files under it, was: "
+						+ DrugReferenceTestSupport.names(esomeprazole));
 		assertEquals(esomeprazole.get(0).normalizedAtcCodes(), esomeprazole.get(1).normalizedAtcCodes(),
 				"and their ATC codes must be identical, so no class comparison can tell them apart");
 		assertFalse(esomeprazole.get(0).displayLabel().equals(esomeprazole.get(1).displayLabel()),
@@ -98,13 +99,15 @@ public class ContraindicationRouteVariantTest {
 
 		List<DrugReference> hydrocortisone = ppi.findByQuery("Is hydrocortisone safe for her?");
 		assertEquals(4, hydrocortisone.size(),
-				"one order word must resolve all four hydrocortisone rows, was: " + names(hydrocortisone));
+				"one order word must resolve all four hydrocortisone rows, was: "
+						+ DrugReferenceTestSupport.names(hydrocortisone));
 
-		DrugReferenceService variants = fixtureService(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS);
+		DrugReferenceService variants = DrugReferenceTestSupport
+				.ddiFixtureService(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS);
 		List<DrugReference> dexamethasone = variants.findByQuery("Is it safe to give dexamethasone?");
 		assertEquals(4, dexamethasone.size(),
 				"and one question word must resolve all four dexamethasone rows, was: "
-						+ names(dexamethasone));
+						+ DrugReferenceTestSupport.names(dexamethasone));
 		DrugReference allergen = variants.lookupByToken("Dexamethasone");
 		assertNotNull(allergen, "the allergy must resolve to one of them");
 		assertEquals("Dexamethasone", allergen.displayLabel(),
@@ -182,9 +185,10 @@ public class ContraindicationRouteVariantTest {
 	 */
 	@Test
 	public void theTwoPpiRowsShareTheSubstanceNameTheStemHasToVeto() throws IOException {
-		List<DrugReference> ppis = fixtureService(FIXTURE).findByQuery("Is it safe to give esomeprazole?");
+		List<DrugReference> ppis = DrugReferenceTestSupport.ddiFixtureService(FIXTURE)
+				.findByQuery("Is it safe to give esomeprazole?");
 
-		assertEquals(2, ppis.size(), "was: " + names(ppis));
+		assertEquals(2, ppis.size(), "was: " + DrugReferenceTestSupport.names(ppis));
 		assertEquals(DrugReference.normalizeName(ppis.get(0).getSubstanceName()),
 				DrugReference.normalizeName(ppis.get(1).getSubstanceName()),
 				"the two rows must share ONE substance name, or the stem is not what keeps them apart");
@@ -239,12 +243,13 @@ public class ContraindicationRouteVariantTest {
 	 */
 	@Test
 	public void theFixtureReallyCarriesAnAllergenRowThatIsNotItsGroupsFirst() throws IOException {
-		DrugReferenceService service = fixtureService(FIXTURE);
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
 
 		List<DrugReference> inPlay = service
 				.findByQuery("Is it safe to give the Pfizer-BioNTech COVID-19 vaccine?");
 		assertEquals(5, inPlay.size(),
-				"one brand word must resolve every presentation row, was: " + names(inPlay));
+				"one brand word must resolve every presentation row, was: "
+						+ DrugReferenceTestSupport.names(inPlay));
 		assertEquals("Tozinameran (12y+)", inPlay.get(0).getName(),
 				"and a presentation comes FIRST, so it is the group's incumbent chip");
 
@@ -283,7 +288,7 @@ public class ContraindicationRouteVariantTest {
 	}
 
 	@Test
-	public void oneLedgerSpansBothCallSitesRatherThanOnePerArm() throws IOException {
+	public void oneLedgerSpansBothCallSites() throws IOException {
 		// The decisive reason this is a ledger and not a filter: the two arms run at TWO call sites, so a
 		// collapse living inside either one leaves the other emitting the siblings. Here both call sites
 		// raise a candidate for the SAME (substance, allergen) key and neither is redundant with the
@@ -293,7 +298,7 @@ public class ContraindicationRouteVariantTest {
 		// one call site supplies the whole group.
 		String question = "Is it safe to give Tozinameran (12y+)?";
 		String order = "Tozinameran (5y-11y)";
-		DrugReferenceService service = fixtureService(FIXTURE);
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
 		// The premise, through the production resolvers: without it the order arm could stop reaching a
 		// row of its own and this would pass on the question arm's collapse alone, testing nothing.
 		List<DrugReference> fromQuestion = service.findByQuery(question);
@@ -301,7 +306,7 @@ public class ContraindicationRouteVariantTest {
 		orderOnly.removeAll(fromQuestion);
 		assertEquals(1, orderOnly.size(),
 				"the order must resolve exactly one row no question word reaches, was: "
-						+ names(orderOnly));
+						+ DrugReferenceTestSupport.names(orderOnly));
 		assertEquals(orderOnly.get(0).substanceKey(), fromQuestion.get(0).substanceKey(),
 				"and it must be the same substance, or the two call sites share no key");
 
@@ -345,7 +350,8 @@ public class ContraindicationRouteVariantTest {
 		// safety-finding record, so N duplicate chips were N near-identical records in the context
 		// window as well. Real injector wired to the real validator, so the record count follows the
 		// chips rather than being asserted separately.
-		DrugReferenceService service = fixtureService(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS);
+		DrugReferenceService service = DrugReferenceTestSupport
+				.ddiFixtureService(DrugReferenceTestSupport.DDI_ROUTE_VARIANTS);
 		DrugReferenceInjector injector = DrugReferenceTestSupport.injector(service);
 		injector.setDrugSafetyValidator(DrugReferenceTestSupport.validator(service));
 
@@ -406,25 +412,8 @@ public class ContraindicationRouteVariantTest {
 				"so the re-spelling's own note is the one dropped, was: " + warnings);
 	}
 
-	private static List<String> names(List<DrugReference> entries) {
-		List<String> out = new ArrayList<String>();
-		for (DrugReference entry : entries) {
-			out.add(entry.getName());
-		}
-		return out;
-	}
-
-	/** The real fixture entries behind a service carrying the real curated cross-reactivity groups —
-	 *  so the class comparisons run against the shipped curated data, not against groups a test
-	 *  pinned empty. */
-	private static DrugReferenceService fixtureService(String fixture) throws IOException {
-		DrugReferenceService service = DrugReferenceTestSupport
-				.serviceWith(DrugReferenceTestSupport.ddiFixtureEntries(fixture));
-		service.setCrossReactivityGroups(DrugReferenceTestSupport.bundledGroups());
-		return service;
-	}
 
 	private static DrugSafetyValidator fixtureValidator(String fixture) throws IOException {
-		return DrugReferenceTestSupport.validator(fixtureService(fixture));
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.ddiFixtureService(fixture));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -49,8 +49,9 @@ import org.junit.jupiter.api.Test;
  * qualifiers removed): see {@link DrugReference#substanceKey()}, which records the measurement for
  * both halves.
  *
- * <p>Both shapes are asserted here against slices taken verbatim from the shipped KB, through the
- * real {@link DdiDrugReferenceSource} parser and the real {@link DrugSafetyValidator#validate}
+ * <p>Both directions are asserted here — and so is the ordering the collapse cannot assume, a group
+ * whose allergen row is not its first — against slices taken verbatim from the shipped KB, through
+ * the real {@link DdiDrugReferenceSource} parser and the real {@link DrugSafetyValidator#validate}
  * entry points.
  */
 public class ContraindicationRouteVariantTest {
@@ -197,6 +198,79 @@ public class ContraindicationRouteVariantTest {
 				+ warnings);
 		assertEquals("The patient has a recorded allergy to Dexamethasone.",
 				warnings.get(0).getDetail());
+	}
+
+	/**
+	 * The premise that makes the case below what it is, asserted through the production resolvers so it
+	 * cannot rot into a test of nothing: a question naming the vaccine resolves all five presentation
+	 * rows, while an allergy to {@code Tozinameran} resolves the FOURTH of them — so the identity match
+	 * arrives after three class matches rather than before them, unlike the dexamethasone shape above.
+	 */
+	@Test
+	public void theFixtureReallyCarriesAnAllergenRowThatIsNotItsGroupsFirst() throws IOException {
+		DrugReferenceService service = fixtureService(FIXTURE);
+
+		List<DrugReference> inPlay = service
+				.findByQuery("Is it safe to give the Pfizer-BioNTech COVID-19 vaccine?");
+		assertEquals(5, inPlay.size(),
+				"one brand word must resolve every presentation row, was: " + names(inPlay));
+		assertEquals("Tozinameran (12y+)", inPlay.get(0).getName(),
+				"and a presentation comes FIRST, so it is the group's incumbent chip");
+
+		DrugReference allergen = service.lookupByToken("Tozinameran");
+		assertNotNull(allergen, "the allergy must resolve to one of the rows");
+		assertEquals(inPlay.get(3), allergen,
+				"and the allergen is the FOURTH: this KB gives each presentation row only its own "
+						+ "qualified name, so the bare substance name skips them — was: "
+						+ (allergen == null ? "null" : allergen.getName()));
+		assertEquals(allergen.substanceKey(), inPlay.get(0).substanceKey(),
+				"while all of them are still one substance to the collapse");
+	}
+
+	@Test
+	public void theIdentityChipSurvivesWhenTheAllergenRowIsNotItsGroupsFirst() throws IOException {
+		// The collapse must keep the most specific relationship even when the weaker candidate is raised
+		// FIRST — an incumbent chip has to be REPLACED, not merely suppressed. Reachable on the shipped
+		// KB, not a hypothetical: measured through this same entry point over the full 19 MB dataset, 10
+		// of its 121 collapsed groups contain a row whose own name resolves an allergy to a LATER member
+		// of the group (`Tozinameran`, `Insulin aspart (aspart)`, `Iobenguane (I-131)`, …). A first-wins
+		// ledger answers this case with "Tozinameran (12y+) … is in the same ATC class (J07BN) as the
+		// patient's allergy to Tozinameran" — the vacuous self-cross-reactivity issue #145 exists to
+		// remove, kept instead of removed.
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
+				"Is it safe to give the Pfizer-BioNTech COVID-19 vaccine?",
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Tozinameran"), null));
+
+		assertEquals(1, warnings.size(),
+				"five presentations of one vaccine are one clinical fact, was: " + warnings);
+		assertEquals("The patient has a recorded allergy to Tozinameran (sars-cov-2 (covid-19) vaccine,"
+				+ " mrna spike protein).", warnings.get(0).getDetail(),
+				"and the IDENTITY chip is the survivor, replacing the class chip an earlier row had "
+						+ "already raised — not the other way round");
+	}
+
+	@Test
+	public void oneSubstanceStillReportsEveryRecordedFindingSeparately() throws IOException {
+		// The other half of the key: the RECORDED FINDING is in it, so the collapse is per (substance,
+		// finding) and never per substance. Two allergies about one substance are two clinical facts and
+		// must stay two chips — a collapse keyed on the subject alone would answer this with one, dropping
+		// the identity statement or the cross-reactivity one depending on which arrived first.
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
+				"Is hydrocortisone safe for her?", DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Dexamethasone", "Hydrocortisone"), null));
+
+		assertEquals(4, warnings.size(), "two substances x two findings, was: " + warnings);
+		assertEquals("Hydrocortisone is in the same ATC class (A01AC) as the patient's allergy to"
+				+ " Dexamethasone — possible cross-reactivity", warnings.get(0).getDetail());
+		assertEquals("The patient has a recorded allergy to Hydrocortisone.",
+				warnings.get(1).getDetail(),
+				"the identity finding about the SAME substance keeps its own chip beside the "
+						+ "cross-reactivity one");
+		assertEquals("Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy"
+				+ " to Dexamethasone — possible cross-reactivity", warnings.get(2).getDetail());
+		assertEquals("Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy"
+				+ " to Hydrocortisone — possible cross-reactivity", warnings.get(3).getDetail());
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceTestSupport.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceTestSupport.java
@@ -284,6 +284,29 @@ public final class DrugReferenceTestSupport {
 		}
 	}
 
+	/**
+	 * A service over a DDInter-shaped test fixture, carrying the real curated cross-reactivity groups —
+	 * so the class comparisons run against the shipped curated data rather than groups a test pinned
+	 * empty. The arrangement lives here rather than in each test file because the two steps have to stay
+	 * together: {@link #serviceWith} pins the groups EMPTY through its {@code setEntries} seam, so a
+	 * fixture service built without the second call silently cannot raise a curated-group chip.
+	 */
+	static DrugReferenceService ddiFixtureService(String classpathResource) throws IOException {
+		DrugReferenceService service = serviceWith(ddiFixtureEntries(classpathResource));
+		service.setCrossReactivityGroups(bundledGroups());
+		return service;
+	}
+
+	/** @return the entries' own {@code name}s. {@link DrugReference} defines no {@code toString}, so a
+	 *          failure message built from the list itself prints identity hashes. */
+	static List<String> names(List<DrugReference> entries) {
+		List<String> out = new ArrayList<String>();
+		for (DrugReference entry : entries) {
+			out.add(entry.getName());
+		}
+		return out;
+	}
+
 	static DrugSafetyValidator validator(DrugReferenceService service) {
 		DrugSafetyValidator validator = new DrugSafetyValidator();
 		validator.setDrugReferenceService(service);

--- a/api/src/test/resources/chartsearchai-test/ddi-contra-route-variants.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-contra-route-variants.json
@@ -1,0 +1,1261 @@
+{
+  "version": null,
+  "source": null,
+  "drugs": [
+    {
+      "id": "DDInter1340",
+      "name": "Omeprazole",
+      "rxcui": "283742",
+      "rxnorm_name": "esomeprazole",
+      "drugbank_id": "DB00338",
+      "atc": [
+        "A02BC05"
+      ],
+      "ciel": [
+        {
+          "code": "167977",
+          "uuid": "2d7b158c-5f97-449b-b0e9-46f75c82a42f",
+          "name": "Amoxicillin / Esomeprazole / Levofloxacin combination kit"
+        },
+        {
+          "code": "167978",
+          "uuid": "cb933181-fd92-4725-91d5-2e851c9eb0b5",
+          "name": "Clarithromycin / Esomeprazole / Levofloxacin combination kit"
+        },
+        {
+          "code": "167995",
+          "uuid": "a78c9f7d-87b8-4216-9153-53e14e5911aa",
+          "name": "Amoxicillin / clarithromycin / esomeprazole combination kit"
+        },
+        {
+          "code": "75875",
+          "uuid": "75875AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Esomeprazole"
+        },
+        {
+          "code": "75876",
+          "uuid": "75876AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Esomeprazole magnesium"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1388",
+      "name": "Pantoprazole",
+      "rxcui": "40790",
+      "rxnorm_name": "pantoprazole",
+      "drugbank_id": "DB00213",
+      "atc": [
+        "A02BC02"
+      ],
+      "ciel": [
+        {
+          "code": "81550",
+          "uuid": "81550AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pantoprazole"
+        },
+        {
+          "code": "81551",
+          "uuid": "81551AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pantoprazole (as pantoprazole sodium sesquihydrate)"
+        }
+      ]
+    },
+    {
+      "id": "DDInter513",
+      "name": "Dexamethasone",
+      "rxcui": "3264",
+      "rxnorm_name": "dexamethasone",
+      "drugbank_id": "DB01234",
+      "atc": [
+        "A01AC02",
+        "C05AA09",
+        "D07AB19",
+        "D07XB05",
+        "D10AA03",
+        "H02AB02",
+        "R01AD03",
+        "S01BA01",
+        "S01CB01",
+        "S02BA06",
+        "S03BA01"
+      ],
+      "ciel": [
+        {
+          "code": "104317",
+          "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / dexamethasone"
+        },
+        {
+          "code": "104422",
+          "uuid": "104422AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / hypromellose"
+        },
+        {
+          "code": "104423",
+          "uuid": "104423AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / lidocaine"
+        },
+        {
+          "code": "104424",
+          "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / neomycin"
+        },
+        {
+          "code": "104425",
+          "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / neomycin / polymyxin B"
+        },
+        {
+          "code": "104426",
+          "uuid": "104426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / tobramycin"
+        },
+        {
+          "code": "104427",
+          "uuid": "104427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone / tramazoline"
+        },
+        {
+          "code": "168548",
+          "uuid": "f5c7c86c-2b95-42d4-95f2-6d9e8949f39e",
+          "name": "Dexamethasone / gentamicin"
+        },
+        {
+          "code": "170697",
+          "uuid": "d2a620d9-138d-4125-a84a-7ddbf3b2ee45",
+          "name": "Dexamethasone / framycetin"
+        },
+        {
+          "code": "74609",
+          "uuid": "74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone"
+        },
+        {
+          "code": "74610",
+          "uuid": "74610AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone acetate"
+        },
+        {
+          "code": "74612",
+          "uuid": "74612AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone isonicotinate"
+        },
+        {
+          "code": "74613",
+          "uuid": "74613AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone phosphate"
+        },
+        {
+          "code": "74614",
+          "uuid": "74614AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone sodium phosphate"
+        },
+        {
+          "code": "74615",
+          "uuid": "74615AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dexamethasone trimethyl acetate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter676",
+      "name": "Esomeprazole",
+      "rxcui": "283742",
+      "rxnorm_name": "esomeprazole",
+      "drugbank_id": "DB00736",
+      "atc": [
+        "A02BC05"
+      ],
+      "ciel": [
+        {
+          "code": "167977",
+          "uuid": "2d7b158c-5f97-449b-b0e9-46f75c82a42f",
+          "name": "Amoxicillin / Esomeprazole / Levofloxacin combination kit"
+        },
+        {
+          "code": "167978",
+          "uuid": "cb933181-fd92-4725-91d5-2e851c9eb0b5",
+          "name": "Clarithromycin / Esomeprazole / Levofloxacin combination kit"
+        },
+        {
+          "code": "167995",
+          "uuid": "a78c9f7d-87b8-4216-9153-53e14e5911aa",
+          "name": "Amoxicillin / clarithromycin / esomeprazole combination kit"
+        },
+        {
+          "code": "75875",
+          "uuid": "75875AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Esomeprazole"
+        },
+        {
+          "code": "75876",
+          "uuid": "75876AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Esomeprazole magnesium"
+        }
+      ]
+    },
+    {
+      "id": "DDInter885",
+      "name": "Hydrocortisone",
+      "rxcui": "5492",
+      "rxnorm_name": "hydrocortisone",
+      "drugbank_id": "DB00741",
+      "atc": [
+        "A01AC03",
+        "A07EA02",
+        "C05AA01",
+        "D07AA02",
+        "D07XA01",
+        "H02AB09",
+        "S01BA02",
+        "S01CB03",
+        "S02BA01"
+      ],
+      "ciel": [
+        {
+          "code": "103309",
+          "uuid": "103309AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acetic acid / hydrocortisone"
+        },
+        {
+          "code": "103596",
+          "uuid": "103596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Antipyrine / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103767",
+          "uuid": "103767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin"
+        },
+        {
+          "code": "103768",
+          "uuid": "103768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103818",
+          "uuid": "103818AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzalkonium / chloroxylenol / hydrocortisone"
+        },
+        {
+          "code": "103886",
+          "uuid": "103886AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzoyl peroxide / hydrocortisone"
+        },
+        {
+          "code": "104168",
+          "uuid": "104168AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone"
+        },
+        {
+          "code": "104169",
+          "uuid": "104169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104170",
+          "uuid": "104170AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorcyclizine / hydrocortisone"
+        },
+        {
+          "code": "104201",
+          "uuid": "104201AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloroxylenol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104244",
+          "uuid": "104244AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pheniramine / pyrilamine"
+        },
+        {
+          "code": "104245",
+          "uuid": "104245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pyrilamine"
+        },
+        {
+          "code": "104270",
+          "uuid": "104270AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorquinaldol / hydrocortisone"
+        },
+        {
+          "code": "104318",
+          "uuid": "104318AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / hydrocortisone"
+        },
+        {
+          "code": "104334",
+          "uuid": "104334AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / coal tar / hydrocortisone"
+        },
+        {
+          "code": "104337",
+          "uuid": "104337AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone"
+        },
+        {
+          "code": "104338",
+          "uuid": "104338AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104340",
+          "uuid": "104340AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clotrimazole / hydrocortisone"
+        },
+        {
+          "code": "104388",
+          "uuid": "104388AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Colistin / hydrocortisone / neomycin / thonzonium"
+        },
+        {
+          "code": "104396",
+          "uuid": "104396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Crotamiton / hydrocortisone"
+        },
+        {
+          "code": "104481",
+          "uuid": "104481AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dibucaine / hydrocortisone"
+        },
+        {
+          "code": "104509",
+          "uuid": "104509AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diperodon / hydrocortisone / zinc oxide"
+        },
+        {
+          "code": "104512",
+          "uuid": "104512AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diphenhydramine / hydrocortisone"
+        },
+        {
+          "code": "104563",
+          "uuid": "104563AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Econazole / hydrocortisone"
+        },
+        {
+          "code": "104696",
+          "uuid": "104696AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Fusidate / hydrocortisone"
+        },
+        {
+          "code": "104706",
+          "uuid": "104706AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Gentamicin sulfate (usp) / hydrocortisone"
+        },
+        {
+          "code": "104819",
+          "uuid": "104819AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hexachlorophene / hydrocortisone / menthol"
+        },
+        {
+          "code": "104857",
+          "uuid": "104857AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / iodoquinol"
+        },
+        {
+          "code": "104859",
+          "uuid": "104859AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / lidocaine"
+        },
+        {
+          "code": "104860",
+          "uuid": "104860AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / miconazole"
+        },
+        {
+          "code": "104861",
+          "uuid": "104861AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin"
+        },
+        {
+          "code": "104862",
+          "uuid": "104862AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "104863",
+          "uuid": "104863AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / oxytetracycline"
+        },
+        {
+          "code": "104864",
+          "uuid": "104864AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104865",
+          "uuid": "104865AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104866",
+          "uuid": "104866AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sodium thiosulfate"
+        },
+        {
+          "code": "104867",
+          "uuid": "104867AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sulfur"
+        },
+        {
+          "code": "104868",
+          "uuid": "104868AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / sulfur / zinc oxide"
+        },
+        {
+          "code": "165454",
+          "uuid": "165454AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Aluminium subacetate / hydrocortisone acetate / lidocaine / zinc oxide"
+        },
+        {
+          "code": "73950",
+          "uuid": "73950AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cortisol succinate"
+        },
+        {
+          "code": "77714",
+          "uuid": "77714AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone"
+        },
+        {
+          "code": "77716",
+          "uuid": "77716AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone 17-butyrate 21-propionate"
+        },
+        {
+          "code": "77718",
+          "uuid": "77718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone aceponate"
+        },
+        {
+          "code": "77719",
+          "uuid": "77719AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone acetate"
+        },
+        {
+          "code": "77720",
+          "uuid": "77720AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone butyrate"
+        },
+        {
+          "code": "77721",
+          "uuid": "77721AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone cypionate"
+        },
+        {
+          "code": "77724",
+          "uuid": "77724AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium phosphate"
+        },
+        {
+          "code": "77725",
+          "uuid": "77725AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium succinate"
+        },
+        {
+          "code": "77726",
+          "uuid": "77726AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone valerate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter886",
+      "name": "Hydrocortisone (ophthalmic)",
+      "rxcui": "5492",
+      "rxnorm_name": "hydrocortisone",
+      "drugbank_id": "DB00741",
+      "atc": [
+        "A01AC03",
+        "A07EA02",
+        "C05AA01",
+        "D07AA02",
+        "D07XA01",
+        "H02AB09",
+        "S01BA02",
+        "S01CB03",
+        "S02BA01"
+      ],
+      "ciel": [
+        {
+          "code": "103309",
+          "uuid": "103309AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acetic acid / hydrocortisone"
+        },
+        {
+          "code": "103596",
+          "uuid": "103596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Antipyrine / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103767",
+          "uuid": "103767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin"
+        },
+        {
+          "code": "103768",
+          "uuid": "103768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103818",
+          "uuid": "103818AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzalkonium / chloroxylenol / hydrocortisone"
+        },
+        {
+          "code": "103886",
+          "uuid": "103886AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzoyl peroxide / hydrocortisone"
+        },
+        {
+          "code": "104168",
+          "uuid": "104168AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone"
+        },
+        {
+          "code": "104169",
+          "uuid": "104169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104170",
+          "uuid": "104170AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorcyclizine / hydrocortisone"
+        },
+        {
+          "code": "104201",
+          "uuid": "104201AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloroxylenol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104244",
+          "uuid": "104244AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pheniramine / pyrilamine"
+        },
+        {
+          "code": "104245",
+          "uuid": "104245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pyrilamine"
+        },
+        {
+          "code": "104270",
+          "uuid": "104270AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorquinaldol / hydrocortisone"
+        },
+        {
+          "code": "104318",
+          "uuid": "104318AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / hydrocortisone"
+        },
+        {
+          "code": "104334",
+          "uuid": "104334AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / coal tar / hydrocortisone"
+        },
+        {
+          "code": "104337",
+          "uuid": "104337AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone"
+        },
+        {
+          "code": "104338",
+          "uuid": "104338AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104340",
+          "uuid": "104340AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clotrimazole / hydrocortisone"
+        },
+        {
+          "code": "104388",
+          "uuid": "104388AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Colistin / hydrocortisone / neomycin / thonzonium"
+        },
+        {
+          "code": "104396",
+          "uuid": "104396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Crotamiton / hydrocortisone"
+        },
+        {
+          "code": "104481",
+          "uuid": "104481AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dibucaine / hydrocortisone"
+        },
+        {
+          "code": "104509",
+          "uuid": "104509AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diperodon / hydrocortisone / zinc oxide"
+        },
+        {
+          "code": "104512",
+          "uuid": "104512AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diphenhydramine / hydrocortisone"
+        },
+        {
+          "code": "104563",
+          "uuid": "104563AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Econazole / hydrocortisone"
+        },
+        {
+          "code": "104696",
+          "uuid": "104696AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Fusidate / hydrocortisone"
+        },
+        {
+          "code": "104706",
+          "uuid": "104706AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Gentamicin sulfate (usp) / hydrocortisone"
+        },
+        {
+          "code": "104819",
+          "uuid": "104819AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hexachlorophene / hydrocortisone / menthol"
+        },
+        {
+          "code": "104857",
+          "uuid": "104857AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / iodoquinol"
+        },
+        {
+          "code": "104859",
+          "uuid": "104859AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / lidocaine"
+        },
+        {
+          "code": "104860",
+          "uuid": "104860AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / miconazole"
+        },
+        {
+          "code": "104861",
+          "uuid": "104861AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin"
+        },
+        {
+          "code": "104862",
+          "uuid": "104862AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "104863",
+          "uuid": "104863AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / oxytetracycline"
+        },
+        {
+          "code": "104864",
+          "uuid": "104864AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104865",
+          "uuid": "104865AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104866",
+          "uuid": "104866AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sodium thiosulfate"
+        },
+        {
+          "code": "104867",
+          "uuid": "104867AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sulfur"
+        },
+        {
+          "code": "104868",
+          "uuid": "104868AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / sulfur / zinc oxide"
+        },
+        {
+          "code": "165454",
+          "uuid": "165454AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Aluminium subacetate / hydrocortisone acetate / lidocaine / zinc oxide"
+        },
+        {
+          "code": "73950",
+          "uuid": "73950AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cortisol succinate"
+        },
+        {
+          "code": "77714",
+          "uuid": "77714AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone"
+        },
+        {
+          "code": "77716",
+          "uuid": "77716AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone 17-butyrate 21-propionate"
+        },
+        {
+          "code": "77718",
+          "uuid": "77718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone aceponate"
+        },
+        {
+          "code": "77719",
+          "uuid": "77719AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone acetate"
+        },
+        {
+          "code": "77720",
+          "uuid": "77720AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone butyrate"
+        },
+        {
+          "code": "77721",
+          "uuid": "77721AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone cypionate"
+        },
+        {
+          "code": "77724",
+          "uuid": "77724AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium phosphate"
+        },
+        {
+          "code": "77725",
+          "uuid": "77725AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium succinate"
+        },
+        {
+          "code": "77726",
+          "uuid": "77726AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone valerate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter887",
+      "name": "Hydrocortisone (topical)",
+      "rxcui": "5492",
+      "rxnorm_name": "hydrocortisone",
+      "drugbank_id": "DB00741",
+      "atc": [
+        "A01AC03",
+        "A07EA02",
+        "C05AA01",
+        "D07AA02",
+        "D07XA01",
+        "H02AB09",
+        "S01BA02",
+        "S01CB03",
+        "S02BA01"
+      ],
+      "ciel": [
+        {
+          "code": "103309",
+          "uuid": "103309AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acetic acid / hydrocortisone"
+        },
+        {
+          "code": "103596",
+          "uuid": "103596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Antipyrine / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103767",
+          "uuid": "103767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin"
+        },
+        {
+          "code": "103768",
+          "uuid": "103768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103818",
+          "uuid": "103818AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzalkonium / chloroxylenol / hydrocortisone"
+        },
+        {
+          "code": "103886",
+          "uuid": "103886AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzoyl peroxide / hydrocortisone"
+        },
+        {
+          "code": "104168",
+          "uuid": "104168AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone"
+        },
+        {
+          "code": "104169",
+          "uuid": "104169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104170",
+          "uuid": "104170AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorcyclizine / hydrocortisone"
+        },
+        {
+          "code": "104201",
+          "uuid": "104201AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloroxylenol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104244",
+          "uuid": "104244AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pheniramine / pyrilamine"
+        },
+        {
+          "code": "104245",
+          "uuid": "104245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pyrilamine"
+        },
+        {
+          "code": "104270",
+          "uuid": "104270AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorquinaldol / hydrocortisone"
+        },
+        {
+          "code": "104318",
+          "uuid": "104318AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / hydrocortisone"
+        },
+        {
+          "code": "104334",
+          "uuid": "104334AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / coal tar / hydrocortisone"
+        },
+        {
+          "code": "104337",
+          "uuid": "104337AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone"
+        },
+        {
+          "code": "104338",
+          "uuid": "104338AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104340",
+          "uuid": "104340AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clotrimazole / hydrocortisone"
+        },
+        {
+          "code": "104388",
+          "uuid": "104388AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Colistin / hydrocortisone / neomycin / thonzonium"
+        },
+        {
+          "code": "104396",
+          "uuid": "104396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Crotamiton / hydrocortisone"
+        },
+        {
+          "code": "104481",
+          "uuid": "104481AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dibucaine / hydrocortisone"
+        },
+        {
+          "code": "104509",
+          "uuid": "104509AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diperodon / hydrocortisone / zinc oxide"
+        },
+        {
+          "code": "104512",
+          "uuid": "104512AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diphenhydramine / hydrocortisone"
+        },
+        {
+          "code": "104563",
+          "uuid": "104563AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Econazole / hydrocortisone"
+        },
+        {
+          "code": "104696",
+          "uuid": "104696AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Fusidate / hydrocortisone"
+        },
+        {
+          "code": "104706",
+          "uuid": "104706AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Gentamicin sulfate (usp) / hydrocortisone"
+        },
+        {
+          "code": "104819",
+          "uuid": "104819AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hexachlorophene / hydrocortisone / menthol"
+        },
+        {
+          "code": "104857",
+          "uuid": "104857AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / iodoquinol"
+        },
+        {
+          "code": "104859",
+          "uuid": "104859AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / lidocaine"
+        },
+        {
+          "code": "104860",
+          "uuid": "104860AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / miconazole"
+        },
+        {
+          "code": "104861",
+          "uuid": "104861AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin"
+        },
+        {
+          "code": "104862",
+          "uuid": "104862AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "104863",
+          "uuid": "104863AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / oxytetracycline"
+        },
+        {
+          "code": "104864",
+          "uuid": "104864AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104865",
+          "uuid": "104865AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104866",
+          "uuid": "104866AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sodium thiosulfate"
+        },
+        {
+          "code": "104867",
+          "uuid": "104867AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sulfur"
+        },
+        {
+          "code": "104868",
+          "uuid": "104868AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / sulfur / zinc oxide"
+        },
+        {
+          "code": "165454",
+          "uuid": "165454AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Aluminium subacetate / hydrocortisone acetate / lidocaine / zinc oxide"
+        },
+        {
+          "code": "73950",
+          "uuid": "73950AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cortisol succinate"
+        },
+        {
+          "code": "77714",
+          "uuid": "77714AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone"
+        },
+        {
+          "code": "77716",
+          "uuid": "77716AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone 17-butyrate 21-propionate"
+        },
+        {
+          "code": "77718",
+          "uuid": "77718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone aceponate"
+        },
+        {
+          "code": "77719",
+          "uuid": "77719AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone acetate"
+        },
+        {
+          "code": "77720",
+          "uuid": "77720AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone butyrate"
+        },
+        {
+          "code": "77721",
+          "uuid": "77721AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone cypionate"
+        },
+        {
+          "code": "77724",
+          "uuid": "77724AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium phosphate"
+        },
+        {
+          "code": "77725",
+          "uuid": "77725AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium succinate"
+        },
+        {
+          "code": "77726",
+          "uuid": "77726AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone valerate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter888",
+      "name": "Hydrocortisone butyrate",
+      "rxcui": "5492",
+      "rxnorm_name": "hydrocortisone",
+      "drugbank_id": "DB14540",
+      "atc": [
+        "A01AC03",
+        "A07EA02",
+        "C05AA01",
+        "D07AA02",
+        "D07XA01",
+        "H02AB09",
+        "S01BA02",
+        "S01CB03",
+        "S02BA01"
+      ],
+      "ciel": [
+        {
+          "code": "103309",
+          "uuid": "103309AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Acetic acid / hydrocortisone"
+        },
+        {
+          "code": "103596",
+          "uuid": "103596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Antipyrine / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103767",
+          "uuid": "103767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin"
+        },
+        {
+          "code": "103768",
+          "uuid": "103768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Bacitracin / hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "103818",
+          "uuid": "103818AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzalkonium / chloroxylenol / hydrocortisone"
+        },
+        {
+          "code": "103886",
+          "uuid": "103886AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Benzoyl peroxide / hydrocortisone"
+        },
+        {
+          "code": "104168",
+          "uuid": "104168AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone"
+        },
+        {
+          "code": "104169",
+          "uuid": "104169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloramphenicol / hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104170",
+          "uuid": "104170AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorcyclizine / hydrocortisone"
+        },
+        {
+          "code": "104201",
+          "uuid": "104201AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chloroxylenol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104244",
+          "uuid": "104244AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pheniramine / pyrilamine"
+        },
+        {
+          "code": "104245",
+          "uuid": "104245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorpheniramine / hydrocortisone / pyrilamine"
+        },
+        {
+          "code": "104270",
+          "uuid": "104270AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Chlorquinaldol / hydrocortisone"
+        },
+        {
+          "code": "104318",
+          "uuid": "104318AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ciprofloxacin / hydrocortisone"
+        },
+        {
+          "code": "104334",
+          "uuid": "104334AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / coal tar / hydrocortisone"
+        },
+        {
+          "code": "104337",
+          "uuid": "104337AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone"
+        },
+        {
+          "code": "104338",
+          "uuid": "104338AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clioquinol / hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104340",
+          "uuid": "104340AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Clotrimazole / hydrocortisone"
+        },
+        {
+          "code": "104388",
+          "uuid": "104388AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Colistin / hydrocortisone / neomycin / thonzonium"
+        },
+        {
+          "code": "104396",
+          "uuid": "104396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Crotamiton / hydrocortisone"
+        },
+        {
+          "code": "104481",
+          "uuid": "104481AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Dibucaine / hydrocortisone"
+        },
+        {
+          "code": "104509",
+          "uuid": "104509AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diperodon / hydrocortisone / zinc oxide"
+        },
+        {
+          "code": "104512",
+          "uuid": "104512AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Diphenhydramine / hydrocortisone"
+        },
+        {
+          "code": "104563",
+          "uuid": "104563AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Econazole / hydrocortisone"
+        },
+        {
+          "code": "104696",
+          "uuid": "104696AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Fusidate / hydrocortisone"
+        },
+        {
+          "code": "104706",
+          "uuid": "104706AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Gentamicin sulfate (usp) / hydrocortisone"
+        },
+        {
+          "code": "104819",
+          "uuid": "104819AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hexachlorophene / hydrocortisone / menthol"
+        },
+        {
+          "code": "104857",
+          "uuid": "104857AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / iodoquinol"
+        },
+        {
+          "code": "104859",
+          "uuid": "104859AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / lidocaine"
+        },
+        {
+          "code": "104860",
+          "uuid": "104860AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / miconazole"
+        },
+        {
+          "code": "104861",
+          "uuid": "104861AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin"
+        },
+        {
+          "code": "104862",
+          "uuid": "104862AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / neomycin / polymyxin B"
+        },
+        {
+          "code": "104863",
+          "uuid": "104863AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / oxytetracycline"
+        },
+        {
+          "code": "104864",
+          "uuid": "104864AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / polymyxin B"
+        },
+        {
+          "code": "104865",
+          "uuid": "104865AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / pramoxine"
+        },
+        {
+          "code": "104866",
+          "uuid": "104866AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sodium thiosulfate"
+        },
+        {
+          "code": "104867",
+          "uuid": "104867AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / salicylic acid / sulfur"
+        },
+        {
+          "code": "104868",
+          "uuid": "104868AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone / sulfur / zinc oxide"
+        },
+        {
+          "code": "165454",
+          "uuid": "165454AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Aluminium subacetate / hydrocortisone acetate / lidocaine / zinc oxide"
+        },
+        {
+          "code": "73950",
+          "uuid": "73950AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Cortisol succinate"
+        },
+        {
+          "code": "77714",
+          "uuid": "77714AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone"
+        },
+        {
+          "code": "77716",
+          "uuid": "77716AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone 17-butyrate 21-propionate"
+        },
+        {
+          "code": "77718",
+          "uuid": "77718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone aceponate"
+        },
+        {
+          "code": "77719",
+          "uuid": "77719AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone acetate"
+        },
+        {
+          "code": "77720",
+          "uuid": "77720AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone butyrate"
+        },
+        {
+          "code": "77721",
+          "uuid": "77721AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone cypionate"
+        },
+        {
+          "code": "77724",
+          "uuid": "77724AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium phosphate"
+        },
+        {
+          "code": "77725",
+          "uuid": "77725AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone sodium succinate"
+        },
+        {
+          "code": "77726",
+          "uuid": "77726AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Hydrocortisone valerate"
+        }
+      ]
+    }
+  ],
+  "mechanisms": {},
+  "interactions": []
+}

--- a/api/src/test/resources/chartsearchai-test/ddi-contra-route-variants.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-contra-route-variants.json
@@ -1254,6 +1254,196 @@
           "name": "Hydrocortisone valerate"
         }
       ]
+    },
+    {
+      "id": "DDInter2110",
+      "name": "Tozinameran (12y+)",
+      "rxcui": "2468231",
+      "rxnorm_name": "SARS-CoV-2 (COVID-19) vaccine, mRNA spike protein",
+      "drugbank_id": null,
+      "atc": [
+        "J07BN01",
+        "J07BN04"
+      ],
+      "ciel": [
+        {
+          "code": "166154",
+          "uuid": "166154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Moderna COVID-19 vaccine"
+        },
+        {
+          "code": "166155",
+          "uuid": "166155AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine"
+        },
+        {
+          "code": "167039",
+          "uuid": "167039AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (adolescent)"
+        },
+        {
+          "code": "167040",
+          "uuid": "167040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (child)"
+        },
+        {
+          "code": "167041",
+          "uuid": "167041AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (infant)"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2111",
+      "name": "Tozinameran (5y-11y)",
+      "rxcui": "2468231",
+      "rxnorm_name": "SARS-CoV-2 (COVID-19) vaccine, mRNA spike protein",
+      "drugbank_id": null,
+      "atc": [
+        "J07BN01",
+        "J07BN04"
+      ],
+      "ciel": [
+        {
+          "code": "166154",
+          "uuid": "166154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Moderna COVID-19 vaccine"
+        },
+        {
+          "code": "166155",
+          "uuid": "166155AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine"
+        },
+        {
+          "code": "167039",
+          "uuid": "167039AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (adolescent)"
+        },
+        {
+          "code": "167040",
+          "uuid": "167040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (child)"
+        },
+        {
+          "code": "167041",
+          "uuid": "167041AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (infant)"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2112",
+      "name": "Tozinameran (6m-4y)",
+      "rxcui": "2468231",
+      "rxnorm_name": "SARS-CoV-2 (COVID-19) vaccine, mRNA spike protein",
+      "drugbank_id": null,
+      "atc": [
+        "J07BN01",
+        "J07BN04"
+      ],
+      "ciel": [
+        {
+          "code": "166154",
+          "uuid": "166154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Moderna COVID-19 vaccine"
+        },
+        {
+          "code": "166155",
+          "uuid": "166155AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine"
+        },
+        {
+          "code": "167039",
+          "uuid": "167039AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (adolescent)"
+        },
+        {
+          "code": "167040",
+          "uuid": "167040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (child)"
+        },
+        {
+          "code": "167041",
+          "uuid": "167041AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (infant)"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2164",
+      "name": "Tozinameran",
+      "rxcui": "2468231",
+      "rxnorm_name": "SARS-CoV-2 (COVID-19) vaccine, mRNA spike protein",
+      "drugbank_id": "DB15696",
+      "atc": [
+        "J07BN01",
+        "J07BN04"
+      ],
+      "ciel": [
+        {
+          "code": "166154",
+          "uuid": "166154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Moderna COVID-19 vaccine"
+        },
+        {
+          "code": "166155",
+          "uuid": "166155AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine"
+        },
+        {
+          "code": "167039",
+          "uuid": "167039AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (adolescent)"
+        },
+        {
+          "code": "167040",
+          "uuid": "167040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (child)"
+        },
+        {
+          "code": "167041",
+          "uuid": "167041AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (infant)"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2220",
+      "name": "Tozinameran (tris-sucrose)",
+      "rxcui": "2468231",
+      "rxnorm_name": "SARS-CoV-2 (COVID-19) vaccine, mRNA spike protein",
+      "drugbank_id": null,
+      "atc": [
+        "J07BN01",
+        "J07BN04"
+      ],
+      "ciel": [
+        {
+          "code": "166154",
+          "uuid": "166154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Moderna COVID-19 vaccine"
+        },
+        {
+          "code": "166155",
+          "uuid": "166155AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine"
+        },
+        {
+          "code": "167039",
+          "uuid": "167039AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (adolescent)"
+        },
+        {
+          "code": "167040",
+          "uuid": "167040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (child)"
+        },
+        {
+          "code": "167041",
+          "uuid": "167041AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Pfizer-BioNtech COVID-19 vaccine (infant)"
+        }
+      ]
     }
   ],
   "mechanisms": {},

--- a/api/src/test/resources/chartsearchai-test/drug-reference-duplicate-rule-tokens.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-duplicate-rule-tokens.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.0",
+  "source": "test fixture — one curated contraindication rule authored twice, differing only in case",
+  "entries": [
+    {
+      "id": "ibuprofen",
+      "name": "Ibuprofen",
+      "aliases": [
+        "ibuprofen"
+      ],
+      "atcCodes": [
+        "M01AE01"
+      ],
+      "contraindications": [
+        {
+          "type": "allergy",
+          "token": "ibuprofen",
+          "note": "documented ibuprofen allergy"
+        },
+        {
+          "type": "ALLERGY",
+          "token": "Ibuprofen",
+          "note": "avoid all NSAIDs"
+        }
+      ],
+      "source": "test fixture"
+    }
+  ]
+}


### PR DESCRIPTION
## The defect

Both contraindication arms are keyed on a subject **entry**, and DDInter files one substance as
several route/formulation rows. One clinician-facing string resolves all of them —
`findByQuery` and `findByDrugName` return every entry whose aliases match — so one clinical fact
became one chip per row.

Worse than duplication: only the row `lookupByToken` resolves the allergy to matches by IDENTITY, so
its siblings fell through to the class comparison and reported the substance as cross-reactive with
the patient's allergy to **itself**. Measured on the 3.7.1 standalone against the build deployed there
before mine, Richard Jones (recorded Dexamethasone allergy + a Dexamethasone order), "Is it safe to give
dexamethasone?" — **4 chips**:

```
[contraindication] Dexamethasone
    The patient has a recorded allergy to Dexamethasone.
[contraindication] Dexamethasone (nasal)
    Dexamethasone (nasal) is in the same ATC class (A01AC) as the patient's allergy to Dexamethasone — possible cross-reactivity
[contraindication] Dexamethasone (ophthalmic)
    Dexamethasone (ophthalmic) is in the same ATC class (A01AC) as the patient's allergy to Dexamethasone — possible cross-reactivity
[contraindication] Dexamethasone (topical)
    Dexamethasone (topical) is in the same ATC class (A01AC) as the patient's allergy to Dexamethasone — possible cross-reactivity
```

Since #110 every chip is also injected as a citable pre-answer record, so each duplicate reached the
prompt too (measured through the real injector: 4 `safety_finding` records for that one allergy).

## Root cause and what changed

`DrugSafetyValidator` gains a validate-scoped ledger, `ContraindicationChips`, that **both**
contraindication arms and **both** of their call sites feed — the drug-in-play loop and
`addActiveOrderContraindications`. It keys on `(subject substance, recorded finding)`, keeps the most
specific relationship, and writes the survivor back into the position the group's first candidate
took, so no client sees the chip sequence reshuffle.

**Not a filter over the finished chip list**, for three reasons, the first decisive: the sibling's
chip is *wrong*, not merely duplicated — the true statement about that substance is the identity one —
so the collapse has to choose which relationship survives, and by the time only rendered text is left
the reasons are gone. Second, those chips differ in text (each names its own route), so
`chipIdentity`'s exact-repeat key cannot see them, and recognising "differs only in a route
qualifier" from the strings means pattern-matching a display label, which is the mistake #148 undid.
Third, the arms run at two call sites, and a collapse inside either one leaves the other emitting the
siblings — Sarah Taylor's shape below.

### The collapse key, and why `rxnorm_name` equality is not the line

`DrugReference.substanceKey()` = **the reference data's own substance name AND the display-name stem**
(the name with trailing parenthesized qualifiers removed). `DrugReference` gains a `substanceName`
field, set unconditionally by `DdiDrugReferenceSource` from `rxnorm_name`; sources that publish none
(the curated `json` file, the `atc` adapter) key on entry identity, so nothing collapses for them.

Measured over the shipped 19 MB KB (2283 entries), each half is load-bearing:

* the substance name is the data's own substance claim — 142 values shared by more than one entry
  across 332 entries, and the `rxcui` partitions those entries **identically**;
* but that claim over-merges. Among those 142 families sit pairs of genuinely different
  substances: `Omeprazole`/`Esomeprazole` (one `rxnorm_name`, one `rxcui`, one ATC code),
  `Amphetamine`/`Dextroamphetamine`, `Fenfluramine`/`Dexfenfluramine`,
  `Gabapentin`/`Gabapentin enacarbil`, `Netupitant`/`Fosnetupitant`,
  `Ketoconazole`/`Levoketoconazole`, `Fenofibrate`/`Fenofibric acid`, `Atropine`/`Hyoscyamine` …
  — each of them the `enalapril`/`enalaprilat` shape #121 decided must stay two chips. The stem
  separates every one of them.
* Conversely the stem alone merges 9 groups the substance name keeps apart, 8 of them different
  substances sharing one stem (`Manganese (chloride)`/`(sulfate)`,
  `Dextran (-1)`/`(low molecular weight)`, `Insulin human`/`(isophane)`,
  `Iron`/`(polysaccharide)`, `Typhoid vaccine (live)`/`(inactivated)` …).

Together the key reduces those 332 entries to 177 substances. A mutation sweep on a throwaway tree
confirms the stem half is load-bearing rather than decorative: with `substanceKey()` cut back to the
substance name alone — issue #145's own proposal 2 — two of the new tests fail by **dropping real
chips**, `Esomeprazole`'s and `Hydrocortisone butyrate`'s.

Conservative where it cannot tell, in both directions: a name that extends the family stem by a WORD
rather than a qualifier (`Hydrocortisone butyrate`, `Estrone sulfate`, `Procaine benzylpenicillin`)
keeps its own chip, and 21 of the 142 families are left entirely unmerged for that reason — some of
which the KB is in fact naming one substance two ways (`Thallous Chloride`/`Thallous chloride
tl-201`). Over-reporting one chip on a non-blocking advisory is the safe direction; dropping a real one is
not.

### Which chip survives

The **most specific relationship** — identity > shared ATC class > shared curated cross-reactivity
group. That is this arm's analogue of "the highest severity wins": a contraindication chip carries no
severity, and what it can under-report is the strength of the claim. Ties keep the incumbent, so a
group of equally-related rows reports the dataset's first row, exactly as `bestRulePerPartner` keeps
its first.

Stated honestly: on the shipped resolution semantics the strongest candidate is always the group's
**first** — `lookupByToken` takes the EARLIEST matching entry, every row of a substance carries that
substance's name among its aliases, and both subject sets are iterated in dataset order — so the
replacement branch is not reachable through the production path today and **no test pins it**. It is
written that way because the ordering is a property of `lookupByToken`, not of this ledger, and a
first-wins ledger would silently start dropping identity chips the moment that changed.

### `SafetyWarning.equals`/`hashCode`: deliberately not added

Value equality on a clinician-facing advisory would collapse two genuinely different findings whose
wording happens to agree, and it could not implement this collapse anyway — the duplicate chips differ
in text. The grouping is structural and belongs where the reasons are known, the same argument #88 and
#121 made.

## Live evidence, verbatim

Deployed to the 3.7.1 standalone (`sourceFormat=ddinter`, 2283 entries, `GET
/chartsearchai/drugreferencestatus` confirming the load). Patients resolved by name lookup against the
live DB. After = this branch. **Before** = the build that was already deployed on that instance,
produced from the branch merged as `dd651ef`; I did not rebuild `main` myself to re-measure it, so read
the before-column as "the previous build on this box" rather than as a build I made from `dd651ef`. The
same 4-chip and 4-record shapes are independently reproduced by the new tests failing on this branch
before the fix (`expected: <1> but was: <4>`).

### A. Richard Jones (`a39e82e7-…`) — recorded Dexamethasone allergy + a Dexamethasone order

"Is it safe to give dexamethasone?"

| | chips |
|---|---|
| before | 4 |
| after | **1** |

```
--- safetyWarnings (1) ---
  [contraindication] drug='Dexamethasone'
      The patient has a recorded allergy to Dexamethasone.
```

Counterfactual: had the collapse been wrong in the *aggressive* direction the surviving chip would be
one of the three "Dexamethasone (nasal/ophthalmic/topical) is in the same ATC class (A01AC) as the
patient's allergy to Dexamethasone" lines — the vacuous one — instead of the identity chip. Had it not
fired at all, this stays at 4, as it does on `main`.

### B. Sarah Taylor (`dc8560c9-…`) — Dexamethasone allergy + 8 active orders

"Is it safe to give her paracetamol?" (names no drug of hers, so the order-driven arm owns every chip)

| | chips |
|---|---|
| before | 13 |
| after | **6** |

Before, verbatim:

```
--- safetyWarnings (13) ---
  [contraindication] Dexamethasone        The patient has a recorded allergy to Dexamethasone.
  [contraindication] Dexamethasone (nasal)        … same ATC class (A01AC) as the patient's allergy to Dexamethasone …
  [contraindication] Dexamethasone (ophthalmic)   … same ATC class (A01AC) …
  [contraindication] Dexamethasone (topical)      … same ATC class (A01AC) …
  [contraindication] Hydrocortisone               … same ATC class (A01AC) …
  [contraindication] Hydrocortisone (ophthalmic)  … same ATC class (A01AC) …
  [contraindication] Hydrocortisone (topical)     … same ATC class (A01AC) …
  [contraindication] Hydrocortisone butyrate      … same ATC class (A01AC) …
  [contraindication] Prednisone                   … same ATC class (H02AB) …
  [contraindication] Budesonide                   … same ATC class (R01AD) …
  [contraindication] Budesonide (nasal)           … same ATC class (R01AD) …
  [contraindication] Methylprednisolone           … same ATC class (D10AA) …
  [contraindication] Methylprednisolone (topical) … same ATC class (D10AA) …
```

After, verbatim:

```
--- safetyWarnings (6) ---
  [contraindication] drug='Dexamethasone'
      The patient has a recorded allergy to Dexamethasone.
  [contraindication] drug='Hydrocortisone'
      Hydrocortisone is in the same ATC class (A01AC) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Hydrocortisone butyrate'
      Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Prednisone'
      Prednisone is in the same ATC class (H02AB) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Budesonide'
      Budesonide is in the same ATC class (R01AD) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Methylprednisolone'
      Methylprednisolone is in the same ATC class (D10AA) as the patient's allergy to Dexamethasone — possible cross-reactivity
```

Seven route/formulation-variant chips gone; **no substance lost**. The dexamethasone family keeps the
IDENTITY chip rather than one of its three self-cross-reactivity siblings, and `Hydrocortisone butyrate`
stays its own chip beside `Hydrocortisone` — the conservative refusal, same rule that keeps Omeprazole
and Esomeprazole apart in C.

Counterfactual: 11 of the 13 were route or formulation variants of five substances. A fix that
collapsed only within the question-driven arm would have changed nothing here at all — every chip on
this patient comes from `addActiveOrderContraindications`.

### C. George Anderson (`d5c9cdad-…`) — MUST NOT COLLAPSE

Fixture I created on the demo DB (documented below): a SEVERE coded **Pantoprazole** allergy, no
orders. "Is it safe to give esomeprazole?" — that one word resolves BOTH rows the KB files under
`rxnorm_name=esomeprazole` / `rxcui=283742`, and both carry the same single ATC code `A02BC05`, so
every key made of reference-data identity alone merges them.

| | chips |
|---|---|
| before | 2 |
| after | **2** |

Identical before and after, verbatim (after):

```
--- safetyWarnings (2) ---
  [contraindication] drug='Omeprazole'
      Omeprazole is in the same ATC class (A02BC) as the patient's allergy to Pantoprazole — possible cross-reactivity
  [contraindication] drug='Esomeprazole'
      Esomeprazole is in the same ATC class (A02BC) as the patient's allergy to Pantoprazole — possible cross-reactivity
```

Counterfactual: this is the discriminating half. With the key cut back to the substance name alone
(issue #145's own proposal 2) this collapses to **1** chip and Esomeprazole's is the one dropped —
measured, both as a live before/after shape and as a mutation sweep failure of
`twoDistinctSubstancesTheKbFilesUnderOneSubstanceNameStayTwoChips`.

### D. Margaret King (`f2397b8a-…`) — a Dexamethasone order, NO allergy

"Is it safe to give dexamethasone?"

| | chips |
|---|---|
| before | 0 |
| after | **0** |

Counterfactual: a collapse that keyed on the subject alone — dropping the recorded-finding half of the
key — could not invent a chip here, but a ledger that mis-ranked could: this is the control that the
change adds nothing where there is no allergy to compare against. It also confirms the four
dexamethasone rows in play still produce no contraindication when nothing contraindicates them.

### E. The four regression controls

All four exact, verbatim from the same run:

| control | expected | measured |
|---|---|---|
| Mary Smith x clarithromycin | 1 chip, Major, x simvastatin | **1** — `Clarithromycin interacts with active order simvastatin — Major. Coadministration with potent inhibitors of CYP450 3A4 …` |
| Agnes Adams x warfarin | 1 chip, Major, x aspirin | **1** — `Warfarin interacts with active order aspirin — Major. Aspirin, even in small doses, may increase the risk of bleeding …` |
| Joshua Johnson x ibuprofen | **2** chips | **2** — see below |
| Mary Smith x paracetamol | 0 chips | **0** |

Joshua's pair is the "2 chips is CORRECT" case — two different clinical facts about two different
partners, and the ledger must not touch them (different chip types, and the contraindication's finding
is the aspirin allergy while the interaction's partner is the lisinopril order):

```
--- safetyWarnings (2) ---
  [contraindication] drug='Ibuprofen'
      Ibuprofen is in the same cross-reactivity group (NSAID) as the patient's allergy to Acetylsalicylic acid (aspirin) — possible cross-reactivity
  [interaction] drug='Ibuprofen'
      Ibuprofen interacts with active order lisinopril — Moderate. Nonsteroidal anti-inflammatory drugs (NSAIDs) may attenuate the antihypertensive effects of ACE inhibitors. …
```

Agnes's case additionally exercises the class arm — her Aspirin 81mg order carries ATC `N02BA01` — and
still yields exactly one chip, so #88's rule/class fold is unaffected.

### Demo data I created (no teardown, per the standing instruction)

* **George Anderson** `d5c9cdad-8873-488d-9f7c-c92af9898b04` — one SEVERE coded DRUG allergy to
  `Pantoprazole` (allergy uuid `4cf5a4ee-65c0-4d79-8e15-b6529abd3fe2`). Nothing else was added,
  voided or changed; no GP was touched.


## Build

Measured myself on this branch, full reactor `mvn -o clean install`:

* **api 876, omod 61 — 0 failures, 34 skipped.**
* Baseline on `main` at `dd651ef`, measured the same way: api 869, omod 61, 0 failures, 34 skipped.
* +7 = exactly the new `ContraindicationRouteVariantTest`. **No existing test changed and none broke.**

## Limitations

* The mislabelled class in the surviving chip is untouched and still wrong: `sharedClass` returns the
  *first* shared subgroup, so a systemic dexamethasone allergy is reported against `A01AC`
  (corticosteroids for local oral treatment) and a Solu-Medrol order against `D10AA` (anti-acne
  corticosteroids). #145 calls that its option 3 and says it should not be bundled; it is not.
* The same subject-side duplication still exists in the **interaction** arms, and I measured it on this
  build rather than leaving it as a guess. Sarah Taylor, "Is it safe to give hydrocortisone?" — the six
  contraindication chips are all distinct substances (this fix working), but the interaction arm reports
  `hydrocortisone x diclofenac` **twice**, once per reference row:

  ```
  [interaction] Hydrocortisone              Hydrocortisone interacts with active order diclofenac — Moderate. The combined use of corticosteroids and nonsteroidal anti-inflammatory …
  [interaction] Hydrocortisone (ophthalmic) Hydrocortisone (ophthalmic) interacts with active order diclofenac — Moderate. Concomitant use of ophthalmic nonsteroidal …
  ```

  `bestRulePerPartner` groups per PARTNER within one subject, so #115/#121/#148 fixed the partner side
  and the subject side is still ungrouped. Not fixed here — #145 is scoped to the contraindication arms,
  and the interaction case needs a decision this one does not (the two rows carry *different* mechanism
  prose, so it is not a pure duplicate). Filed separately.
* The injector duplicates the reference RECORD the same way: `DrugReferenceInjector.matchingEntries`
  dedups on `ref.getId()`, and route variants deliberately have distinct ids, so asking about
  dexamethasone injects four near-identical `drug_reference` records. Code-reasoned, not measured live
  (the REST layer returns only cited references). The *finding* records are fixed here, and pinned:
  4 → 1 through the real injector.
* This does not resolve #146: the curated-rule arm and the allergy arm keep separate key spaces on
  purpose, because a curated token may name a class (`nsaid`, `aminoglycoside`) rather than a drug, so
  resolving it to an entry to make the two comparable would collapse a class-level rule into an
  identity chip. `ActiveOrderContraindicationTest` pins that pair at 2 chips and still passes.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
