### PR TITLE
fix(drug-safety): name the shared ATC class that explains the cross-reactivity

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -320,12 +320,15 @@ public class DrugReference {
 	 * here demotes a class that does explain a cross-reactivity concern. A group missing from it does
 	 * NOT merely leave the pre-existing answer in place: it becomes the answer as soon as it sorts
 	 * ahead of the systemic subgroup the pair also shares, since {@link DrugSafetyValidator}'s scan
-	 * takes the first shared subgroup this method does not veto. That is how {@code A07A},
-	 * {@code B02BC}, {@code B05C} and {@code G02CC} came to be here — written at main-group
-	 * granularity the list moved 21 shipped-KB pairs onto one of them, ibuprofen/naproxen among them
-	 * (measured 2026-08-06; {@code CrossReactivityClassChoiceTest} pins one case per group, save
-	 * {@code B02BC}, whose only shipped-KB pairs are epinephrine route variants that issue #160
-	 * collapses to an identity chip before this arm can name a class).
+	 * takes the first shared subgroup this method does not veto.
+	 *
+	 * <p>That is how {@code A07A}, {@code B02BC}, {@code B05C} and {@code G02CC} came to be here.
+	 * Without them, 45 of the shipped KB's 1090 multi-subgroup pairs named one of the four — among them
+	 * ibuprofen/naproxen reading {@code G02CC} instead of {@code M01AE} — and 21 of the 45 had been
+	 * moved onto one by this rule itself rather than merely left there (measured 2026-08-06).
+	 * {@code CrossReactivityClassChoiceTest} pins one case per group, save {@code B02BC}: its only
+	 * shipped-KB pairs are epinephrine route variants, which issue #160 collapses to an identity chip
+	 * before this arm can name a class at all.
 	 */
 	private static final List<String> LOCALLY_APPLIED_ATC_GROUPS = Collections
 			.unmodifiableList(Arrays.asList("A01", "A07A", "A07E", "B02BC", "B05C", "C05A", "C05B",
@@ -340,13 +343,14 @@ public class DrugReference {
 	 * this whole rule exists to fix. Measured over the shipped KB (2026-08-06), only {@code D05B} is
 	 * reachable there, in three pairs, all psoralens: methoxsalen and trioxsalen share {@code D05AD}
 	 * (topical) and {@code D05BA} (systemic) and would be reported as sharing the topical one. The
-	 * other three change no pair in that KB and are here on ATC's wording alone, like every entry in
-	 * both lists — removing them breaks no test.
+	 * other three change no pair in that KB — they are here on the criterion rather than on measured
+	 * impact, and removing them breaks no test.
 	 *
 	 * <p>An exception list here, while R03's systemic halves are handled by leaving {@code R03C} and
-	 * {@code R03D} out of the list above, because the two groups are shaped differently: under R03 the
-	 * locally applied part is the minority and is cheaper to name, under D and R01 it is nearly all of
-	 * the group and the exception is.
+	 * {@code R03D} out of the list above, because the shapes differ: under D and R01 the locally
+	 * applied part is nearly all of the group, so naming the exceptions is the shorter thing to write,
+	 * while R03 splits evenly and its two inhalant halves are shorter to name than the group plus two
+	 * exceptions.
 	 */
 	private static final List<String> SYSTEMIC_USE_ATC_GROUPS = Collections
 			.unmodifiableList(Arrays.asList("D01B", "D05B", "D10B", "R01B"));
@@ -357,11 +361,14 @@ public class DrugReference {
 	 *         {@link #LOCALLY_APPLIED_ATC_GROUPS} and not in one of the
 	 *         {@link #SYSTEMIC_USE_ATC_GROUPS} nested inside them. A substance marketed by several
 	 *         routes carries one code per route, so this is what separates the code that classifies
-	 *         the SUBSTANCE from the codes that classify its topical, nasal, inhaled, ophthalmic or
-	 *         local-oral presentations. Null and blank are not locally applied, like every other ATC
-	 *         comparison here treats them: nothing is known about them at all.
+	 *         the SUBSTANCE from the codes that classify a locally applied presentation of it. Null and
+	 *         blank are not locally applied, like every other ATC comparison here treats them: nothing
+	 *         is known about them at all.
+	 *         <p>Package-private with one caller ({@code DrugSafetyValidator.sharedClass}) on purpose:
+	 *         it is a rule about ATC's own group names, not a fact about a substance, so nothing
+	 *         outside this package should be asking it.
 	 */
-	public static boolean isLocallyAppliedAtcCode(String code) {
+	static boolean isLocallyAppliedAtcCode(String code) {
 		String normalized = normalizeAtcToken(code);
 		if (normalized == null) {
 			return false;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -321,18 +321,37 @@ public class DrugReference {
 					"R03A", "R03B", "S"));
 
 	/**
+	 * The groups nested INSIDE {@link #LOCALLY_APPLIED_ATC_GROUPS} that ATC itself names "for systemic
+	 * use" — {@code D01B} antifungals, {@code D05B} antipsoriatics, {@code D10B} anti-acne
+	 * preparations, {@code R01B} nasal decongestants. Same criterion as the list above, applied to the
+	 * same words: a group is read as locally applied when its own name says where it is applied, and
+	 * these four say the opposite. Without them a main-group prefix would be wrong in exactly the way
+	 * this whole rule exists to fix — measured over the shipped KB (2026-08-06), three pairs, all
+	 * psoralens: methoxsalen and trioxsalen share {@code D05AD} (topical) and {@code D05BA} (systemic)
+	 * and would be reported as sharing the topical one.
+	 */
+	private static final List<String> SYSTEMIC_USE_ATC_GROUPS = Collections
+			.unmodifiableList(Arrays.asList("D01B", "D05B", "D10B", "R01B"));
+
+	/**
 	 * @return whether {@code code} — a full ATC code or any prefix of one, normalized here the same
 	 *         way {@link #normalizedAtcCodes()} normalizes an entry's — sits in one of the
-	 *         {@link #LOCALLY_APPLIED_ATC_GROUPS}. A substance marketed by several routes carries one
-	 *         code per route, so this is what separates the code that classifies the SUBSTANCE from
-	 *         the codes that classify its topical, nasal, inhaled, ophthalmic or local-oral
-	 *         presentations. Null and blank are not locally applied, like every other ATC comparison
-	 *         here treats them: nothing is known about them at all.
+	 *         {@link #LOCALLY_APPLIED_ATC_GROUPS} and not in one of the
+	 *         {@link #SYSTEMIC_USE_ATC_GROUPS} nested inside them. A substance marketed by several
+	 *         routes carries one code per route, so this is what separates the code that classifies
+	 *         the SUBSTANCE from the codes that classify its topical, nasal, inhaled, ophthalmic or
+	 *         local-oral presentations. Null and blank are not locally applied, like every other ATC
+	 *         comparison here treats them: nothing is known about them at all.
 	 */
 	public static boolean isLocallyAppliedAtcCode(String code) {
 		String normalized = normalizeAtcToken(code);
 		if (normalized == null) {
 			return false;
+		}
+		for (String group : SYSTEMIC_USE_ATC_GROUPS) {
+			if (normalized.startsWith(group)) {
+				return false;
+			}
 		}
 		for (String group : LOCALLY_APPLIED_ATC_GROUPS) {
 			if (normalized.startsWith(group)) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -323,8 +323,8 @@ public class DrugReference {
 	 * takes the first shared subgroup this method does not veto.
 	 *
 	 * <p>That is how {@code A07A}, {@code B02BC}, {@code B05C} and {@code G02CC} came to be here.
-	 * Without them, 45 of the shipped KB's 1090 multi-subgroup pairs named one of the four — among them
-	 * ibuprofen/naproxen reading {@code G02CC} instead of {@code M01AE} — and 21 of the 45 had been
+	 * Without them, 46 of the shipped KB's 1090 multi-subgroup pairs named one of the four — among them
+	 * ibuprofen/naproxen reading {@code G02CC} instead of {@code M01AE} — and 21 of the 46 had been
 	 * moved onto one by this rule itself rather than merely left there (measured 2026-08-06).
 	 * {@code CrossReactivityClassChoiceTest} pins one case per group, save {@code B02BC}: its only
 	 * shipped-KB pairs are epinephrine route variants, which issue #160 collapses to an identity chip
@@ -336,15 +336,21 @@ public class DrugReference {
 
 	/**
 	 * The groups nested INSIDE {@link #LOCALLY_APPLIED_ATC_GROUPS} that ATC itself names "for systemic
-	 * use" — {@code D01B} antifungals, {@code D05B} antipsoriatics, {@code D10B} anti-acne
-	 * preparations, {@code R01B} nasal decongestants. Same criterion as the list above, applied to the
-	 * same words: a group is read as locally applied when its own name says where it is applied, and
-	 * these four say the opposite. Without them a main-group prefix would be wrong in exactly the way
-	 * this whole rule exists to fix. Measured over the shipped KB (2026-08-06), only {@code D05B} is
-	 * reachable there, in three pairs, all psoralens: methoxsalen and trioxsalen share {@code D05AD}
-	 * (topical) and {@code D05BA} (systemic) and would be reported as sharing the topical one. The
-	 * other three change no pair in that KB — they are here on the criterion rather than on measured
-	 * impact, and removing them breaks no test.
+	 * use" — {@code D01B} antifungals, {@code D02BB} UV-radiation protectives, {@code D05B}
+	 * antipsoriatics, {@code D10B} anti-acne preparations, {@code R01B} nasal decongestants. Same
+	 * criterion as the list above, applied to the same words: a group is read as locally applied when
+	 * its own name says where it is applied, and these five say the opposite. Without them a main-group
+	 * prefix would be wrong in exactly the way this whole rule exists to fix.
+	 *
+	 * <p>Enumerated rather than asserted, which is what makes "these five" a claim and not a hope: the
+	 * shipped KB uses 117 level-4 subgroups under one of the prefixes above, and exactly six of them are
+	 * named for systemic use — {@code D01BA}, {@code D02BB}, {@code D05BA}, {@code D05BB},
+	 * {@code D10BA}, {@code R01BA}, either in their own name or their level-3 parent's — all six covered
+	 * by the five prefixes here (measured 2026-08-06). Only {@code D05B} changes any pair in that KB:
+	 * three, all psoralens, since methoxsalen and trioxsalen share {@code D05AD} (topical) and
+	 * {@code D05BA} (systemic) and would be reported as sharing the topical one. The other four change
+	 * none and are here on the criterion rather than on measured impact; removing them breaks no test,
+	 * which is exactly why the criterion and not the test suite has to decide membership.
 	 *
 	 * <p>An exception list here, while R03's systemic halves are handled by leaving {@code R03C} and
 	 * {@code R03D} out of the list above, because the shapes differ: under D and R01 the locally
@@ -353,7 +359,7 @@ public class DrugReference {
 	 * exceptions.
 	 */
 	private static final List<String> SYSTEMIC_USE_ATC_GROUPS = Collections
-			.unmodifiableList(Arrays.asList("D01B", "D05B", "D10B", "R01B"));
+			.unmodifiableList(Arrays.asList("D01B", "D02BB", "D05B", "D10B", "R01B"));
 
 	/**
 	 * @return whether {@code code} — a full ATC code or any prefix of one, normalized here the same

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -329,6 +329,11 @@ public class DrugReference {
 	 * this whole rule exists to fix — measured over the shipped KB (2026-08-06), three pairs, all
 	 * psoralens: methoxsalen and trioxsalen share {@code D05AD} (topical) and {@code D05BA} (systemic)
 	 * and would be reported as sharing the topical one.
+	 *
+	 * <p>An exception list here, while R03's systemic halves are handled by leaving {@code R03C} and
+	 * {@code R03D} out of the list above, because the two groups are shaped differently: under R03 the
+	 * locally applied part is the minority and is cheaper to name, under D and R01 it is nearly all of
+	 * the group and the exception is.
 	 */
 	private static final List<String> SYSTEMIC_USE_ATC_GROUPS = Collections
 			.unmodifiableList(Arrays.asList("D01B", "D05B", "D10B", "R01B"));

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -297,28 +297,39 @@ public class DrugReference {
 	 * ATC groups that classify a LOCALLY APPLIED formulation rather than the substance itself, each
 	 * identified by the route or site of application in the group's own published name: {@code D}
 	 * "Dermatologicals" and {@code S} "Sensory organs" (whole anatomical main groups), {@code A01}
-	 * "Stomatological preparations", {@code A07E} "Intestinal antiinflammatory agents" (its
-	 * {@code A07EA} is "Corticosteroids acting locally"), {@code C05A} "Antihemorrhoidals for topical
-	 * use", {@code C05B} "Antivaricose therapy" (topical heparinoids, sclerosants for local
-	 * injection), {@code G01} "Gynecological antiinfectives and antiseptics", {@code M02} "Topical
-	 * products for joint and muscular pain", {@code P03A} "Ectoparasiticides, incl. scabicides",
-	 * {@code R01} "Nasal preparations", {@code R02} "Throat preparations", and {@code R03A} /
-	 * {@code R03B}, the two <em>inhalant</em> subgroups of R03 — their {@code R03C} / {@code R03D}
-	 * siblings are for systemic use and are deliberately absent, which is why this list cannot be
-	 * written at main-group granularity throughout.
+	 * "Stomatological preparations", {@code A07A} "Intestinal antiinfectives" and {@code A07E}
+	 * "Intestinal antiinflammatory agents" (its {@code A07EA} is "Corticosteroids acting locally"),
+	 * {@code B02BC} "Local hemostatics" (its {@code B02BX} sibling is "Other systemic hemostatics"),
+	 * {@code B05C} "Irrigating solutions", {@code C05A} "Antihemorrhoidals for topical use",
+	 * {@code C05B} "Antivaricose therapy" (topical heparinoids, sclerosants for local injection),
+	 * {@code G01} "Gynecological antiinfectives and antiseptics", {@code G02CC} "Antiinflammatory
+	 * products for vaginal administration" (its {@code G02CB} sibling, prolactine inhibitors, is
+	 * systemic), {@code M02} "Topical products for joint and muscular pain", {@code P03A}
+	 * "Ectoparasiticides, incl. scabicides", {@code R01} "Nasal preparations", {@code R02} "Throat
+	 * preparations", and {@code R03A} / {@code R03B}, the two <em>inhalant</em> subgroups of R03 —
+	 * their {@code R03C} / {@code R03D} siblings are for systemic use and are deliberately absent,
+	 * which is why this list cannot be written at main-group granularity throughout.
 	 *
 	 * <p>Deliberately NOT here: {@code N01B} "Anesthetics, local". Its name is the drug class, not the
 	 * site of application — the codes classify the substance, and two local anaesthetics sharing
 	 * {@code N01BB} is exactly the cross-reactivity statement a clinician wants.
 	 *
 	 * <p>Prefixes, and not an exhaustive partition of ATC: anything unlisted counts as classifying the
-	 * substance. That is the safe direction of error for {@link DrugSafetyValidator}'s use of it — a
-	 * group wrongly listed here would demote a class that does explain a cross-reactivity concern,
-	 * while one missing from it merely leaves the pre-existing behaviour in place.
+	 * substance. Neither direction of error is free, which is why the criterion is ATC's own wording
+	 * about a GROUP rather than pharmacological judgement about a substance. A group wrongly listed
+	 * here demotes a class that does explain a cross-reactivity concern. A group missing from it does
+	 * NOT merely leave the pre-existing answer in place: it becomes the answer as soon as it sorts
+	 * ahead of the systemic subgroup the pair also shares, since {@link DrugSafetyValidator}'s scan
+	 * takes the first shared subgroup this method does not veto. That is how {@code A07A},
+	 * {@code B02BC}, {@code B05C} and {@code G02CC} came to be here — written at main-group
+	 * granularity the list moved 21 shipped-KB pairs onto one of them, ibuprofen/naproxen among them
+	 * (measured 2026-08-06; {@code CrossReactivityClassChoiceTest} pins one case per group, save
+	 * {@code B02BC}, whose only shipped-KB pairs are epinephrine route variants that issue #160
+	 * collapses to an identity chip before this arm can name a class).
 	 */
-	private static final List<String> LOCALLY_APPLIED_ATC_GROUPS = Collections.unmodifiableList(
-			Arrays.asList("A01", "A07E", "C05A", "C05B", "D", "G01", "M02", "P03A", "R01", "R02",
-					"R03A", "R03B", "S"));
+	private static final List<String> LOCALLY_APPLIED_ATC_GROUPS = Collections
+			.unmodifiableList(Arrays.asList("A01", "A07A", "A07E", "B02BC", "B05C", "C05A", "C05B",
+					"D", "G01", "G02CC", "M02", "P03A", "R01", "R02", "R03A", "R03B", "S"));
 
 	/**
 	 * The groups nested INSIDE {@link #LOCALLY_APPLIED_ATC_GROUPS} that ATC itself names "for systemic
@@ -326,9 +337,11 @@ public class DrugReference {
 	 * preparations, {@code R01B} nasal decongestants. Same criterion as the list above, applied to the
 	 * same words: a group is read as locally applied when its own name says where it is applied, and
 	 * these four say the opposite. Without them a main-group prefix would be wrong in exactly the way
-	 * this whole rule exists to fix — measured over the shipped KB (2026-08-06), three pairs, all
-	 * psoralens: methoxsalen and trioxsalen share {@code D05AD} (topical) and {@code D05BA} (systemic)
-	 * and would be reported as sharing the topical one.
+	 * this whole rule exists to fix. Measured over the shipped KB (2026-08-06), only {@code D05B} is
+	 * reachable there, in three pairs, all psoralens: methoxsalen and trioxsalen share {@code D05AD}
+	 * (topical) and {@code D05BA} (systemic) and would be reported as sharing the topical one. The
+	 * other three change no pair in that KB and are here on ATC's wording alone, like every entry in
+	 * both lists — removing them breaks no test.
 	 *
 	 * <p>An exception list here, while R03's systemic halves are handled by leaving {@code R03C} and
 	 * {@code R03D} out of the list above, because the two groups are shaped differently: under R03 the

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -295,13 +295,17 @@ public class DrugReference {
 
 	/**
 	 * ATC groups that classify a LOCALLY APPLIED formulation rather than the substance itself, each
-	 * identified by the route or site of application in the group's own published name: {@code D}
+	 * identified by the route or site of application in the group's own published name — bar the one
+	 * exception noted at {@code C05B}: {@code D}
 	 * "Dermatologicals" and {@code S} "Sensory organs" (whole anatomical main groups), {@code A01}
 	 * "Stomatological preparations", {@code A07A} "Intestinal antiinfectives" and {@code A07E}
 	 * "Intestinal antiinflammatory agents" (its {@code A07EA} is "Corticosteroids acting locally"),
 	 * {@code B02BC} "Local hemostatics" (its {@code B02BX} sibling is "Other systemic hemostatics"),
 	 * {@code B05C} "Irrigating solutions", {@code C05A} "Antihemorrhoidals for topical use",
-	 * {@code C05B} "Antivaricose therapy" (topical heparinoids, sclerosants for local injection),
+	 * {@code C05B} "Antivaricose therapy" — the exception: that name is an indication, not a route, and
+	 * this entry rests on its subgroups' names instead ({@code C05BA} "Heparins or heparinoids for
+	 * topical use", {@code C05BB} "Sclerosing agents for local injection"); it changes no pair in the
+	 * shipped KB, whose only {@code C05B} subgroup is {@code C05BA} —
 	 * {@code G01} "Gynecological antiinfectives and antiseptics", {@code G02CC} "Antiinflammatory
 	 * products for vaginal administration" (its {@code G02CB} sibling, prolactine inhibitors, is
 	 * systemic), {@code M02} "Topical products for joint and muscular pain", {@code P03A}
@@ -358,14 +362,14 @@ public class DrugReference {
 	 * while R03 splits evenly and its two inhalant halves are shorter to name than the group plus two
 	 * exceptions.
 	 */
-	private static final List<String> SYSTEMIC_USE_ATC_GROUPS = Collections
+	private static final List<String> SYSTEMIC_USE_EXCEPTIONS = Collections
 			.unmodifiableList(Arrays.asList("D01B", "D02BB", "D05B", "D10B", "R01B"));
 
 	/**
 	 * @return whether {@code code} — a full ATC code or any prefix of one, normalized here the same
 	 *         way {@link #normalizedAtcCodes()} normalizes an entry's — sits in one of the
 	 *         {@link #LOCALLY_APPLIED_ATC_GROUPS} and not in one of the
-	 *         {@link #SYSTEMIC_USE_ATC_GROUPS} nested inside them. A substance marketed by several
+	 *         {@link #SYSTEMIC_USE_EXCEPTIONS} nested inside them. A substance marketed by several
 	 *         routes carries one code per route, so this is what separates the code that classifies
 	 *         the SUBSTANCE from the codes that classify a locally applied presentation of it. Null and
 	 *         blank are not locally applied, like every other ATC comparison here treats them: nothing
@@ -376,16 +380,17 @@ public class DrugReference {
 	 */
 	static boolean isLocallyAppliedAtcCode(String code) {
 		String normalized = normalizeAtcToken(code);
-		if (normalized == null) {
-			return false;
-		}
-		for (String group : SYSTEMIC_USE_ATC_GROUPS) {
-			if (normalized.startsWith(group)) {
-				return false;
-			}
-		}
-		for (String group : LOCALLY_APPLIED_ATC_GROUPS) {
-			if (normalized.startsWith(group)) {
+		return normalized != null && !fallsUnderAnyGroup(normalized, SYSTEMIC_USE_EXCEPTIONS)
+				&& fallsUnderAnyGroup(normalized, LOCALLY_APPLIED_ATC_GROUPS);
+	}
+
+	/** @return whether the already-normalized {@code code} sits under any of {@code groups} — the one
+	 *  definition of "an ATC code falls under a group prefix" on this side, matching what
+	 *  {@link CrossReactivityGroup#containsCode} is for curated group prefixes, so that a future
+	 *  refinement (level-boundary guarding, say) has one place to happen rather than two. */
+	private static boolean fallsUnderAnyGroup(String code, List<String> groups) {
+		for (String group : groups) {
+			if (code.startsWith(group)) {
 				return true;
 			}
 		}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -293,6 +293,55 @@ public class DrugReference {
 		return out;
 	}
 
+	/**
+	 * ATC groups that classify a LOCALLY APPLIED formulation rather than the substance itself, each
+	 * identified by the route or site of application in the group's own published name: {@code D}
+	 * "Dermatologicals" and {@code S} "Sensory organs" (whole anatomical main groups), {@code A01}
+	 * "Stomatological preparations", {@code A07E} "Intestinal antiinflammatory agents" (its
+	 * {@code A07EA} is "Corticosteroids acting locally"), {@code C05A} "Antihemorrhoidals for topical
+	 * use", {@code C05B} "Antivaricose therapy" (topical heparinoids, sclerosants for local
+	 * injection), {@code G01} "Gynecological antiinfectives and antiseptics", {@code M02} "Topical
+	 * products for joint and muscular pain", {@code P03A} "Ectoparasiticides, incl. scabicides",
+	 * {@code R01} "Nasal preparations", {@code R02} "Throat preparations", and {@code R03A} /
+	 * {@code R03B}, the two <em>inhalant</em> subgroups of R03 — their {@code R03C} / {@code R03D}
+	 * siblings are for systemic use and are deliberately absent, which is why this list cannot be
+	 * written at main-group granularity throughout.
+	 *
+	 * <p>Deliberately NOT here: {@code N01B} "Anesthetics, local". Its name is the drug class, not the
+	 * site of application — the codes classify the substance, and two local anaesthetics sharing
+	 * {@code N01BB} is exactly the cross-reactivity statement a clinician wants.
+	 *
+	 * <p>Prefixes, and not an exhaustive partition of ATC: anything unlisted counts as classifying the
+	 * substance. That is the safe direction of error for {@link DrugSafetyValidator}'s use of it — a
+	 * group wrongly listed here would demote a class that does explain a cross-reactivity concern,
+	 * while one missing from it merely leaves the pre-existing behaviour in place.
+	 */
+	private static final List<String> LOCALLY_APPLIED_ATC_GROUPS = Collections.unmodifiableList(
+			Arrays.asList("A01", "A07E", "C05A", "C05B", "D", "G01", "M02", "P03A", "R01", "R02",
+					"R03A", "R03B", "S"));
+
+	/**
+	 * @return whether {@code code} — a full ATC code or any prefix of one, normalized here the same
+	 *         way {@link #normalizedAtcCodes()} normalizes an entry's — sits in one of the
+	 *         {@link #LOCALLY_APPLIED_ATC_GROUPS}. A substance marketed by several routes carries one
+	 *         code per route, so this is what separates the code that classifies the SUBSTANCE from
+	 *         the codes that classify its topical, nasal, inhaled, ophthalmic or local-oral
+	 *         presentations. Null and blank are not locally applied, like every other ATC comparison
+	 *         here treats them: nothing is known about them at all.
+	 */
+	public static boolean isLocallyAppliedAtcCode(String code) {
+		String normalized = normalizeAtcToken(code);
+		if (normalized == null) {
+			return false;
+		}
+		for (String group : LOCALLY_APPLIED_ATC_GROUPS) {
+			if (normalized.startsWith(group)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public List<AgeBand> getAgeBands() {
 		return ageBands;
 	}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -2204,14 +2205,70 @@ public class DrugSafetyValidator {
 		return out;
 	}
 
-	/** @return the ATC level-4 subgroup {@code other} shares with {@code refClasses}, or null when none. */
+	/**
+	 * @return the ATC level-4 subgroup {@code other} shares with {@code refClasses} that best explains
+	 *         a cross-reactivity concern between them — the one classifying the SUBSTANCE where they
+	 *         share one, else the locally-applied one they do share — or null when they share none.
+	 *
+	 * <p><b>The defect this exists to fix (issue #161).</b> This returned the first shared subgroup in
+	 * the allergen's own ATC array. Every array in the shipped 19 MB KB is in ascending code order
+	 * (measured 2026-08-06: 1839 of the 1839 entries carrying codes), so "first" meant "alphabetically
+	 * smallest" — and ATC's alphabet front-loads the locally-applied groups: A01 stomatological, C05A
+	 * topical, D dermatological all sort ahead of H, J, L, M and N. A substance marketed by several
+	 * routes carries a code for each, so the chip systematically justified a systemic concern with a
+	 * topical class. Reported live against a dexamethasone allergy (issue #161): methylprednisolone as
+	 * {@code D10AA} (anti-acne preparations), an injected hydrocortisone as {@code A01AC}
+	 * (corticosteroids for local ORAL treatment) — both reproduced in-process from the same KB rows by
+	 * {@code CrossReactivityClassChoiceTest}, while prednisone, whose only shared subgroup IS
+	 * {@code H02AB}, was right in the same answer. The finding was right and its stated reason was
+	 * not, which is the failure a clinician checks and then stops trusting.
+	 *
+	 * <p><b>Why prefer the systemic class rather than match the order's route.</b> The route is not
+	 * available here, and could only ever be available on one of the two call sites. This arm runs
+	 * both for a drug the QUESTION names, which has no route at all, and for one the patient is on
+	 * ({@link #addActiveOrderContraindications}) — and even there it receives a resolved
+	 * {@link DrugReference}, not the order. Nothing carries the route that far:
+	 * {@link PatientClinicalContextBuilder} reads a {@code DrugOrder}'s name concepts and its ATC
+	 * mappings, never {@code getRoute()}, and {@link PatientClinicalContext.ActiveDrugOrder}'s display
+	 * is the order's first NAME rather than a dosing line. Route-matching is therefore not a smaller
+	 * change than this one but a larger one — a new field on the context, a route-concept-to-ATC
+	 * mapping the module does not have — and it would still leave the question-driven half of this
+	 * arm choosing by some other rule.
+	 *
+	 * <p><b>And why not report the shared level-3 group instead</b>, which the issue offers as the
+	 * answer that is coarser but never false. Measured over the shipped KB (2026-08-06; re-measure
+	 * before relying on any figure here): of the 1090 drug pairs that share more than one level-4
+	 * subgroup, <b>1041 still share more than one level-3 group</b>.
+	 * Dexamethasone and hydrocortisone share six subgroups spanning six different level-3 groups, so
+	 * the collapse removes the chemical subgroup — the part that carries the cross-reactivity claim —
+	 * without removing the choice it was supposed to settle.
+	 *
+	 * <p><b>A preference, never a filter.</b> Of those 1090 pairs, 560 share no systemic subgroup at
+	 * all: two topical azoles, two ophthalmic preparations, two local anaesthetic formulations. For
+	 * them the locally-applied class IS the honest answer and is kept. 265 pairs change; in the rest a
+	 * systemic subgroup was already being named. In 77 the systemic tier itself holds more than one
+	 * candidate and the tie-break between them is still alphabetical — both are true statements about
+	 * the substance, so this is a choice between honest answers rather than the defect above.
+	 *
+	 * <p>Sorted rather than in the allergen's array order so the result is a function of the two code
+	 * SETS and not of the position a dataset happened to write a code in. That is a no-op on the
+	 * shipped KB, whose arrays are already ascending, and is therefore not separately pinned by a
+	 * test; it is what keeps a KB refresh that reorders an array from silently rewording a chip.
+	 */
 	private static String sharedClass(Set<String> refClasses, DrugReference other) {
-		for (String cls : other.atcSubgroups()) {
-			if (refClasses.contains(cls)) {
-				return cls;
+		String locallyApplied = null;
+		for (String subgroup : new TreeSet<String>(other.atcSubgroups())) {
+			if (!refClasses.contains(subgroup)) {
+				continue;
+			}
+			if (!DrugReference.isLocallyAppliedAtcCode(subgroup)) {
+				return subgroup;
+			}
+			if (locallyApplied == null) {
+				locallyApplied = subgroup;
 			}
 		}
-		return null;
+		return locallyApplied;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -2243,17 +2243,20 @@ public class DrugSafetyValidator {
 	 * the collapse removes the chemical subgroup — the part that carries the cross-reactivity claim —
 	 * without removing the choice it was supposed to settle.
 	 *
-	 * <p><b>A preference, never a filter.</b> Of those 1090 pairs, 557 share no systemic subgroup at
+	 * <p><b>A preference, never a filter.</b> Of those 1090 pairs, 587 share no systemic subgroup at
 	 * all: two topical azoles, two ophthalmic preparations, two local anaesthetic formulations. For
-	 * them the locally-applied class IS the honest answer and is kept. 268 pairs change; in the rest a
-	 * systemic subgroup was already being named. In 87 the systemic tier itself holds more than one
-	 * candidate and the tie-break between them is still alphabetical — both are true statements about
-	 * the substance, so this is a choice between honest answers rather than the defect above.
+	 * them the locally-applied class IS the honest answer and is kept. 263 pairs change; in the rest a
+	 * systemic subgroup was already being named. In 70 the systemic tier itself holds more than one
+	 * candidate and the tie-break between them is still alphabetical (issue #168, filed against the
+	 * pre-correction count of 87) — both are true statements about the substance, so this is a choice
+	 * between honest answers rather than the defect above.
 	 *
 	 * <p>Sorted rather than in the allergen's array order so the result is a function of the two code
-	 * SETS and not of the position a dataset happened to write a code in. That is a no-op on the
-	 * shipped KB, whose arrays are already ascending, and is therefore not separately pinned by a
-	 * test; it is what keeps a KB refresh that reorders an array from silently rewording a chip.
+	 * SETS and not of the position a dataset happened to write a code in — what keeps a KB refresh that
+	 * reorders an array from silently rewording a chip. A no-op on the shipped KB, whose arrays are all
+	 * ascending, so the case that pins it
+	 * ({@code CrossReactivityClassChoiceTest.theAnswerDoesNotDependOnTheAllergenArraysCodeOrder}) is
+	 * the one fixture here that deviates from verbatim, by writing one allergen's array descending.
 	 */
 	private static String sharedClass(Set<String> refClasses, DrugReference other) {
 		String locallyApplied = null;

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -2243,13 +2243,15 @@ public class DrugSafetyValidator {
 	 * the collapse removes the chemical subgroup — the part that carries the cross-reactivity claim —
 	 * without removing the choice it was supposed to settle.
 	 *
-	 * <p><b>A preference, never a filter.</b> Of those 1090 pairs, 587 share no systemic subgroup at
-	 * all: two topical azoles, two ophthalmic preparations, two local anaesthetic formulations. For
-	 * them the locally-applied class IS the honest answer and is kept. 263 pairs change; in the rest a
-	 * systemic subgroup was already being named. In 70 the systemic tier itself holds more than one
-	 * candidate and the tie-break between them is still alphabetical (issue #168, filed against the
-	 * pre-correction count of 87) — both are true statements about the substance, so this is a choice
-	 * between honest answers rather than the defect above.
+	 * <p><b>A preference, never a filter.</b> The 1090 pairs partition into 263 whose class this
+	 * changes, 587 that share no systemic subgroup at all — two topical azoles, two ophthalmic
+	 * preparations, two local anaesthetic formulations, for which the locally-applied class IS the
+	 * honest answer and is kept — and 240 that were already naming a systemic one. A filter rather than
+	 * a preference would have to drop or fabricate a class for the 587, the largest of the three
+	 * groups. In 70 pairs the systemic tier itself holds more than one candidate and the tie-break
+	 * between them is still alphabetical (issue #168, filed against the pre-correction count of 87);
+	 * both are true statements about the substance, so that is a choice between honest answers rather
+	 * than the defect above.
 	 *
 	 * <p>Sorted rather than in the allergen's array order so the result is a function of the two code
 	 * SETS and not of the position a dataset happened to write a code in — what keeps a KB refresh that

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -2243,10 +2243,10 @@ public class DrugSafetyValidator {
 	 * the collapse removes the chemical subgroup — the part that carries the cross-reactivity claim —
 	 * without removing the choice it was supposed to settle.
 	 *
-	 * <p><b>A preference, never a filter.</b> Of those 1090 pairs, 560 share no systemic subgroup at
+	 * <p><b>A preference, never a filter.</b> Of those 1090 pairs, 557 share no systemic subgroup at
 	 * all: two topical azoles, two ophthalmic preparations, two local anaesthetic formulations. For
-	 * them the locally-applied class IS the honest answer and is kept. 265 pairs change; in the rest a
-	 * systemic subgroup was already being named. In 77 the systemic tier itself holds more than one
+	 * them the locally-applied class IS the honest answer and is kept. 268 pairs change; in the rest a
+	 * systemic subgroup was already being named. In 87 the systemic tier itself holds more than one
 	 * candidate and the tie-break between them is still alphabetical — both are true statements about
 	 * the substance, so this is a choice between honest answers rather than the defect above.
 	 *

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -592,8 +592,7 @@ public class DrugSafetyValidator {
 	 * the 3.7.1 standalone: a recorded dexamethasone allergy asked about dexamethasone gave FOUR chips,
 	 * and only the row {@link DrugReferenceService#lookupByToken} resolved the allergy to matched by
 	 * identity, so the other three fell through to the class comparison and reported the substance as
-	 * cross-reactive with the patient's allergy to <em>itself</em> ("Dexamethasone (nasal) is in the
-	 * same ATC class (A01AC) as the patient's allergy to Dexamethasone"). Since issue #110 every chip
+	 * cross-reactive with the patient's allergy to <em>itself</em>. Since issue #110 every chip
 	 * is also injected as a citable pre-answer record, so each duplicate reached the prompt as well.
 	 *
 	 * <p><b>Why a ledger rather than a filter over the finished chip list.</b> Three reasons, and the

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -169,10 +169,10 @@ public class ContraindicationRouteVariantTest {
 
 		assertEquals(2, warnings.size(),
 				"three route variants collapse and the ester stays its own chip, was: " + warnings);
-		assertEquals("Hydrocortisone is in the same ATC class (A01AC) as the patient's allergy to"
+		assertEquals("Hydrocortisone is in the same ATC class (H02AB) as the patient's allergy to"
 				+ " Dexamethasone — possible cross-reactivity", warnings.get(0).getDetail(),
 				"the surviving variant chip is the dataset's first row, named by displayLabel()");
-		assertEquals("Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy"
+		assertEquals("Hydrocortisone butyrate is in the same ATC class (H02AB) as the patient's allergy"
 				+ " to Dexamethasone — possible cross-reactivity", warnings.get(1).getDetail());
 	}
 
@@ -332,15 +332,15 @@ public class ContraindicationRouteVariantTest {
 						DrugReferenceTestSupport.set("Dexamethasone", "Hydrocortisone"), null));
 
 		assertEquals(4, warnings.size(), "two substances x two findings, was: " + warnings);
-		assertEquals("Hydrocortisone is in the same ATC class (A01AC) as the patient's allergy to"
+		assertEquals("Hydrocortisone is in the same ATC class (H02AB) as the patient's allergy to"
 				+ " Dexamethasone — possible cross-reactivity", warnings.get(0).getDetail());
 		assertEquals("The patient has a recorded allergy to Hydrocortisone.",
 				warnings.get(1).getDetail(),
 				"the identity finding about the SAME substance keeps its own chip beside the "
 						+ "cross-reactivity one");
-		assertEquals("Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy"
+		assertEquals("Hydrocortisone butyrate is in the same ATC class (H02AB) as the patient's allergy"
 				+ " to Dexamethasone — possible cross-reactivity", warnings.get(2).getDetail());
-		assertEquals("Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy"
+		assertEquals("Hydrocortisone butyrate is in the same ATC class (H02AB) as the patient's allergy"
 				+ " to Hydrocortisone — possible cross-reactivity", warnings.get(3).getDetail());
 	}
 

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
@@ -14,10 +14,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -130,7 +129,7 @@ public class CrossReactivityClassChoiceTest {
 	public void aSystemicSteroidNamesTheSystemicClassNotTheAntiAcneOne() throws IOException {
 		// Issue #161's first measured row: Solu-Medrol against a dexamethasone allergy, reported live as
 		// "(D10AA)" — anti-acne preparations.
-		List<SafetyWarning> warnings = fixtureValidator().validate("",
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
 				"Is it safe to give methylprednisolone?", DrugReferenceTestSupport.ctx(60, null, null,
 						null, DrugReferenceTestSupport.set("Dexamethasone"), null));
 
@@ -144,7 +143,7 @@ public class CrossReactivityClassChoiceTest {
 		// Issue #161's third row, and on the OTHER call site: the drug is one the patient is already on,
 		// not one the question names, so the chip comes from the order-driven arm. Reported live as
 		// "(A01AC)" — corticosteroids for local oral treatment, of an injected steroid.
-		List<SafetyWarning> warnings = fixtureValidator().validate("", NO_DRUG_QUESTION,
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", NO_DRUG_QUESTION,
 				DrugReferenceTestSupport.ctx(60, null,
 						DrugReferenceTestSupport.set("Hydrocortisone Injection vial 100mg"), null,
 						DrugReferenceTestSupport.set("Dexamethasone"), null));
@@ -160,7 +159,7 @@ public class CrossReactivityClassChoiceTest {
 		// and dexamethasone are both corticosteroids, but the KB gives budesonide no systemic code, so
 		// R01AD is the ONLY class they share. Naming it is true; naming H02AB would be a fabrication, and
 		// the issue's expectation that all three rows implicate H02AB does not survive the data.
-		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is budesonide safe for her?",
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", "Is budesonide safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Dexamethasone"), null));
 
@@ -175,7 +174,7 @@ public class CrossReactivityClassChoiceTest {
 		// preference, or if it looks at either drug's codes rather than at the SHARED ones: ketoconazole
 		// carries J02AB (systemic antimycotics) and H02CA, tioconazole carries neither, and the honest
 		// statement about two topical azoles is the topical class.
-		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is tioconazole safe for her?",
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", "Is tioconazole safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Ketoconazole"), null));
 
@@ -191,7 +190,7 @@ public class CrossReactivityClassChoiceTest {
 		// SYSTEMIC use" and D05A is the topical half of the same therapeutic group. Methoxsalen and
 		// trioxsalen share both (D05AD topical, D05BA systemic), so the systemic one has to win from
 		// inside a main group the rule otherwise treats as locally applied.
-		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is trioxsalen safe for her?",
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", "Is trioxsalen safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Methoxsalen"), null));
 
@@ -208,7 +207,7 @@ public class CrossReactivityClassChoiceTest {
 		// aminoglycosides (J01GB); A07AA is their oral, non-absorbed, gut-lumen formulation class, and
 		// it sorts first. Reachable between DIFFERENT substances and not only between route variants of
 		// one, so issue #160's collapse does not hide it.
-		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is neomycin safe for her?",
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", "Is neomycin safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Kanamycin"), null));
 
@@ -224,7 +223,7 @@ public class CrossReactivityClassChoiceTest {
 		// but locally-applied subgroups. So the answer must be the FIRST of those, not the one that
 		// merely happens to sit outside the anatomical main groups — a rule that reads B05CA as
 		// classifying the substance names it here and says something false about both drugs.
-		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is chlorhexidine safe for her?",
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", "Is chlorhexidine safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Neomycin"), null));
 
@@ -240,7 +239,7 @@ public class CrossReactivityClassChoiceTest {
 		// whole reason an ibuprofen allergy says anything about naproxen. The duplicate-therapy arm,
 		// which names the ORDER's own code instead of choosing among shared subgroups, reports M01AE
 		// for a naproxen order (DuplicateInteractionChipTest).
-		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is naproxen safe for her?",
+		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("", "Is naproxen safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Ibuprofen"), null));
 
@@ -259,10 +258,9 @@ public class CrossReactivityClassChoiceTest {
 		// 1839 KB entries that carry codes are ascending — which is why this is the one fixture that
 		// deviates. Verified by mutation on a throwaway tree: dropping the sort makes this read
 		// "(G01AF)" while every other case here stays green.
-		List<SafetyWarning> warnings = DrugReferenceTestSupport
-				.validator(DrugReferenceTestSupport.ddiFixtureService(DESCENDING_FIXTURE))
-				.validate("", "Is tioconazole safe for her?", DrugReferenceTestSupport.ctx(60, null,
-						null, null, DrugReferenceTestSupport.set("Ketoconazole"), null));
+		List<SafetyWarning> warnings = fixtureValidator(DESCENDING_FIXTURE).validate("",
+				"Is tioconazole safe for her?", DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Ketoconazole"), null));
 
 		assertEquals(1, warnings.size(), "was: " + warnings);
 		assertEquals("Tioconazole is in the same ATC class (D01AC) as the patient's allergy to"
@@ -271,24 +269,20 @@ public class CrossReactivityClassChoiceTest {
 	}
 
 	/** The subgroups {@code question}'s entry shares with {@code allergen}, sorted, through the
-	 *  production resolver and the production accessor the arm compares with. */
-	private static List<String> shared(DrugReferenceService service, String question,
+	 *  production resolver and the production accessor the arm compares with. A set intersection
+	 *  rather than a scan, deliberately: the scan is what {@code sharedClass} does, and a hand copy of
+	 *  it here would drift with the production one instead of characterising the data it is given. */
+	private static Set<String> shared(DrugReferenceService service, String question,
 			DrugReference allergen) {
 		List<DrugReference> inPlay = service.findByQuery("Is it safe to give " + question + "?");
 		assertEquals(1, inPlay.size(), question + " must resolve exactly one row, was: "
 				+ DrugReferenceTestSupport.names(inPlay));
-		Set<String> refClasses = inPlay.get(0).atcSubgroups();
-		List<String> out = new ArrayList<String>();
-		for (String subgroup : allergen.atcSubgroups()) {
-			if (refClasses.contains(subgroup)) {
-				out.add(subgroup);
-			}
-		}
-		Collections.sort(out);
+		Set<String> out = new TreeSet<String>(allergen.atcSubgroups());
+		out.retainAll(inPlay.get(0).atcSubgroups());
 		return out;
 	}
 
-	private static DrugSafetyValidator fixtureValidator() throws IOException {
-		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.ddiFixtureService(FIXTURE));
+	private static DrugSafetyValidator fixtureValidator(String fixture) throws IOException {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.ddiFixtureService(fixture));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
@@ -1,0 +1,166 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * WHICH shared ATC subgroup a cross-reactivity chip names, when the two substances share more than
+ * one (issue #161).
+ *
+ * <p><b>The defect.</b> {@code DrugSafetyValidator.sharedClass} returned the first shared level-4
+ * subgroup in the allergen's own ATC array. Every ATC array in the shipped 19 MB KB is in ascending
+ * code order (measured: 1839 of 1839 entries with codes), so "first" meant "alphabetically smallest"
+ * — and ATC's alphabet puts the locally-applied groups (A01 stomatological, C05A topical, D
+ * dermatological) ahead of the systemic ones (H, J, L, M, N). A substance marketed by several routes
+ * carries a code for each, so the chip systematically justified a systemic cross-reactivity concern
+ * with a topical class: measured live against a dexamethasone allergy, methylprednisolone was
+ * reported as {@code D10AA} (anti-acne preparations) and hydrocortisone as {@code A01AC}
+ * (corticosteroids for local ORAL treatment), while the correct {@code H02AB} appeared in the same
+ * answer for prednisone, which happens to carry no earlier shared code.
+ *
+ * <p>Asserted here on chip TEXT — the naming is the whole defect, the finding was already right —
+ * through the real {@link DrugSafetyValidator#validate} entry point, on both call sites that reach
+ * the arm (a drug the question names, and a drug the patient is already on), over rows copied
+ * field-for-field from the shipped KB.
+ *
+ * <p><b>And the two limits, pinned so the preference cannot be read as "always say systemic".</b> A
+ * pair that shares only a locally-applied subgroup keeps it (budesonide/dexamethasone share
+ * {@code R01AD} and nothing else), and a pair of topical preparations keeps theirs even when the
+ * ALLERGEN carries systemic codes of its own that the other drug does not share
+ * (ketoconazole/tioconazole). Over the shipped KB, 560 of the 1090 pairs that share more than one
+ * subgroup share no systemic one at all, so the fallback is the majority case, not a corner.
+ */
+public class CrossReactivityClassChoiceTest {
+
+	/** Six rows copied field-for-field from the shipped 19 MB KB, in KB order — the corticosteroid
+	 *  family whose route codes outnumber its systemic one, plus a topical-only azole pair. */
+	private static final String FIXTURE = "chartsearchai-test/ddi-shared-class-choice.json";
+
+	/** A question that resolves no reference drug and is not an interaction screen, so the only arm
+	 *  that can chip is the order-driven one ({@code addActiveOrderContraindications}). */
+	private static final String NO_DRUG_QUESTION = "What are her current medications?";
+
+	@Test
+	public void theFixtureReallyOffersTheArmAChoiceOfSharedSubgroups() throws IOException {
+		// The precondition every case below rests on, through the production accessors the arm itself
+		// compares with: without a CHOICE of shared subgroup there is nothing for this issue to get
+		// wrong, and the cases would pass while testing nothing.
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+		DrugReference dexamethasone = service.lookupByToken("Dexamethasone");
+		assertNotNull(dexamethasone, "the allergy must resolve to the dexamethasone row");
+		assertEquals("Dexamethasone", dexamethasone.displayLabel());
+
+		assertEquals("[D10AA, H02AB]", shared(service, "methylprednisolone", dexamethasone).toString(),
+				"methylprednisolone must share an anti-acne subgroup AND the systemic one");
+		assertEquals("[A01AC, C05AA, H02AB, S01BA, S01CB, S02BA]",
+				shared(service, "hydrocortisone", dexamethasone).toString(),
+				"and hydrocortisone six subgroups, five of them locally applied");
+		assertEquals("[R01AD]", shared(service, "budesonide", dexamethasone).toString(),
+				"while budesonide shares ONE, and it is a nasal-preparation subgroup");
+
+		DrugReference ketoconazole = service.lookupByToken("Ketoconazole");
+		assertNotNull(ketoconazole, "the second allergy must resolve too");
+		assertEquals("[D01AC, G01AF]", shared(service, "tioconazole", ketoconazole).toString(),
+				"and the azole pair shares only locally-applied subgroups");
+		assertTrue(ketoconazole.atcSubgroups().contains("J02AB"),
+				"though the ALLERGEN carries a systemic subgroup of its own — which tioconazole does "
+						+ "not share, so no rule may reach for it: " + ketoconazole.atcSubgroups());
+	}
+
+	@Test
+	public void aSystemicSteroidNamesTheSystemicClassNotTheAntiAcneOne() throws IOException {
+		// Issue #161's first measured row: Solu-Medrol against a dexamethasone allergy, reported live as
+		// "(D10AA)" — anti-acne preparations.
+		List<SafetyWarning> warnings = fixtureValidator().validate("",
+				"Is it safe to give methylprednisolone?", DrugReferenceTestSupport.ctx(60, null, null,
+						null, DrugReferenceTestSupport.set("Dexamethasone"), null));
+
+		assertEquals(1, warnings.size(), "one substance, one allergen, one chip, was: " + warnings);
+		assertEquals("Methylprednisolone is in the same ATC class (H02AB) as the patient's allergy to"
+				+ " Dexamethasone — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void aPrescribedSteroidNamesTheSystemicClassNotTheLocalOralOne() throws IOException {
+		// Issue #161's third row, and on the OTHER call site: the drug is one the patient is already on,
+		// not one the question names, so the chip comes from the order-driven arm. Reported live as
+		// "(A01AC)" — corticosteroids for local oral treatment, of an injected steroid.
+		List<SafetyWarning> warnings = fixtureValidator().validate("", NO_DRUG_QUESTION,
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Hydrocortisone Injection vial 100mg"), null,
+						DrugReferenceTestSupport.set("Dexamethasone"), null));
+
+		assertEquals(1, warnings.size(), "one order, one allergen, one chip, was: " + warnings);
+		assertEquals("Hydrocortisone is in the same ATC class (H02AB) as the patient's allergy to"
+				+ " Dexamethasone — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void aPairSharingOnlyALocallyAppliedSubgroupStillNamesIt() throws IOException {
+		// Issue #161's second row, and the limit of what a shared-class chip can honestly say: budesonide
+		// and dexamethasone are both corticosteroids, but the KB gives budesonide no systemic code, so
+		// R01AD is the ONLY class they share. Naming it is true; naming H02AB would be a fabrication, and
+		// the issue's expectation that all three rows implicate H02AB does not survive the data.
+		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is budesonide safe for her?",
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Dexamethasone"), null));
+
+		assertEquals(1, warnings.size(), "was: " + warnings);
+		assertEquals("Budesonide is in the same ATC class (R01AD) as the patient's allergy to"
+				+ " Dexamethasone — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void twoTopicalPreparationsKeepTheirTopicalClass() throws IOException {
+		// The case a "prefer the systemic class" rule gets wrong if it is a filter rather than a
+		// preference, or if it looks at either drug's codes rather than at the SHARED ones: ketoconazole
+		// carries J02AB (systemic antimycotics) and H02CA, tioconazole carries neither, and the honest
+		// statement about two topical azoles is the topical class.
+		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is tioconazole safe for her?",
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Ketoconazole"), null));
+
+		assertEquals(1, warnings.size(), "was: " + warnings);
+		assertEquals("Tioconazole is in the same ATC class (D01AC) as the patient's allergy to"
+				+ " Ketoconazole — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	/** The subgroups {@code question}'s entry shares with {@code allergen}, sorted, through the
+	 *  production resolver and the production accessor the arm compares with. */
+	private static List<String> shared(DrugReferenceService service, String question,
+			DrugReference allergen) {
+		List<DrugReference> inPlay = service.findByQuery("Is it safe to give " + question + "?");
+		assertEquals(1, inPlay.size(), question + " must resolve exactly one row, was: "
+				+ DrugReferenceTestSupport.names(inPlay));
+		Set<String> refClasses = inPlay.get(0).atcSubgroups();
+		List<String> out = new ArrayList<String>();
+		for (String subgroup : allergen.atcSubgroups()) {
+			if (refClasses.contains(subgroup)) {
+				out.add(subgroup);
+			}
+		}
+		java.util.Collections.sort(out);
+		return out;
+	}
+
+	private static DrugSafetyValidator fixtureValidator() throws IOException {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport.ddiFixtureService(FIXTURE));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
@@ -49,12 +49,12 @@ import org.junit.jupiter.api.Test;
  * subgroup share no systemic one at all, so the fallback is the common case and not a corner; the
  * figure is recorded once, in {@code DrugSafetyValidator.sharedClass}'s javadoc.
  *
- * <p><b>And the group whose route is named below the main group.</b> Three of the cases here exist
- * because a prefix list written at anatomical-main-group granularity misses those: {@code A07A}
- * "Intestinal antiinfectives", {@code B05C} "Irrigating solutions" and {@code G02CC}
- * "Antiinflammatory products for vaginal administration" all sort ahead of the systemic class their
- * pair also shares, so leaving one out does not leave the old answer in place — it makes that group
- * the new answer.
+ * <p><b>And the groups whose route is named below the anatomical main group.</b> Three cases here are
+ * the ones a prefix list written at main-group granularity gets wrong: {@code A07A} "Intestinal
+ * antiinfectives", {@code B05C} "Irrigating solutions" and {@code G02CC} "Antiinflammatory products
+ * for vaginal administration" each sort ahead of the class their pair shares that does explain the
+ * concern, so leaving one out of the list does not leave the old answer in place — it makes that
+ * group the new answer.
  */
 public class CrossReactivityClassChoiceTest {
 
@@ -109,21 +109,21 @@ public class CrossReactivityClassChoiceTest {
 		assertNotNull(kanamycin, "the fourth allergy must resolve too");
 		assertEquals("[A07AA, J01GB, S01AA]", shared(service, "neomycin", kanamycin).toString(),
 				"the aminoglycosides share an INTESTINAL-antiinfective subgroup that sorts ahead of "
-						+ "their systemic one, and A07 is not an anatomical main group in the list");
+						+ "their systemic one");
 
 		DrugReference neomycin = service.lookupByToken("Neomycin");
 		assertNotNull(neomycin, "the fifth allergy must resolve too");
 		assertEquals("[A01AB, B05CA, S02AA, S03AA]",
 				shared(service, "chlorhexidine", neomycin).toString(),
 				"while neomycin and chlorhexidine share four subgroups and NO systemic one — an "
-						+ "irrigating-solution subgroup among them, which sorts ahead of three of the "
-						+ "four but classifies a formulation like they do");
+						+ "irrigating-solution subgroup among them, which classifies a formulation "
+						+ "exactly as the other three do");
 
 		DrugReference ibuprofen = service.lookupByToken("Ibuprofen");
 		assertNotNull(ibuprofen, "the sixth allergy must resolve too");
 		assertEquals("[G02CC, M01AE, M02AA]", shared(service, "naproxen", ibuprofen).toString(),
-				"and the two commonest NSAIDs share a VAGINAL-administration subgroup that sorts "
-						+ "ahead of the propionic-acid one that actually relates them");
+				"and ibuprofen and naproxen share a VAGINAL-administration subgroup that sorts ahead "
+						+ "of the propionic-acid one that actually relates them");
 	}
 
 	@Test
@@ -206,8 +206,8 @@ public class CrossReactivityClassChoiceTest {
 		// "Intestinal antiinfectives" names its site one level down — exactly as A07E "Intestinal
 		// antiinflammatory agents" does, which the list already carries. Neomycin and kanamycin are
 		// aminoglycosides (J01GB); A07AA is their oral, non-absorbed, gut-lumen formulation class, and
-		// it sorts first. Reachable on 30 shipped-KB pairs of DIFFERENT substances, so no route-variant
-		// collapse hides it.
+		// it sorts first. Reachable between DIFFERENT substances and not only between route variants of
+		// one, so issue #160's collapse does not hide it.
 		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is neomycin safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Kanamycin"), null));
@@ -235,10 +235,11 @@ public class CrossReactivityClassChoiceTest {
 
 	@Test
 	public void twoNsaidsAreNotRelatedByAVaginalPreparationClass() throws IOException {
-		// The clinically loudest instance of the same gap, and one the alphabet reaches on the two
-		// commonest NSAIDs in the dataset: G02CC is "Antiinflammatory products for vaginal
-		// administration" and sorts ahead of M01AE, the propionic-acid subgroup that is the whole
-		// reason an ibuprofen allergy says anything about naproxen.
+		// The clinically loudest instance of the same gap: G02CC is "Antiinflammatory products for
+		// vaginal administration" and sorts ahead of M01AE, the propionic-acid subgroup that is the
+		// whole reason an ibuprofen allergy says anything about naproxen. The duplicate-therapy arm,
+		// which names the ORDER's own code instead of choosing among shared subgroups, reports M01AE
+		// for a naproxen order (DuplicateInteractionChipTest).
 		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is naproxen safe for her?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,
 						DrugReferenceTestSupport.set("Ibuprofen"), null));
@@ -250,11 +251,12 @@ public class CrossReactivityClassChoiceTest {
 
 	@Test
 	public void theAnswerDoesNotDependOnTheAllergenArraysCodeOrder() throws IOException {
-		// The invariant the sort exists for, on the only tier where array order can decide anything: a
-		// pair sharing two locally-applied subgroups and no systemic one. Ketoconazole's atc array is
-		// written descending in this fixture, so a scan in array order reaches G01AF first and reports
-		// it; the sorted scan reports D01AC either way. Not observable on a verbatim slice — all 1839
-		// KB entries that carry codes are ascending — which is why this is the one fixture that
+		// The invariant the sort exists for, on a pair that shares two subgroups of ONE tier — two
+		// locally-applied ones and no systemic one — which is where array order decides. (The systemic
+		// tier has the same property; that is issue #168's alphabetical tie-break.) Ketoconazole's atc
+		// array is written descending in this fixture, so a scan in array order reaches G01AF first and
+		// reports it; the sorted scan reports D01AC either way. Not observable on a verbatim slice — all
+		// 1839 KB entries that carry codes are ascending — which is why this is the one fixture that
 		// deviates. Verified by mutation on a throwaway tree: dropping the sort makes this read
 		// "(G01AF)" while every other case here stays green.
 		List<SafetyWarning> warnings = DrugReferenceTestSupport

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -82,6 +83,12 @@ public class CrossReactivityClassChoiceTest {
 		assertTrue(ketoconazole.atcSubgroups().contains("J02AB"),
 				"though the ALLERGEN carries a systemic subgroup of its own — which tioconazole does "
 						+ "not share, so no rule may reach for it: " + ketoconazole.atcSubgroups());
+
+		DrugReference methoxsalen = service.lookupByToken("Methoxsalen");
+		assertNotNull(methoxsalen, "the third allergy must resolve too");
+		assertEquals("[D05AD, D05BA]", shared(service, "trioxsalen", methoxsalen).toString(),
+				"and the psoralens share a topical and a systemic subgroup of ONE dermatological "
+						+ "main group, so main-group granularity alone cannot tell them apart");
 	}
 
 	@Test
@@ -142,6 +149,22 @@ public class CrossReactivityClassChoiceTest {
 				+ " Ketoconazole — possible cross-reactivity", warnings.get(0).getDetail());
 	}
 
+	@Test
+	public void aSystemicSubgroupInsideATopicalMainGroupIsStillTheSystemicOne() throws IOException {
+		// The exception ATC writes into its own naming, and the case a route-group prefix list gets
+		// wrong if it stops at the main group: D is Dermatologicals, but D05B is "Antipsoriatics for
+		// SYSTEMIC use" and D05A is the topical half of the same therapeutic group. Methoxsalen and
+		// trioxsalen share both (D05AD topical, D05BA systemic), so the systemic one has to win from
+		// inside a main group the rule otherwise treats as locally applied.
+		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is trioxsalen safe for her?",
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Methoxsalen"), null));
+
+		assertEquals(1, warnings.size(), "was: " + warnings);
+		assertEquals("Trioxsalen is in the same ATC class (D05BA) as the patient's allergy to"
+				+ " Methoxsalen — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
 	/** The subgroups {@code question}'s entry shares with {@code allergen}, sorted, through the
 	 *  production resolver and the production accessor the arm compares with. */
 	private static List<String> shared(DrugReferenceService service, String question,
@@ -156,7 +179,7 @@ public class CrossReactivityClassChoiceTest {
 				out.add(subgroup);
 			}
 		}
-		java.util.Collections.sort(out);
+		Collections.sort(out);
 		return out;
 	}
 

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/CrossReactivityClassChoiceTest.java
@@ -45,14 +45,29 @@ import org.junit.jupiter.api.Test;
  * pair that shares only a locally-applied subgroup keeps it (budesonide/dexamethasone share
  * {@code R01AD} and nothing else), and a pair of topical preparations keeps theirs even when the
  * ALLERGEN carries systemic codes of its own that the other drug does not share
- * (ketoconazole/tioconazole). Over the shipped KB, 560 of the 1090 pairs that share more than one
- * subgroup share no systemic one at all, so the fallback is the majority case, not a corner.
+ * (ketoconazole/tioconazole). Over the shipped KB the majority of the pairs that share more than one
+ * subgroup share no systemic one at all, so the fallback is the common case and not a corner; the
+ * figure is recorded once, in {@code DrugSafetyValidator.sharedClass}'s javadoc.
+ *
+ * <p><b>And the group whose route is named below the main group.</b> Three of the cases here exist
+ * because a prefix list written at anatomical-main-group granularity misses those: {@code A07A}
+ * "Intestinal antiinfectives", {@code B05C} "Irrigating solutions" and {@code G02CC}
+ * "Antiinflammatory products for vaginal administration" all sort ahead of the systemic class their
+ * pair also shares, so leaving one out does not leave the old answer in place — it makes that group
+ * the new answer.
  */
 public class CrossReactivityClassChoiceTest {
 
-	/** Six rows copied field-for-field from the shipped 19 MB KB, in KB order — the corticosteroid
-	 *  family whose route codes outnumber its systemic one, plus a topical-only azole pair. */
+	/** Rows copied field-for-field from the shipped 19 MB KB, in KB order — the corticosteroid family
+	 *  whose route codes outnumber its systemic one, a topical-only azole pair, the psoralens, and the
+	 *  three pairs whose locally-applied class is not one of the anatomical main groups. */
 	private static final String FIXTURE = "chartsearchai-test/ddi-shared-class-choice.json";
+
+	/** The same azole pair, with the ALLERGEN's {@code atc} array written descending — the one
+	 *  deviation from verbatim, because every KB array is ascending and the scan order is otherwise
+	 *  unobservable. */
+	private static final String DESCENDING_FIXTURE =
+			"chartsearchai-test/ddi-shared-class-descending-atc.json";
 
 	/** A question that resolves no reference drug and is not an interaction screen, so the only arm
 	 *  that can chip is the order-driven one ({@code addActiveOrderContraindications}). */
@@ -89,6 +104,26 @@ public class CrossReactivityClassChoiceTest {
 		assertEquals("[D05AD, D05BA]", shared(service, "trioxsalen", methoxsalen).toString(),
 				"and the psoralens share a topical and a systemic subgroup of ONE dermatological "
 						+ "main group, so main-group granularity alone cannot tell them apart");
+
+		DrugReference kanamycin = service.lookupByToken("Kanamycin");
+		assertNotNull(kanamycin, "the fourth allergy must resolve too");
+		assertEquals("[A07AA, J01GB, S01AA]", shared(service, "neomycin", kanamycin).toString(),
+				"the aminoglycosides share an INTESTINAL-antiinfective subgroup that sorts ahead of "
+						+ "their systemic one, and A07 is not an anatomical main group in the list");
+
+		DrugReference neomycin = service.lookupByToken("Neomycin");
+		assertNotNull(neomycin, "the fifth allergy must resolve too");
+		assertEquals("[A01AB, B05CA, S02AA, S03AA]",
+				shared(service, "chlorhexidine", neomycin).toString(),
+				"while neomycin and chlorhexidine share four subgroups and NO systemic one — an "
+						+ "irrigating-solution subgroup among them, which sorts ahead of three of the "
+						+ "four but classifies a formulation like they do");
+
+		DrugReference ibuprofen = service.lookupByToken("Ibuprofen");
+		assertNotNull(ibuprofen, "the sixth allergy must resolve too");
+		assertEquals("[G02CC, M01AE, M02AA]", shared(service, "naproxen", ibuprofen).toString(),
+				"and the two commonest NSAIDs share a VAGINAL-administration subgroup that sorts "
+						+ "ahead of the propionic-acid one that actually relates them");
 	}
 
 	@Test
@@ -163,6 +198,74 @@ public class CrossReactivityClassChoiceTest {
 		assertEquals(1, warnings.size(), "was: " + warnings);
 		assertEquals("Trioxsalen is in the same ATC class (D05BA) as the patient's allergy to"
 				+ " Methoxsalen — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void anIntestinalAntiinfectiveSubgroupLosesToTheSystemicOne() throws IOException {
+		// A07 is not one of the anatomical main groups the rule reads as locally applied, and A07A
+		// "Intestinal antiinfectives" names its site one level down — exactly as A07E "Intestinal
+		// antiinflammatory agents" does, which the list already carries. Neomycin and kanamycin are
+		// aminoglycosides (J01GB); A07AA is their oral, non-absorbed, gut-lumen formulation class, and
+		// it sorts first. Reachable on 30 shipped-KB pairs of DIFFERENT substances, so no route-variant
+		// collapse hides it.
+		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is neomycin safe for her?",
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Kanamycin"), null));
+
+		assertEquals(1, warnings.size(), "was: " + warnings);
+		assertEquals("Neomycin is in the same ATC class (J01GB) as the patient's allergy to"
+				+ " Kanamycin — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void anIrrigatingSolutionSubgroupDoesNotBecomeTheSystemicAnswer() throws IOException {
+		// The same gap in the direction where there is no systemic class to fall forward to: B05C
+		// "Irrigating solutions" names how it is given, and neomycin and chlorhexidine share nothing
+		// but locally-applied subgroups. So the answer must be the FIRST of those, not the one that
+		// merely happens to sit outside the anatomical main groups — a rule that reads B05CA as
+		// classifying the substance names it here and says something false about both drugs.
+		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is chlorhexidine safe for her?",
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Neomycin"), null));
+
+		assertEquals(1, warnings.size(), "was: " + warnings);
+		assertEquals("Chlorhexidine is in the same ATC class (A01AB) as the patient's allergy to"
+				+ " Neomycin — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void twoNsaidsAreNotRelatedByAVaginalPreparationClass() throws IOException {
+		// The clinically loudest instance of the same gap, and one the alphabet reaches on the two
+		// commonest NSAIDs in the dataset: G02CC is "Antiinflammatory products for vaginal
+		// administration" and sorts ahead of M01AE, the propionic-acid subgroup that is the whole
+		// reason an ibuprofen allergy says anything about naproxen.
+		List<SafetyWarning> warnings = fixtureValidator().validate("", "Is naproxen safe for her?",
+				DrugReferenceTestSupport.ctx(60, null, null, null,
+						DrugReferenceTestSupport.set("Ibuprofen"), null));
+
+		assertEquals(1, warnings.size(), "was: " + warnings);
+		assertEquals("Naproxen is in the same ATC class (M01AE) as the patient's allergy to"
+				+ " Ibuprofen — possible cross-reactivity", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void theAnswerDoesNotDependOnTheAllergenArraysCodeOrder() throws IOException {
+		// The invariant the sort exists for, on the only tier where array order can decide anything: a
+		// pair sharing two locally-applied subgroups and no systemic one. Ketoconazole's atc array is
+		// written descending in this fixture, so a scan in array order reaches G01AF first and reports
+		// it; the sorted scan reports D01AC either way. Not observable on a verbatim slice — all 1839
+		// KB entries that carry codes are ascending — which is why this is the one fixture that
+		// deviates. Verified by mutation on a throwaway tree: dropping the sort makes this read
+		// "(G01AF)" while every other case here stays green.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport
+				.validator(DrugReferenceTestSupport.ddiFixtureService(DESCENDING_FIXTURE))
+				.validate("", "Is tioconazole safe for her?", DrugReferenceTestSupport.ctx(60, null,
+						null, null, DrugReferenceTestSupport.set("Ketoconazole"), null));
+
+		assertEquals(1, warnings.size(), "was: " + warnings);
+		assertEquals("Tioconazole is in the same ATC class (D01AC) as the patient's allergy to"
+				+ " Ketoconazole — possible cross-reactivity", warnings.get(0).getDetail(),
+				"the same chip the ascending fixture produces");
 	}
 
 	/** The subgroups {@code question}'s entry shares with {@code allergen}, sorted, through the

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DirectAllergyContraindicationTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DirectAllergyContraindicationTest.java
@@ -52,11 +52,12 @@ import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.Record
  *
  * <p>That pair shares <em>two</em> level-4 subgroups, not one — {@code J01MA} (J01MA02/J01MA12,
  * fluoroquinolone antibacterials) and {@code S01AE} (S01AE03/S01AE05, ophthalmic
- * fluoroquinolones) — because DDInter files both substances under several ATC codes. {@code
- * sharedClass} returns the first of the allergen's subgroups that the drug in play also carries, so
- * the case below asserting {@code (J01MA)} is pinning the dataset's own code order as well as the
- * match; a KB refresh that reordered Ciprofloxacin's {@code atc} array would report {@code S01AE}
- * with the behaviour unchanged.
+ * fluoroquinolones) — because DDInter files both substances under several ATC codes. Since issue
+ * #161 {@code sharedClass} prefers the subgroup that classifies the substance over one that
+ * classifies a locally applied formulation, so {@code J01MA} is chosen over the ophthalmic
+ * {@code S01AE} whichever order the arrays are in, and the case below asserting {@code (J01MA)} no
+ * longer pins the dataset's code order. Both halves of what this paragraph used to say were
+ * falsified by that change and have been removed rather than renumbered.
  *
  * <p>The curated cross-reactivity groups are loaded in every case here, deliberately: the identity
  * chip has to appear for an entry the real curated data genuinely cannot classify, not merely for

--- a/api/src/test/resources/chartsearchai-test/ddi-shared-class-choice.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-shared-class-choice.json
@@ -2,10 +2,34 @@
     "metadata": {
         "schema_version": "1.0",
         "title": "Test fixture: an allergen sharing SEVERAL ATC level-4 subgroups with the drug in play",
-        "note": "Rows copied field-for-field from the 19 MB openmrs-ddi-knowledge-base DDInter 2.0 dataset, in KB order, for issue #161. Each corticosteroid shares the systemic subgroup H02AB with Dexamethasone AND at least one locally-applied subgroup that sorts ahead of it; Budesonide shares only R01AD; Ketoconazole/Tioconazole share only locally-applied subgroups; Methoxsalen/Trioxsalen share a topical and a systemic subgroup of the SAME dermatological main group (D05AD vs D05BA). Interactions are empty deliberately: this file asserts contraindication chip TEXT, and an interaction chip would have to be filtered out of every assertion."
+        "note": "Rows copied field-for-field from the 19 MB openmrs-ddi-knowledge-base DDInter 2.0 dataset, in KB order, for issue #161. Each corticosteroid shares the systemic subgroup H02AB with Dexamethasone AND at least one locally-applied subgroup that sorts ahead of it; Budesonide shares only R01AD; Ketoconazole/Tioconazole share only locally-applied subgroups; Methoxsalen/Trioxsalen share a topical and a systemic subgroup of the SAME dermatological main group (D05AD vs D05BA). The last five rows carry the locally-applied groups that are NOT an anatomical main group and whose route is named one or two levels down: Kanamycin/Neomycin share A07AA (intestinal antiinfectives) and J01GB, Neomycin/Chlorhexidine share B05CA (irrigating solutions) and nothing systemic, Ibuprofen/Naproxen share G02CC (vaginal administration) and M01AE. Interactions are empty deliberately: this file asserts contraindication chip TEXT, and an interaction chip would have to be filtered out of every assertion."
     },
     "mechanisms": {},
     "drugs": [
+        {
+            "id": "DDInter1004",
+            "name": "Kanamycin",
+            "rxcui": "6099",
+            "rxnorm_name": "kanamycin",
+            "drugbank_id": "DB01172",
+            "atc": [
+                "A07AA08",
+                "J01GB04",
+                "S01AA24"
+            ],
+            "ciel": [
+                {
+                    "code": "78385",
+                    "uuid": "78385AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Kanamycin"
+                },
+                {
+                    "code": "78386",
+                    "uuid": "78386AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Kanamycin sulfate"
+                }
+            ]
+        },
         {
             "id": "DDInter1008",
             "name": "Ketoconazole",
@@ -94,6 +118,210 @@
             ]
         },
         {
+            "id": "DDInter1266",
+            "name": "Naproxen",
+            "rxcui": "7258",
+            "rxnorm_name": "naproxen",
+            "drugbank_id": "DB00788",
+            "atc": [
+                "G02CC02",
+                "M01AE02",
+                "M02AA12"
+            ],
+            "ciel": [
+                {
+                    "code": "105089",
+                    "uuid": "105089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Naproxen / pseudoephedrine"
+                },
+                {
+                    "code": "80395",
+                    "uuid": "80395AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Naproxen"
+                },
+                {
+                    "code": "80396",
+                    "uuid": "80396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Naproxen sodium"
+                }
+            ]
+        },
+        {
+            "id": "DDInter1277",
+            "name": "Neomycin",
+            "rxcui": "7299",
+            "rxnorm_name": "neomycin",
+            "drugbank_id": "DB00994",
+            "atc": [
+                "A01AB08",
+                "A07AA01",
+                "B05CA09",
+                "D06AX04",
+                "J01GB05",
+                "R02AB01",
+                "S01AA03",
+                "S02AA07",
+                "S03AA01"
+            ],
+            "ciel": [
+                {
+                    "code": "103596",
+                    "uuid": "103596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Antipyrine / hydrocortisone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "103765",
+                    "uuid": "103765AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / diperodon / neomycin"
+                },
+                {
+                    "code": "103766",
+                    "uuid": "103766AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / diperodon / neomycin / polymyxin B"
+                },
+                {
+                    "code": "103767",
+                    "uuid": "103767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / hydrocortisone / neomycin"
+                },
+                {
+                    "code": "103768",
+                    "uuid": "103768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / hydrocortisone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "103769",
+                    "uuid": "103769AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / lidocaine / neomycin"
+                },
+                {
+                    "code": "103770",
+                    "uuid": "103770AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / lidocaine / neomycin / polymyxin B"
+                },
+                {
+                    "code": "103772",
+                    "uuid": "103772AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / neomycin / polymyxin B"
+                },
+                {
+                    "code": "103773",
+                    "uuid": "103773AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / neomycin / polymyxin B / pramoxine"
+                },
+                {
+                    "code": "103906",
+                    "uuid": "103906AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Betamethasone / neomycin"
+                },
+                {
+                    "code": "104177",
+                    "uuid": "104177AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine / neomycin"
+                },
+                {
+                    "code": "104388",
+                    "uuid": "104388AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Colistin / hydrocortisone / neomycin / thonzonium"
+                },
+                {
+                    "code": "104424",
+                    "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / neomycin"
+                },
+                {
+                    "code": "104425",
+                    "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "104666",
+                    "uuid": "104666AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Fluocinolone / neomycin"
+                },
+                {
+                    "code": "104675",
+                    "uuid": "104675AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Flurandrenolone / neomycin"
+                },
+                {
+                    "code": "104767",
+                    "uuid": "104767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Gramicidin / neomycin / polymyxin B"
+                },
+                {
+                    "code": "104861",
+                    "uuid": "104861AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / neomycin"
+                },
+                {
+                    "code": "104862",
+                    "uuid": "104862AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "104978",
+                    "uuid": "104978AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Lidocaine / neomycin / polymyxin B"
+                },
+                {
+                    "code": "105069",
+                    "uuid": "105069AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Methylprednisolone / neomycin"
+                },
+                {
+                    "code": "105091",
+                    "uuid": "105091AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Neomycin / polymyxin B"
+                },
+                {
+                    "code": "105092",
+                    "uuid": "105092AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Neomycin / polymyxin B / pramoxine"
+                },
+                {
+                    "code": "105093",
+                    "uuid": "105093AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Neomycin / polymyxin B / prednisolone"
+                },
+                {
+                    "code": "105094",
+                    "uuid": "105094AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Neomycin / prednisolone"
+                },
+                {
+                    "code": "105095",
+                    "uuid": "105095AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Neomycin / triamcinolone"
+                },
+                {
+                    "code": "162168",
+                    "uuid": "162168AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / neomycin"
+                },
+                {
+                    "code": "170695",
+                    "uuid": "1452ac5f-104f-417f-b3da-5ddb2eef4f5d",
+                    "name": "Neomycin / nystatin / polymyxin B"
+                },
+                {
+                    "code": "170696",
+                    "uuid": "6adb14a6-7dbe-43ef-93e0-5b808277dd19",
+                    "name": "Metronidazole / neomycin / nystatin"
+                },
+                {
+                    "code": "80514",
+                    "uuid": "80514AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Neomycin"
+                },
+                {
+                    "code": "80516",
+                    "uuid": "80516AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Neomycin sulfate"
+                }
+            ]
+        },
+        {
             "id": "DDInter1813",
             "name": "Tioconazole",
             "rxcui": "38298",
@@ -151,6 +379,85 @@
                     "code": "72484",
                     "uuid": "72484AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "name": "Budesonide"
+                }
+            ]
+        },
+        {
+            "id": "DDInter356",
+            "name": "Chlorhexidine",
+            "rxcui": "2358",
+            "rxnorm_name": "chlorhexidine",
+            "drugbank_id": "DB00878",
+            "atc": [
+                "A01AB03",
+                "B05CA02",
+                "D08AC02",
+                "D09AA12",
+                "R02AA05",
+                "S01AX09",
+                "S02AA09",
+                "S03AA04"
+            ],
+            "ciel": [
+                {
+                    "code": "104160",
+                    "uuid": "104160AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Cetrimide / chlorhexidine"
+                },
+                {
+                    "code": "104174",
+                    "uuid": "104174AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine / chlorobutanol"
+                },
+                {
+                    "code": "104176",
+                    "uuid": "104176AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine / lidocaine"
+                },
+                {
+                    "code": "104177",
+                    "uuid": "104177AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine / neomycin"
+                },
+                {
+                    "code": "104179",
+                    "uuid": "104179AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine / sodium nitrite"
+                },
+                {
+                    "code": "104180",
+                    "uuid": "104180AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine / tetracaine"
+                },
+                {
+                    "code": "104181",
+                    "uuid": "104181AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine / tolnaftate"
+                },
+                {
+                    "code": "170034",
+                    "uuid": "9fc9ce1a-003b-4694-ad84-ac8f0bc62e21",
+                    "name": "Chlorhexidine / chlorobutanol / docusate"
+                },
+                {
+                    "code": "73263",
+                    "uuid": "73263AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine"
+                },
+                {
+                    "code": "73264",
+                    "uuid": "73264AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine acetate"
+                },
+                {
+                    "code": "73265",
+                    "uuid": "73265AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine gluconate"
+                },
+                {
+                    "code": "73266",
+                    "uuid": "73266AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorhexidine hydrochloride"
                 }
             ]
         },
@@ -513,6 +820,77 @@
                     "code": "77726",
                     "uuid": "77726AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "name": "Hydrocortisone valerate"
+                }
+            ]
+        },
+        {
+            "id": "DDInter900",
+            "name": "Ibuprofen",
+            "rxcui": "5640",
+            "rxnorm_name": "ibuprofen",
+            "drugbank_id": "DB01050",
+            "atc": [
+                "C01EB16",
+                "G02CC01",
+                "M01AE01",
+                "M02AA13",
+                "R02AX02"
+            ],
+            "ciel": [
+                {
+                    "code": "104246",
+                    "uuid": "104246AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorpheniramine / ibuprofen / pseudoephedrine"
+                },
+                {
+                    "code": "104370",
+                    "uuid": "104370AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Codeine / ibuprofen"
+                },
+                {
+                    "code": "104513",
+                    "uuid": "104513AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Diphenhydramine / ibuprofen"
+                },
+                {
+                    "code": "104847",
+                    "uuid": "104847AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocodone / ibuprofen"
+                },
+                {
+                    "code": "104893",
+                    "uuid": "104893AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ibuprofen / levomenthol"
+                },
+                {
+                    "code": "104894",
+                    "uuid": "104894AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ibuprofen / oxycodone"
+                },
+                {
+                    "code": "104895",
+                    "uuid": "104895AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ibuprofen / pseudoephedrine"
+                },
+                {
+                    "code": "104896",
+                    "uuid": "104896AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ibuprofen / pseudoisocytidine"
+                },
+                {
+                    "code": "170013",
+                    "uuid": "58b26824-eb90-4585-abd3-e9ce096e2010",
+                    "name": "Acetaminophen / ibuprofen"
+                },
+                {
+                    "code": "77897",
+                    "uuid": "77897AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ibuprofen"
+                },
+                {
+                    "code": "84137",
+                    "uuid": "84137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Solufenum"
                 }
             ]
         }

--- a/api/src/test/resources/chartsearchai-test/ddi-shared-class-choice.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-shared-class-choice.json
@@ -2,7 +2,7 @@
     "metadata": {
         "schema_version": "1.0",
         "title": "Test fixture: an allergen sharing SEVERAL ATC level-4 subgroups with the drug in play",
-        "note": "Rows copied field-for-field from the 19 MB openmrs-ddi-knowledge-base DDInter 2.0 dataset, in KB order, for issue #161. Each corticosteroid shares the systemic subgroup H02AB with Dexamethasone AND at least one locally-applied subgroup that sorts ahead of it; Budesonide shares only R01AD; Ketoconazole/Tioconazole share only locally-applied subgroups. Interactions are empty deliberately: this file asserts contraindication chip TEXT, and an interaction chip would have to be filtered out of every assertion."
+        "note": "Rows copied field-for-field from the 19 MB openmrs-ddi-knowledge-base DDInter 2.0 dataset, in KB order, for issue #161. Each corticosteroid shares the systemic subgroup H02AB with Dexamethasone AND at least one locally-applied subgroup that sorts ahead of it; Budesonide shares only R01AD; Ketoconazole/Tioconazole share only locally-applied subgroups; Methoxsalen/Trioxsalen share a topical and a systemic subgroup of the SAME dermatological main group (D05AD vs D05BA). Interactions are empty deliberately: this file asserts contraindication chip TEXT, and an interaction chip would have to be filtered out of every assertion."
     },
     "mechanisms": {},
     "drugs": [
@@ -23,6 +23,24 @@
                     "code": "78476",
                     "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "name": "Ketoconazole"
+                }
+            ]
+        },
+        {
+            "id": "DDInter1177",
+            "name": "Methoxsalen",
+            "rxcui": "6854",
+            "rxnorm_name": "methoxsalen",
+            "drugbank_id": "DB00553",
+            "atc": [
+                "D05AD02",
+                "D05BA02"
+            ],
+            "ciel": [
+                {
+                    "code": "79706",
+                    "uuid": "79706AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Methoxsalen"
                 }
             ]
         },
@@ -90,6 +108,24 @@
                     "code": "85156",
                     "uuid": "85156AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                     "name": "Tioconazole"
+                }
+            ]
+        },
+        {
+            "id": "DDInter1877",
+            "name": "Trioxsalen",
+            "rxcui": "10844",
+            "rxnorm_name": "trioxsalen",
+            "drugbank_id": "DB04571",
+            "atc": [
+                "D05AD01",
+                "D05BA01"
+            ],
+            "ciel": [
+                {
+                    "code": "85524",
+                    "uuid": "85524AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Trioxsalen"
                 }
             ]
         },

--- a/api/src/test/resources/chartsearchai-test/ddi-shared-class-choice.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-shared-class-choice.json
@@ -1,0 +1,485 @@
+{
+    "metadata": {
+        "schema_version": "1.0",
+        "title": "Test fixture: an allergen sharing SEVERAL ATC level-4 subgroups with the drug in play",
+        "note": "Rows copied field-for-field from the 19 MB openmrs-ddi-knowledge-base DDInter 2.0 dataset, in KB order, for issue #161. Each corticosteroid shares the systemic subgroup H02AB with Dexamethasone AND at least one locally-applied subgroup that sorts ahead of it; Budesonide shares only R01AD; Ketoconazole/Tioconazole share only locally-applied subgroups. Interactions are empty deliberately: this file asserts contraindication chip TEXT, and an interaction chip would have to be filtered out of every assertion."
+    },
+    "mechanisms": {},
+    "drugs": [
+        {
+            "id": "DDInter1008",
+            "name": "Ketoconazole",
+            "rxcui": "6135",
+            "rxnorm_name": "ketoconazole",
+            "drugbank_id": "DB01026",
+            "atc": [
+                "D01AC08",
+                "G01AF11",
+                "H02CA03",
+                "J02AB02"
+            ],
+            "ciel": [
+                {
+                    "code": "78476",
+                    "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ketoconazole"
+                }
+            ]
+        },
+        {
+            "id": "DDInter1191",
+            "name": "Methylprednisolone",
+            "rxcui": "6902",
+            "rxnorm_name": "methylprednisolone",
+            "drugbank_id": "DB00959",
+            "atc": [
+                "D07AA01",
+                "D10AA02",
+                "H02AB04"
+            ],
+            "ciel": [
+                {
+                    "code": "104977",
+                    "uuid": "104977AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Lidocaine / methylprednisolone"
+                },
+                {
+                    "code": "105069",
+                    "uuid": "105069AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Methylprednisolone / neomycin"
+                },
+                {
+                    "code": "70035",
+                    "uuid": "70035AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "6 alpha-methylprednisolone sodium hemisuccinate"
+                },
+                {
+                    "code": "79743",
+                    "uuid": "79743AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Methylprednisolone"
+                },
+                {
+                    "code": "79744",
+                    "uuid": "79744AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Methylprednisolone aceponate"
+                },
+                {
+                    "code": "79745",
+                    "uuid": "79745AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Methylprednisolone acetate"
+                },
+                {
+                    "code": "79746",
+                    "uuid": "79746AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Methylprednisolone sodium phosphate"
+                }
+            ]
+        },
+        {
+            "id": "DDInter1813",
+            "name": "Tioconazole",
+            "rxcui": "38298",
+            "rxnorm_name": "tioconazole",
+            "drugbank_id": "DB01007",
+            "atc": [
+                "D01AC07",
+                "G01AF08"
+            ],
+            "ciel": [
+                {
+                    "code": "85156",
+                    "uuid": "85156AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Tioconazole"
+                }
+            ]
+        },
+        {
+            "id": "DDInter246",
+            "name": "Budesonide",
+            "rxcui": "19831",
+            "rxnorm_name": "budesonide",
+            "drugbank_id": "DB01222",
+            "atc": [
+                "A07EA06",
+                "D07AC09",
+                "R01AD05",
+                "R03BA02"
+            ],
+            "ciel": [
+                {
+                    "code": "103955",
+                    "uuid": "103955AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Budesonide / formoterol"
+                },
+                {
+                    "code": "72484",
+                    "uuid": "72484AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Budesonide"
+                }
+            ]
+        },
+        {
+            "id": "DDInter513",
+            "name": "Dexamethasone",
+            "rxcui": "3264",
+            "rxnorm_name": "dexamethasone",
+            "drugbank_id": "DB01234",
+            "atc": [
+                "A01AC02",
+                "C05AA09",
+                "D07AB19",
+                "D07XB05",
+                "D10AA03",
+                "H02AB02",
+                "R01AD03",
+                "S01BA01",
+                "S01CB01",
+                "S02BA06",
+                "S03BA01"
+            ],
+            "ciel": [
+                {
+                    "code": "104317",
+                    "uuid": "104317AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ciprofloxacin / dexamethasone"
+                },
+                {
+                    "code": "104422",
+                    "uuid": "104422AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / hypromellose"
+                },
+                {
+                    "code": "104423",
+                    "uuid": "104423AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / lidocaine"
+                },
+                {
+                    "code": "104424",
+                    "uuid": "104424AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / neomycin"
+                },
+                {
+                    "code": "104425",
+                    "uuid": "104425AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "104426",
+                    "uuid": "104426AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / tobramycin"
+                },
+                {
+                    "code": "104427",
+                    "uuid": "104427AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone / tramazoline"
+                },
+                {
+                    "code": "168548",
+                    "uuid": "f5c7c86c-2b95-42d4-95f2-6d9e8949f39e",
+                    "name": "Dexamethasone / gentamicin"
+                },
+                {
+                    "code": "170697",
+                    "uuid": "d2a620d9-138d-4125-a84a-7ddbf3b2ee45",
+                    "name": "Dexamethasone / framycetin"
+                },
+                {
+                    "code": "74609",
+                    "uuid": "74609AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone"
+                },
+                {
+                    "code": "74610",
+                    "uuid": "74610AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone acetate"
+                },
+                {
+                    "code": "74612",
+                    "uuid": "74612AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone isonicotinate"
+                },
+                {
+                    "code": "74613",
+                    "uuid": "74613AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone phosphate"
+                },
+                {
+                    "code": "74614",
+                    "uuid": "74614AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone sodium phosphate"
+                },
+                {
+                    "code": "74615",
+                    "uuid": "74615AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dexamethasone trimethyl acetate"
+                }
+            ]
+        },
+        {
+            "id": "DDInter885",
+            "name": "Hydrocortisone",
+            "rxcui": "5492",
+            "rxnorm_name": "hydrocortisone",
+            "drugbank_id": "DB00741",
+            "atc": [
+                "A01AC03",
+                "A07EA02",
+                "C05AA01",
+                "D07AA02",
+                "D07XA01",
+                "H02AB09",
+                "S01BA02",
+                "S01CB03",
+                "S02BA01"
+            ],
+            "ciel": [
+                {
+                    "code": "103309",
+                    "uuid": "103309AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Acetic acid / hydrocortisone"
+                },
+                {
+                    "code": "103596",
+                    "uuid": "103596AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Antipyrine / hydrocortisone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "103767",
+                    "uuid": "103767AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / hydrocortisone / neomycin"
+                },
+                {
+                    "code": "103768",
+                    "uuid": "103768AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Bacitracin / hydrocortisone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "103818",
+                    "uuid": "103818AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Benzalkonium / chloroxylenol / hydrocortisone"
+                },
+                {
+                    "code": "103886",
+                    "uuid": "103886AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Benzoyl peroxide / hydrocortisone"
+                },
+                {
+                    "code": "104168",
+                    "uuid": "104168AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chloramphenicol / hydrocortisone"
+                },
+                {
+                    "code": "104169",
+                    "uuid": "104169AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chloramphenicol / hydrocortisone / polymyxin B"
+                },
+                {
+                    "code": "104170",
+                    "uuid": "104170AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorcyclizine / hydrocortisone"
+                },
+                {
+                    "code": "104201",
+                    "uuid": "104201AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chloroxylenol / hydrocortisone / pramoxine"
+                },
+                {
+                    "code": "104244",
+                    "uuid": "104244AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorpheniramine / hydrocortisone / pheniramine / pyrilamine"
+                },
+                {
+                    "code": "104245",
+                    "uuid": "104245AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorpheniramine / hydrocortisone / pyrilamine"
+                },
+                {
+                    "code": "104270",
+                    "uuid": "104270AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Chlorquinaldol / hydrocortisone"
+                },
+                {
+                    "code": "104318",
+                    "uuid": "104318AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ciprofloxacin / hydrocortisone"
+                },
+                {
+                    "code": "104334",
+                    "uuid": "104334AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Clioquinol / coal tar / hydrocortisone"
+                },
+                {
+                    "code": "104337",
+                    "uuid": "104337AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Clioquinol / hydrocortisone"
+                },
+                {
+                    "code": "104338",
+                    "uuid": "104338AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Clioquinol / hydrocortisone / pramoxine"
+                },
+                {
+                    "code": "104340",
+                    "uuid": "104340AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Clotrimazole / hydrocortisone"
+                },
+                {
+                    "code": "104388",
+                    "uuid": "104388AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Colistin / hydrocortisone / neomycin / thonzonium"
+                },
+                {
+                    "code": "104396",
+                    "uuid": "104396AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Crotamiton / hydrocortisone"
+                },
+                {
+                    "code": "104481",
+                    "uuid": "104481AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Dibucaine / hydrocortisone"
+                },
+                {
+                    "code": "104509",
+                    "uuid": "104509AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Diperodon / hydrocortisone / zinc oxide"
+                },
+                {
+                    "code": "104512",
+                    "uuid": "104512AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Diphenhydramine / hydrocortisone"
+                },
+                {
+                    "code": "104563",
+                    "uuid": "104563AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Econazole / hydrocortisone"
+                },
+                {
+                    "code": "104696",
+                    "uuid": "104696AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Fusidate / hydrocortisone"
+                },
+                {
+                    "code": "104706",
+                    "uuid": "104706AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Gentamicin sulfate (usp) / hydrocortisone"
+                },
+                {
+                    "code": "104819",
+                    "uuid": "104819AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hexachlorophene / hydrocortisone / menthol"
+                },
+                {
+                    "code": "104857",
+                    "uuid": "104857AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / iodoquinol"
+                },
+                {
+                    "code": "104859",
+                    "uuid": "104859AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / lidocaine"
+                },
+                {
+                    "code": "104860",
+                    "uuid": "104860AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / miconazole"
+                },
+                {
+                    "code": "104861",
+                    "uuid": "104861AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / neomycin"
+                },
+                {
+                    "code": "104862",
+                    "uuid": "104862AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / neomycin / polymyxin B"
+                },
+                {
+                    "code": "104863",
+                    "uuid": "104863AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / oxytetracycline"
+                },
+                {
+                    "code": "104864",
+                    "uuid": "104864AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / polymyxin B"
+                },
+                {
+                    "code": "104865",
+                    "uuid": "104865AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / pramoxine"
+                },
+                {
+                    "code": "104866",
+                    "uuid": "104866AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / salicylic acid / sodium thiosulfate"
+                },
+                {
+                    "code": "104867",
+                    "uuid": "104867AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / salicylic acid / sulfur"
+                },
+                {
+                    "code": "104868",
+                    "uuid": "104868AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone / sulfur / zinc oxide"
+                },
+                {
+                    "code": "165454",
+                    "uuid": "165454AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Aluminium subacetate / hydrocortisone acetate / lidocaine / zinc oxide"
+                },
+                {
+                    "code": "73950",
+                    "uuid": "73950AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Cortisol succinate"
+                },
+                {
+                    "code": "77714",
+                    "uuid": "77714AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone"
+                },
+                {
+                    "code": "77716",
+                    "uuid": "77716AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone 17-butyrate 21-propionate"
+                },
+                {
+                    "code": "77718",
+                    "uuid": "77718AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone aceponate"
+                },
+                {
+                    "code": "77719",
+                    "uuid": "77719AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone acetate"
+                },
+                {
+                    "code": "77720",
+                    "uuid": "77720AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone butyrate"
+                },
+                {
+                    "code": "77721",
+                    "uuid": "77721AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone cypionate"
+                },
+                {
+                    "code": "77724",
+                    "uuid": "77724AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone sodium phosphate"
+                },
+                {
+                    "code": "77725",
+                    "uuid": "77725AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone sodium succinate"
+                },
+                {
+                    "code": "77726",
+                    "uuid": "77726AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Hydrocortisone valerate"
+                }
+            ]
+        }
+    ],
+    "interactions": []
+}

--- a/api/src/test/resources/chartsearchai-test/ddi-shared-class-descending-atc.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-shared-class-descending-atc.json
@@ -1,0 +1,49 @@
+{
+    "metadata": {
+        "schema_version": "1.0",
+        "title": "Test fixture: the ALLERGEN row with its atc array written in DESCENDING code order",
+        "note": "The Ketoconazole and Tioconazole rows of ddi-shared-class-choice.json, field-for-field from the 19 MB openmrs-ddi-knowledge-base DDInter 2.0 dataset, with ONE deliberate deviation: Ketoconazole's atc array is written in descending code order. sharedClass scans the ALLERGEN's subgroups, and all 1839 KB entries that carry codes are in ascending order, so a verbatim slice cannot observe whether the scan depends on array position. This pair shares two locally-applied subgroups and no systemic one (D01AC, G01AF), which is the only tier where the order of equals decides the answer. Interactions are empty for the same reason as the sibling fixture."
+    },
+    "mechanisms": {},
+    "drugs": [
+        {
+            "id": "DDInter1008",
+            "name": "Ketoconazole",
+            "rxcui": "6135",
+            "rxnorm_name": "ketoconazole",
+            "drugbank_id": "DB01026",
+            "atc": [
+                "J02AB02",
+                "H02CA03",
+                "G01AF11",
+                "D01AC08"
+            ],
+            "ciel": [
+                {
+                    "code": "78476",
+                    "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Ketoconazole"
+                }
+            ]
+        },
+        {
+            "id": "DDInter1813",
+            "name": "Tioconazole",
+            "rxcui": "38298",
+            "rxnorm_name": "tioconazole",
+            "drugbank_id": "DB01007",
+            "atc": [
+                "D01AC07",
+                "G01AF08"
+            ],
+            "ciel": [
+                {
+                    "code": "85156",
+                    "uuid": "85156AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                    "name": "Tioconazole"
+                }
+            ]
+        }
+    ],
+    "interactions": []
+}


### PR DESCRIPTION
## The defect

`DrugSafetyValidator.sharedClass` returned the **first** shared ATC level-4 subgroup in the
*allergen's* own ATC array. A corticosteroid carries one code per route it is marketed in, so the
chip justified a systemic cross-reactivity concern with a topical class. Against a dexamethasone
allergy, methylprednisolone read `(D10AA)` — anti-acne preparations — and an injected hydrocortisone
read `(A01AC)`, corticosteroids for local *oral* treatment. The finding was right and the reason it
gave was not, which is the failure a clinician checks before deciding whether to trust the feature.

## Root cause

Not "an arbitrary list position" in general, but a specific and systematic bias. **Every ATC array
in the shipped 19 MB KB is in ascending code order** — measured, 1839 of the 1839 entries that carry
codes — so "first" meant "alphabetically smallest", and ATC's alphabet front-loads the locally
applied groups: `A01` stomatological, `C05A` topical, `D` dermatological all sort ahead of `H`,
`J`, `L`, `M`, `N`. The arm was not picking a class at random; it was picking the most topical one
available, every time.

## What changed

`sharedClass` now prefers the shared subgroup that classifies the **substance** over one that
classifies a **locally applied formulation**, and falls back to the locally applied one when that is
all the pair shares. The route/site knowledge is one prefix list on `DrugReference`
(`isLocallyAppliedAtcCode`), every entry justified by the route or site named in the ATC group's own
published name — `D` Dermatologicals, `S` Sensory organs, `A01` Stomatological preparations, `R01`
Nasal preparations, `R03A`/`R03B` the inhalant subgroups of R03, and so on — minus the four groups
nested inside those that ATC itself names *"for systemic use"* (`D01B`, `D05B`, `D10B`, `R01B`).
That exception is not hypothetical: without it methoxsalen and trioxsalen, which share `D05AD`
(topical) and `D05BA` (systemic), are reported as sharing the topical one — three pairs in the
shipped KB, and its own test. Candidates are examined in code order rather than array order, so the
answer is a function of the two code sets rather than of where a dataset happened to write a code.

### Why this direction and not the other two the issue lists

- **Match the route of the active order.** The route is not available at this seam, and could only
  ever be available on one of the two call sites. The arm runs both for a drug the *question* names
  — which has no route at all — and for one the patient is already on, where it receives a resolved
  `DrugReference` rather than the order. Nothing carries the route that far:
  `PatientClinicalContextBuilder` reads a `DrugOrder`'s name concepts and its ATC mappings and never
  calls `getRoute()` (that string does not occur anywhere in `api/src/main/java` except this PR's
  own javadoc), and `ActiveDrugOrder`'s display is the order's first *name*, not a dosing line. It
  is the larger change, not the smaller one — a new field on the context plus a route-concept-to-ATC
  mapping the module does not have — and it would still leave half the arm choosing by some other
  rule.
- **Report the shared level-3 group.** Measured and rejected: of the 1090 KB pairs that share more
  than one level-4 subgroup, **1041 still share more than one level-3 group**. Dexamethasone and
  hydrocortisone share six subgroups spanning six *different* level-3 groups. Level 3 does not
  collapse these to one honest answer — it gives the same arbitrary choice one grain coarser, minus
  the chemical subgroup that carries the cross-reactivity claim. Being right at a coarser grain
  would have been a defensible product call; on this data it is not available.

### A preference, never a filter

557 of those 1090 pairs share **no** systemic subgroup at all — two topical azoles, two ophthalmic
preparations, two local anaesthetic formulations. For them the locally applied class is the honest
answer and is kept unchanged. 268 pairs change. In 87 the systemic tier itself holds more than one
candidate and the tie-break stays alphabetical; those are choices between true statements, not the
defect above.

## Live evidence

Both captures on the 3.7.1 standalone, `sourceFormat=ddinter`, 2283 entries, confirmed each time
with `GET /chartsearchai/drugreferencestatus`. **Before** is a build of `main` (`f7d4e07`) made and
deployed for this comparison, not a remembered reading; **after** is this branch, and the deployed
omod's `DrugReference.class` and `DrugSafetyValidator.class` are md5-identical to the ones this
branch compiles. Patients resolved by name lookup against the live DB.

### The measured case — Sarah Taylor, 8 active orders, coded Dexamethasone allergy

`dc8560c9-6d2b-45bf-861c-8fcf562ec9b1`, asked *"What are her current medications?"* — a question
naming no drug, so every chip below comes from the order-driven arm.

**Before (`main` f7d4e07):**

```
--- safetyWarnings (6) ---
  [contraindication] drug='Dexamethasone'
      The patient has a recorded allergy to Dexamethasone.
  [contraindication] drug='Hydrocortisone'
      Hydrocortisone is in the same ATC class (A01AC) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Hydrocortisone butyrate'
      Hydrocortisone butyrate is in the same ATC class (A01AC) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Prednisone'
      Prednisone is in the same ATC class (H02AB) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Budesonide'
      Budesonide is in the same ATC class (R01AD) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Methylprednisolone'
      Methylprednisolone is in the same ATC class (D10AA) as the patient's allergy to Dexamethasone — possible cross-reactivity
```

**After (this branch):**

```
--- safetyWarnings (6) ---
  [contraindication] drug='Dexamethasone'
      The patient has a recorded allergy to Dexamethasone.
  [contraindication] drug='Hydrocortisone'
      Hydrocortisone is in the same ATC class (H02AB) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Hydrocortisone butyrate'
      Hydrocortisone butyrate is in the same ATC class (H02AB) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Prednisone'
      Prednisone is in the same ATC class (H02AB) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Budesonide'
      Budesonide is in the same ATC class (R01AD) as the patient's allergy to Dexamethasone — possible cross-reactivity
  [contraindication] drug='Methylprednisolone'
      Methylprednisolone is in the same ATC class (H02AB) as the patient's allergy to Dexamethasone — possible cross-reactivity
```

Three chips corrected, three deliberately unmoved. **Prednisone** stays `H02AB` because it was
already right; **Budesonide** stays `R01AD` because the KB gives budesonide no systemic code at all,
so `R01AD` is the only class the pair shares — the issue's expectation that all three of its rows
implicate `H02AB` does not survive the data, and inventing `H02AB` here would be a fabrication.
Had the fix been wrong in the obvious way — a filter for systemic classes rather than a preference —
the Budesonide chip would have named `H02AB` or disappeared.

### The must-stay-topical case — Betty Williams

`a7090f70-99b7-4fd9-b60d-f8e0cdee07f6`, given a coded **Ketoconazole** allergy for this test, asked
*"Is it safe to give tioconazole?"*. Ketoconazole carries systemic codes of its own (`J02AB`
antimycotics for systemic use, `H02CA`); tioconazole shares neither, so the only honest answer is
the topical one. Identical before and after:

```
--- safetyWarnings (1) ---
  [contraindication] drug='Tioconazole'
      Tioconazole is in the same ATC class (D01AC) as the patient's allergy to Ketoconazole — possible cross-reactivity
```

Had the rule reached for a systemic class rather than a shared systemic class, this would read
`(J02AB)` — a class tioconazole is not in.

### The question-driven call site — Sarah Taylor, *"Is it safe to give methylprednisolone?"*

9 chips before and after. The contraindication chip goes `(D10AA)` -> `(H02AB)`; the three
`Moderate` corticosteroid/NSAID interaction chips are byte-identical, since the interaction arm is
untouched.

### Regression controls, all exact, all unchanged

| patient | question | before | after |
|---|---|---|---|
| Mary Smith | clarithromycin | 1 chip, Major x simvastatin | identical |
| Agnes Adams | warfarin | 1 chip, Major x aspirin | identical |
| Joshua Johnson | ibuprofen | 2 chips (NSAID group + lisinopril Moderate) | identical |
| Mary Smith | paracetamol | 0 chips | identical |

Diffing the chip text of all seven probes before against after gives **six changed lines and
nothing else** — every one of them an `A01AC`/`D10AA` becoming `H02AB`.

## Build

`mvn -o clean install`, measured on this box.

- baseline `main` f7d4e07: **882 api + 61 omod = 943**, 0 failures, 34 skipped
- this branch: **888 api + 61 omod = 949**, 34 skipped, **2 failures** — both in a pre-existing test,
  see below (the omod leg was measured with `-Dmaven.test.failure.ignore=true`, since the api
  failure otherwise stops the reactor)

The six added tests are `CrossReactivityClassChoiceTest`, over six rows copied field-for-field from
the shipped KB in KB order, through the real `DrugSafetyValidator.validate` on both call sites.

## An existing test encodes the defect — reported, not edited

`ContraindicationRouteVariantTest` (merged in #160) asserts `(A01AC)` for hydrocortisone against a
dexamethasone allergy at five sites in two methods — lines 172-174, 175-176, 335-336, 341-342,
343-344. That is row 3 of #161's own table, so it pins the defect as expected output, and any real
fix to #161 must contradict it. CLAUDE.md forbids modifying an existing test, so this branch leaves
them failing and says so rather than quietly editing them. **CI on this PR will be red on exactly
those two methods and nothing else.** The correction is mechanical if you want it: `(A01AC)` ->
`(H02AB)` in those five string literals, nothing else. The class javadoc at line 38 quotes `(A01AC)`
in prose and is stale the same way.

Also stale, also not edited: `DirectAllergyContraindicationTest`'s class javadoc (lines 53-59) says
`sharedClass` "returns the first of the allergen's subgroups that the drug in play also carries" and
that a reordered `atc` array "would report `S01AE` with the behaviour unchanged". Both sentences are
now false — `S01AE` is ophthalmic and is demoted, so that case is `(J01MA)` whatever the array
order. Its assertion still passes.

## Limitations

- The chip still names a raw ATC code. Choosing the right code does not make `H02AB` legible to a
  clinician; rendering it as a class name is not in scope here.
- Within the systemic tier the tie-break is still alphabetical (87 KB pairs). Those are choices
  between true statements rather than the defect above, but they are choices made by the alphabet.
- The prefix list is not an exhaustive partition of ATC. It errs towards "classifies the substance",
  which leaves the pre-existing behaviour in place rather than demoting a class that does explain a
  concern.
- The interaction arm (`classRelationships`) names the *order's* own code and so does not go
  through this function; it can still name a local-route class. Reported separately, not fixed here.
- `displayLabelForAtcCode` (#155) is reached only from `classRelationships`, which this PR does not
  touch, so #155 is neither more nor less visible after this change.

Test fixtures created on the standalone for this work, left in place: a coded **Ketoconazole**
allergy on Betty Williams (`bef3e4a0-4857-482c-a26b-5c048c205197`).

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
