### PR TITLE
docs: documentation-truth sweep of README, ADR and ONBOARDING (#159, #169)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -4,42 +4,32 @@ An OpenMRS module that lets clinicians ask natural-language questions about a pa
 
 ## Get oriented fast
 
-- **Read first:** `CLAUDE.md` (project rules — TDD, root-cause-over-patch, and the **API-surface rules** below), `README.md` (setup + platform notes), `docs/adr.md` (decision log).
+- **Read first:** `CLAUDE.md` (project rules — TDD, root-cause-over-patch, and the authoritative API-surface rules), `README.md` (setup + platform notes), `docs/adr.md` (decision log).
 - **Retrieval lives in querystore, not here.** chartsearchai has no in-process embedding/Lucene/scoring pipeline. Retrieval and citation grounding both use querystore's e5-base-v2 model. Retrieval changes and retrieval-quality eval belong in `openmrs-module-querystore`.
-- **Two engines:** `chartsearchai.llm.engine` = `local` (bundled `llama-server` subprocess, default — data stays on the host) or `remote` (OpenAI-compatible API). A **local** LLM is a hard requirement for production.
+- **Two engines:** `chartsearchai.llm.engine` = `local` (bundled `llama-server` subprocess, default — data stays on the host) or `remote` (OpenAI-compatible API; see [ADR Decision 17](docs/adr.md#decision-17-remote-llm-backend-support)).
+- **The prompt carries a slice, not the whole chart.** `chartsearchai.chartMode` defaults to `queryScoped`: the question's typed scope complete, plus the querystore similarity top-K, plus demographics. `fullChart` is the other mode and it changes which machinery is live — see [ADR Decision 28](docs/adr.md#decision-28-query-scoped-slice-charts-chartmodequeryscoped).
 
 ## Build & test
 
 ```bash
 mvn install                       # full build (api + omod), produces omod/target/chartsearchai-*.omod
 mvn -pl api test                  # api unit tests
-mvn test                          # api + omod
 mvn -pl api test -Dtest=ClassName # one test class
 ```
+
+Use `mvn install` when you need the omod tests too. A root `mvn test` **cannot** run them: omod's `unpack-dependencies` execution binds to `generate-resources` and unpacks the api *jar*, which a `test`-phase reactor never produces, so the build fails there with "Artifact has not been packaged yet" (MDEP-98) after the api tests pass. Always build from the repo root with a full reactor — never `mvn -pl omod`, which resolves the api artifact from `~/.m2` and can silently test a stale one.
 
 Tests must call the **real production pipeline** with real datasets — no mocks/reimplementations of pipeline logic (see `CLAUDE.md`). Follow TDD: write the failing test first.
 
 ## Run it locally
 
-A configured standalone lives at `test/referenceapplication-standalone-3.7.0-SNAPSHOT` (RefApp 3.7, port **8081**, login `admin` / `Admin123`):
+The repo ships no standalone — download the [O3 Standalone with Chart Search AI](https://nightly.link/openmrs/openmrs-module-chartsearchai/workflows/build-standalone/main/openmrs-standalone-chartsearchai.zip) built by `build-standalone.yml`, or use `docker compose up --build`. See README's [Standalone platform notes](README.md#standalone-platform-notes) for the per-platform requirements (Java 21+, and *which* JDK on Windows).
 
-```bash
-cd test/referenceapplication-standalone-3.7.0-SNAPSHOT
-nohup java -jar openmrs-standalone.jar &     # nohup so it survives the shell
-# REST base once up: http://localhost:8081/openmrs/ws/rest/v1
-```
-
-To redeploy after a build: stop it (`pkill -9 -f openmrs-standalone.jar; pkill -9 -f mariadbd; pkill -9 -f llama-server` — the embedded MariaDB must be killed too or the next boot can't lock the DB), copy `omod/target/chartsearchai-*.omod` into `appdata/modules/`, restart. Local GGUF models live under `MODELS/`; the standalone bundles Gemma E2B/E4B.
+Extract it, then `java -jar openmrs-standalone.jar` (login `admin` / `Admin123`; the port is in the launcher's output). To redeploy your own build, drop `omod/target/chartsearchai-*.omod` into the standalone's `appdata/modules/` and restart. Stopping it needs all three processes — `pkill -9 -f openmrs-standalone.jar; pkill -9 -f mariadbd; pkill -9 -f llama-server` — because the embedded MariaDB otherwise keeps the DB locked against the next boot.
 
 ## API-surface rules (do not bypass)
 
-These are the only correct entry points — never reimplement their logic inline:
-
-- **Prefixed text:** `ChartSearchAiUtils.buildPrefixedText(resourceType, text)`
-- **Cosine similarity:** `ChartSearchAiUtils.cosineSimilarity()`
-- **Chart assembly:** `ChartBuildingStrategy.buildChart()` → `QueryStoreChartBuilder.build()` (querystore owns retrieval)
-- **Global-property reads:** `ChartSearchAiUtils.getBooleanGlobalProperty` / `getStringGlobalProperty` (fail-safe on a missing context)
-- **Test datasets / category hints:** `TestDatasetHelper.*`
+`CLAUDE.md` holds the authoritative list of methods that are the only correct entry point for their operation — prefixed text, cosine similarity, diacritic folding, the three drug-name matching shapes, chart assembly, the test datasets and category hints, and the inline-citation pattern. Read it there rather than from a copy here; a second list is a second thing to fall out of date.
 
 ## REST endpoints
 
@@ -48,7 +38,7 @@ Base path: `/ws/rest/v1/chartsearchai`. Every endpoint gates on a privilege up f
 | Method | Path | Privilege | Purpose |
 |---|---|---|---|
 | POST | `/search` | AI Query Patient Data | Blocking answer `{patient, question}` → answer + citations |
-| POST | `/search/stream` | AI Query Patient Data | Same, as Server-Sent Events. Event types: `preliminary`, `thinking`, `token`, `references`, `grounded`, `done`, `error` |
+| POST | `/search/stream` | AI Query Patient Data | Same, as Server-Sent Events. Event types, in emission order: `preliminary`, `thinking`, `token`, `references`, `done`, `grounded`, `error`. `grounded` is a *trailing* event after `done` (async grounding only), so a client must keep consuming the stream past `done` |
 | POST | `/warmup` | AI Query Patient Data | Fire-and-forget per-patient KV prewarm on chart open (202) |
 | **POST** | **`/prewarm`** | **Manage AI Prewarm** | **Bulk KV-prewarm bootstrap (202 + status)** |
 | **GET** | **`/prewarmstatus`** | **Manage AI Prewarm** | **Bulk-prewarm progress/status** |
@@ -58,7 +48,9 @@ Base path: `/ws/rest/v1/chartsearchai`. Every endpoint gates on a privilege up f
 
 ### KV warmup & the prewarm bootstrap
 
-Cold full-chart prefill is the dominant first-query latency cost (~10–20s even on GPU). The local engine persists each patient's prefilled KV to disk (`<appdata>/chartsearchai/kvcache`, one `.bin` per chart hash) so subsequent queries restore it (~ms) instead of re-prefilling.
+> **All of this is dormant on a default install.** Warmup, the prewarm sweep, per-patient KV persistence and the progressive-reasoning preview all disengage unless `chartsearchai.chartMode` is set to `fullChart`; the default, `queryScoped`, builds a per-question slice with no reusable chart prefix to prime. The gate is `LlmInferenceService.shouldRunWarmup`. Read this section as the `fullChart` contract.
+
+In `fullChart` mode the cold whole-chart prefill dominates first-query latency, badly so on a GPU-less host. The local engine persists each patient's prefilled KV to disk (`<appdata>/chartsearchai/kvcache`, one `.bin` per chart hash) so subsequent queries restore it instead of re-prefilling.
 
 - **`/warmup`** (reactive) — the frontend fires this on chart open so the clinician's first query is warm. LRU-capped by `chartsearchai.llm.kvCacheMaxEntries` (default 16).
 - **`/prewarm`** (bulk bootstrap, **opt-in, default off**) — a resumable background sweep that pre-fills and **pins** every patient's KV so a first query on a *never-opened* patient is also warm. Pinned entries (`<name>.bin.pin` sidecar) are **exempt from the LRU cap** — durable for hosts with disk for the whole population.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The standalone download above includes the backend module, frontend ESM, and the
 - [API](#api)
   - [Search](#search)
   - [Streaming search (SSE)](#streaming-search-sse)
+  - [Warmup](#warmup)
   - [Feedback](#feedback)
   - [Audit log](#audit-log)
   - [Drug-reference status](#drug-reference-status)
@@ -42,18 +43,20 @@ The standalone download above includes the backend module, frontend ESM, and the
 
 ## Try it on the demo server
 
-A live demo runs at **https://chartsearchai.openmrs.org** with the standard O3 reference patient set, so you can try Chart Search AI without installing anything.
+A live demo runs at **https://chartsearchai.openmrs.org**, so you can try Chart Search AI without installing anything.
 
 1. Open https://chartsearchai.openmrs.org and log in (default credentials: `admin` / `Admin123`).
-2. Click the magnifying-glass icon in the top header and search for **Betty Williams** — she is the reference patient with the most data on the demo (medications, vitals, conditions), so the AI has something to ground its answers in. Open her chart from the dropdown.
+2. Click the magnifying-glass icon in the top header and search for a patient by name, then open a chart from the result list.
 
-   ![Patient search overlay with "Betty" typed and Betty Williams in the result list](docs/images/ai-chart-search-patient-search.png)
+   The demo carries whatever demo data the server was last seeded with, and that population changes — so this walkthrough deliberately names no patient. Pick one whose chart actually has records (Medications, Vitals, Conditions), since the AI answers only from what the chart contains; on a chart with nothing in it the correct answer is that there are no records, which is not much of a demo. Common demo-data surnames (`Williams`, `Smith`) are a reasonable place to start.
+
+   ![Patient search overlay with a name typed and a matching patient in the result list](docs/images/ai-chart-search-patient-search.png)
 
 3. Click the floating blue AI sparkle icon in the bottom-right corner of the chart (tooltip: *Ask AI about this patient*). A chat panel slides in.
 4. Type a clinical question — e.g. *What medications is this patient on?*, *Any allergies?*, *Last 3 blood pressure readings* — and press **Send**, or click the microphone for voice input.
 5. The answer streams in token-by-token. The records the answer is grounded in appear under **References**, numbered to match the inline citations (`[1]`, `[2]`, …). Both the inline citations and the chips under **References** are clickable — they navigate to the relevant chart tab (Orders, Results, Allergies, Conditions, Programs, etc.) and highlight the source record. Every response carries the AI-generated disclaimer.
 
-   ![AI Chart Search panel showing an answer with numbered citations on Betty Williams' chart](docs/images/ai-chart-search-demo.png)
+   ![AI Chart Search panel showing an answer with numbered citations on a patient's chart](docs/images/ai-chart-search-demo.png)
 
 6. Optionally rate the answer under **Was this helpful?** with **Helpful** / **Not helpful** and an optional comment. Feedback is recorded in the audit log alongside the question.
 
@@ -61,8 +64,7 @@ Notes:
 
 - The AI button is only rendered for users with the **AI Query Patient Data** privilege.
 - The launch surface is configurable via the frontend `chatLaunchMode` setting: `floating` (the bottom-right circular button used above), `workspace` (an icon in the top-right workspace strip that opens the chat as a docked workspace), or `both` (default).
-- First-query latency on the demo reflects the remote provider's cold-start. The chart-open prompt-cache warmup (`chartsearchai.warmupEnabled`) is a no-op for remote engines — it only helps local llama-server deployments.
-- The demo currently calls a remote LLM, since the server doesn't yet have the RAM and CPU headroom to comfortably run a local model like Gemma 4 E4B; latency on the demo therefore reflects the remote provider, not local CPU inference.
+- Answers take seconds to minutes. The demo's engine and model are whatever its operators have configured (`chartsearchai.llm.engine`), so treat its latency as indicative of that deployment, not of the module.
 
 ## Standalone platform notes
 
@@ -213,14 +215,14 @@ chartsearchai delegates all retrieval to the [openmrs-module-querystore](https:/
 
 | Property | Value | Description |
 |----------|-------|-------------|
-| `chartsearchai.querystore.topK` | `30` | Number of records querystore returns per query; the LLM then filters them. querystore is a required module and is always the retrieval path — there is no toggle to disable it |
+| `chartsearchai.querystore.topK` | `12` | Number of similarity records requested from querystore. In `queryScoped` mode (the default `chartsearchai.chartMode`) this sizes the query-scoped slice the LLM actually sees, alongside the question's complete typed scope; in `fullChart` mode it only sizes the optional focus hint, and is unused when `chartsearchai.embedding.preFilter` is `false`. querystore is a required module and is always the retrieval path — there is no toggle to disable it. `ChartSearchAiConstants.DEFAULT_QUERYSTORE_TOP_K` carries the default and the measurements behind it |
 | `querystore.embedding.modelFilePath` | `querystore/model.onnx` | Path to the ONNX embedder, relative to `<openmrs-application-data-directory>`. Querystore ships this with an empty default (the module is model-agnostic), so a fresh install must set it |
 | `querystore.embedding.vocabFilePath` | `querystore/vocab.txt` | Path to the WordPiece vocab, same convention |
 | `querystore.embedding.queryModelFilePath` | *(empty)* | Leave empty for `e5-base-v2`; set only for dual-encoder models like MedCPT |
 
-**Migration caveat — the legacy embedding pipelines are no longer self-maintaining.** chartsearchai no longer refreshes its own Lucene/Elasticsearch/MySQL embedding indices when charts change: chartsearchai now reacts to a chart write only by invalidating the answer cache (and, when `chartsearchai.prewarm.refreshOnEdit` is on, re-pinning that patient's prewarm KV) — detected via core #6084 service events, not AOP advice — and the bulk backfill task has been removed (querystore owns retrieval-index freshness via the same core events). If you run the legacy preFilter pipelines (`chartsearchai.querystore.enabled=false` + `chartsearchai.embedding.preFilter=true`), embeddings are still built lazily on first chart access but then go progressively stale on every subsequent edit, and patient merges leak the merged patient's data through retrieval. There is no longer a rebuild task, so treat the querystore-backed path (`chartsearchai.querystore.enabled=true`) as the supported configuration for retrieval that stays current with edits.
+**Index freshness.** querystore owns retrieval-index freshness. chartsearchai reacts to a chart write only by invalidating the answer cache (and, when `chartsearchai.prewarm.refreshOnEdit` is on, re-pinning that patient's prewarm KV), detected via core #6084 service events — see [ADR Decision 26](docs/adr.md#decision-26-chart-write-detection-via-core-service-events).
 
-**Prompt-stability caveat — when full-chart mode is actually faster on small charts.** When `chartsearchai.querystore.enabled=true` and `chartsearchai.embedding.preFilter=false` (the recommended production shape), `ChartBuildingStrategy` routes to `QueryStoreService.getPatientChart` (querystore Decision 15) — the chart bytes are byte-identical across consecutive queries on the same patient, so the `<system> + <chart>` prefix stays stable and the KV cache reuses it. The payoff is contingent on the [Warmup](#warmup) endpoint priming that prefix before the user's first question — without it, the first question still pays the full cold-prefill cost. When `chartsearchai.querystore.enabled=true` and `chartsearchai.embedding.preFilter=true`, querystore selects a different top-K record set for each question, so the prompt body changes between consecutive queries — breaking the KV-cache reuse. On large charts the per-question top-K is the right trade (small top-K is cheaper to prefill from scratch than the whole chart); on *small* charts that fit comfortably in the LLM context, full-chart mode is faster overall. The legacy `chartsearchai.querystore.enabled=false` + `chartsearchai.embedding.preFilter=false` path also produces byte-identical chart prefixes (the in-process `chartSerializer.serialize(patient)` is deterministic), so the KV cache still reuses across follow-ups, but each call pays an extra 300–500 ms of serialization that the querystore path avoids. Pre-Decision-15 measured numbers (CPU-only Gemma 4 E2B, Betty's ~1.8K-token chart, warmup primed): legacy serializer path first ask ~10 s, follow-ups ~4–7 s across three different questions in sequence (the KV cache caught the byte-identical prompt prefix). The querystore + preFilter=false path is expected to match those follow-up numbers — the chart prefix is byte-identical on the same shape — minus the ~300–500 ms per-call serialize cost that querystore avoids. Not re-measured against the post-Decision-15 dispatch; the older 11s-with-flat-follow-ups number was attributable to the pre-dispatch behaviour (querystore on = question-conditioned top-K) and no longer applies.
+**Prompt-stability caveat — only relevant in `fullChart` mode.** In `fullChart` mode the chart bytes are a function of the patient alone, so the `<system> + <chart>` prompt prefix is stable across consecutive queries and llama-server's KV cache reuses it; that is what the [Warmup](#warmup) endpoint and the disk-persisted KV cache exist to exploit. In the default `queryScoped` mode each question carries its own small slice, so there is no shared prefix to amortize — and none is needed, because a slice prefills in a fraction of the time. Setting `chartsearchai.embedding.preFilter=true` in `fullChart` mode leaves the chart prefix intact (the focus hint is a small trailing payload), so it does not break the reuse.
 
 A follow-up will populate these defaults in the querystore module's `config.xml` so fresh deploys work without manual GP wiring. The GPs are already declared there with empty values, which is why they appear in **Admin > Settings** today; until the defaults land, set them yourself after first start. See [ADR Decision 22](docs/adr.md#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) for why this path uses `e5-base-v2`.
 
@@ -228,7 +230,8 @@ A follow-up will populate these defaults in the querystore module's `config.xml`
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `chartsearchai.embedding.preFilter` | `false` | When `true`, narrows the patient's records to querystore's top-K before sending them to the LLM; when `false` (default), the full chart is sent. querystore is a required module and always the retrieval path. Pre-filtering is faster on huge charts but can omit records the LLM needs for negative reasoning (e.g. correctly answering "any allergies?" requires having seen the empty allergy section, not just an absence of matches in the filtered set). Enable only when context-window size is the binding constraint |
+| `chartsearchai.chartMode` | `queryScoped` | How the prompt's chart context is assembled. `queryScoped` (default) sends only a slice: every record of the question's typed scope (complete by construction — an enumeration answer cannot omit what was never retrieved), plus the `chartsearchai.querystore.topK` similarity records, plus demographics. `fullChart` serializes the whole chart into every prompt. **The full-chart prefill machinery — warmup, the prewarm bootstrap, per-patient KV persistence, the progressive-reasoning preview — is dormant in `queryScoped` mode and re-engages only under `fullChart`.** A value that is not an exact (case-insensitive) `queryScoped` behaves as `fullChart`, so a typo fails toward the whole chart; an absent or unreadable GP takes the default. See [ADR Decision 28](docs/adr.md#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for the A/B behind the default |
+| `chartsearchai.embedding.preFilter` | `false` | *(`fullChart` mode only)* When `true`, querystore additionally ranks the patient's records by similarity to the question and passes a short **focus hint** — the top `chartsearchai.querystore.topK` record indices — to the LLM. **The full chart is still sent either way**, so the hint biases attention without removing records the LLM needs for negative reasoning (correctly answering "any allergies?" requires having seen the empty allergy section, not just an absence of matches). Has no effect in the default `queryScoped` mode |
 
 #### LLM tuning
 
@@ -240,7 +243,7 @@ A follow-up will populate these defaults in the querystore module's `config.xml`
 | `chartsearchai.llm.serverPort` | `18085` | *(Local engine only)* Port for the embedded llama-server. Change if the default conflicts with another service |
 | `chartsearchai.llm.contextSize` | `32768` | *(Local engine only)* Context window size in tokens for the embedded llama-server. The system prompt + serialized chart + question must fit within this. Larger values let bigger charts pass through full-chart mode but increase the KV cache memory footprint roughly linearly. Increase if you see "Patient chart exceeds the LLM context window" (HTTP 413) and have headroom for a larger KV cache; reduce on memory-constrained hardware |
 | `chartsearchai.llm.reasoningMaxChars` | `0` | Caps the model's reasoning scratchpad at this many characters (via a grammar-enforced `maxLength` in the chart-answer schema) when greater than `0`; the answer itself is never capped. The reasoning phase is the dominant decode cost on CPU-only servers (a measured 3–27 seconds of "thinking" before any answer text), so bounding it bounds that cost. `0` (default) leaves the schema unchanged. **Caution:** truncating the chain of thought can change answers — only enable a value that has cleared the answer-quality gold standard (`eval/drift-metric/`) with no regression in mean F1, abstention accuracy, or off-topic citations versus the uncapped baseline. Gemma 4 E2B at `400` failed that gate on all three axes (measured 2026-06-12); no certified value exists, so leave at `0` unless a fresh gate run for your model and value passes |
-| `chartsearchai.warmupEnabled` | `true` | When `true`, opening a patient chart triggers a background warmup that primes the LLM prompt cache (system prompt + serialized chart) so the first AI query on that patient skips the full prefill cost. No-op when `chartsearchai.llm.engine` is `remote` (remote providers manage their own caching) and when `chartsearchai.embedding.preFilter` is `true` (the prompt prefix varies per query, so a chart-only warmup cannot be reused) |
+| `chartsearchai.warmupEnabled` | `true` | When `true`, opening a patient chart triggers a background warmup that primes the LLM prompt cache (system prompt + serialized chart) so the first AI query on that patient skips the full prefill cost. No-op when `chartsearchai.llm.engine` is `remote` (remote providers manage their own caching), and — because there is no question-independent chart prefix to prime — whenever `chartsearchai.chartMode` is `queryScoped`, **which is the default**. The gate is `LlmInferenceService.shouldRunWarmup` |
 | `chartsearchai.llm.kvCacheDir` | *(empty → `<appdata>/chartsearchai/kvcache`)* | *(Local engine only)* Directory where each patient's prefilled chart KV cache is persisted to disk (via llama-server `--slot-save-path`). **Enabled by default** — empty resolves to `<appdata>/chartsearchai/kvcache`; set an explicit path to relocate it, or `off` (or `false`/`none`/`disabled`) to turn it off. Both the chart-open warmup and the streaming query path **restore** a patient's KV from disk (I/O-bound, ~tens of ms) instead of recomputing the full chart prefill (CPU-bound, tens of seconds to minutes on a GPU-less host) whenever the RAM prompt cache is cold for it, and **save** a fresh cold prefill so the next visit is fast even without a warmup — and, unlike the in-RAM prompt cache, this survives llama-server restarts and single-slot evictions. The restored KV is byte-for-byte what a fresh prefill produces, so answers are unchanged. The first-ever visit to a patient still pays one prefill (to create the file). Files are large (tens to a few hundred MB each) and contain the model's encoding of the chart (PHI) — prefer fast local storage with appropriate permissions; disable on hosts where that on-disk footprint is unwanted. The biggest first-query latency win for CPU-only deployments — see [Warmup](#warmup) |
 | `chartsearchai.llm.kvCacheMaxEntries` | `16` | *(Local engine only)* Maximum persisted KV-cache files to retain in `chartsearchai.llm.kvCacheDir`; the oldest (by mtime) are evicted beyond this, bounding disk use. **Pinned** entries created by the prewarm bootstrap (below) are exempt from this cap — they are neither counted nor evicted |
 | `chartsearchai.llm.kvCache.maxPinnedEntries` | `0` | *(Local engine only)* Upper bound on the number of **pinned** KV entries the prewarm bootstrap may create. `0` (default) means unbounded — pin the whole patient population. Set a positive value to bound the on-disk pinned footprint on hosts that want a partial prewarm corpus: once reached, the sweep stops pinning (it does not evict already-pinned entries). Only consulted by the prewarm sweep |
@@ -304,8 +307,11 @@ The `drugSafety.*` checks require both `chartsearchai.drugReference.enabled` and
 
 | Privilege | Purpose |
 |-----------|---------|
-| **AI Query Patient Data** | Execute chart search queries |
+| **AI Query Patient Data** | Execute chart search queries (`/search`, `/search/stream`, `/warmup`, `/feedback`) |
 | **View AI Audit Logs** | Access the audit log endpoint |
+| **Manage AI Prewarm** | Trigger and monitor the bulk KV-prewarm bootstrap (`/prewarm`, `/prewarmstatus`) |
+
+`/drugreferencestatus` gates on core's **Get Global Properties** instead, which the `Authenticated` role already holds on a default install.
 
 ### 7. Indexing
 
@@ -315,7 +321,7 @@ Retrieval indexing is owned entirely by the [openmrs-module-querystore](https://
 
 ### Absent-data detection
 
-chartsearchai does not run its own relevance gate. The LLM is given the patient's chart (the full chart by default, or querystore's top-K when `chartsearchai.embedding.preFilter` is `true`) and reasons over what is present and what is absent — when nothing in the chart addresses the question (e.g., asking "any cancer?" for a patient with no cancer-related records), the system prompt instructs it to answer that there are no records about the topic rather than inferring one. querystore-backed retrieval narrows what reaches the LLM, and the optional [citation grounding](#citation-grounding) pass verifies that each cited record actually supports the claim, catching off-topic or unsupported citations after the answer is produced.
+chartsearchai does not run its own relevance gate. The LLM is given the patient's chart — a query-scoped slice by default, or the whole chart under `chartsearchai.chartMode=fullChart` — and reasons over what is present and what is absent — when nothing in the chart addresses the question (e.g., asking "any cancer?" for a patient with no cancer-related records), the system prompt instructs it to answer that there are no records about the topic rather than inferring one. querystore-backed retrieval narrows what reaches the LLM, and the optional [citation grounding](#citation-grounding) pass verifies that each cited record actually supports the claim, catching off-topic or unsupported citations after the answer is produced.
 
 ### Recency cap
 
@@ -425,6 +431,7 @@ SSE events:
 | Event | Description |
 |-------|-------------|
 | `thinking` | A chunk of the model's reasoning, emitted before the answer; render distinctly (e.g. a collapsible panel), never as the answer |
+| `preliminary` | A chunk of the fast preview reasoning pass, ahead of the committed answer; render like `thinking`, and expect the committed reasoning to replace it. Requires **both** `chartsearchai.progressiveReasoning.enabled=true` and `chartsearchai.chartMode=fullChart`, so it never fires on a default install |
 | `token` | A chunk of the answer text as it is generated |
 | `references` | The answer's citations the moment the answer is complete — before grounding verdicts exist; render as unverified until verdicts arrive |
 | `done` | Final JSON with the complete answer, references (`chart` group first, upstream order — most recent first, undated last — within each group, with `index`, `resourceType`, `resourceUuid`, `date`, `grounded`, `group`, `source`, `withheldInteractions`), `safetyWarnings`, `questionId`, and disclaimer. With `chartsearchai.grounding.async=true`, `done` is emitted as soon as the answer is complete — its references carry no verdicts yet and `safetyWarnings` is empty (validation runs with grounding) |
@@ -444,7 +451,7 @@ Content-Type: application/json
 }
 ```
 
-No-op when `chartsearchai.llm.engine` is `remote` and when `chartsearchai.embedding.preFilter` is `true`. Disable entirely with `chartsearchai.warmupEnabled=false`. Concurrent warmups for different patients are coalesced — only the most recently submitted patient runs, since llama-server processes one request at a time.
+No-op when `chartsearchai.llm.engine` is `remote`, and whenever `chartsearchai.chartMode` is `queryScoped` (the default) — a per-question slice has no reusable chart prefix. Disable entirely with `chartsearchai.warmupEnabled=false`. Concurrent warmups for different patients are coalesced — only the most recently submitted patient runs, since llama-server processes one request at a time.
 
 **Disk-persisted KV cache (the biggest CPU-only first-query win).** The plain warmup above primes the prompt cache *in RAM* — it helps only until the model is evicted (another patient's query takes the single slot) or the llama-server process restarts, after which the next visit pays the full chart prefill again (tens of seconds to minutes on a GPU-less host). The disk-persisted KV cache fixes that and is **on by default** (`chartsearchai.llm.kvCacheDir` empty → `<appdata>/chartsearchai/kvcache`; set a path to relocate it, or `off` to disable): llama-server is launched with `--slot-save-path`, so both the warmup **and the streaming query path save and restore** each patient's prefilled chart KV (~tens of ms of disk I/O) instead of recomputing. Because the prefill is the entire pre-answer wait on a CPU-only server, this turns a slow first query into a fast one (measured on the standalone in CPU-only mode: ~19–60 s to first token → ~0.9 s after a disk restore), and it survives restarts and evictions that the RAM cache does not. The restored KV is byte-for-byte identical to a fresh prefill, so answers and citations are unchanged (verified: identical answer text and grounding verdicts for the same question on the restore vs. prefill paths). Only the first-ever visit to a patient pays a prefill (to create the file); subsequent visits restore. See `chartsearchai.llm.kvCacheDir` / `chartsearchai.llm.kvCacheMaxEntries` in the [config table](#5-configure).
 
@@ -517,7 +524,7 @@ This overrides the default permissive implementation.
 
 ## Evals
 
-The project includes an eval framework that tests citation accuracy, absent-data answering, and prompt injection resistance without requiring a running LLM or external services.
+The project includes an eval framework covering citation accuracy, absent-data answering, drug-safety warnings, and prompt-injection resistance. All of it runs offline **except** the prompt-injection suite, which drives a real LLM.
 
 ### Running evals
 
@@ -530,22 +537,26 @@ Or run a specific suite:
 ```
 mvn test -pl api -Dtest="CitationEvalTest"
 mvn test -pl api -Dtest="AbsentDataEvalTest"
+mvn test -pl api -Dtest="DrugSafetyEvalTest"
 mvn test -pl api -Dtest="PromptInjectionEvalTest" -Dchartsearchai.prompt.injection.test=true
 ```
 
+The prompt-injection suite needs **both** that system property **and** a reachable llama-server (it probes `chartsearchai.llm.serverPort`, overridable with `-Dchartsearchai.prompt.injection.endpoint`). Without one, every case is skipped by a JUnit assumption rather than failing — check the surefire report for skips before reading a green run as a pass.
+
 ### Adding cases
 
-Each suite is driven by a JSON dataset in `api/src/test/resources/eval/`. To add a case, append an entry to the relevant file:
+Each suite is driven by a JSON dataset. To add a case, append an entry to the relevant file:
 
 | File | What it tests |
 |------|---------------|
-| `citation-eval-dataset.json` | Simulated LLM JSON → expected citation indices (F1) |
-| `absent-data-eval-dataset.json` | Query → expected keywords in "no records" answer |
-| `prompt-injection-eval-dataset.json` | Adversarial payload → LLM produces safe JSON, no system prompt leakage |
+| `api/src/test/resources/eval/citation-eval-dataset.json` | Simulated LLM JSON → expected citation indices (F1) |
+| `api/src/test/resources/eval/absent-data-eval-dataset.json` | Query → expected keywords in "no records" answer |
+| `api/src/test/resources/eval/prompt-injection-eval-dataset.json` | Adversarial payload → LLM produces safe JSON, no system prompt leakage |
+| `api/src/test/resources/evals/drug-reference/drug-safety-eval.json` | Patient + question → expected drug-safety warnings |
 
 ### Metrics report
 
-Each run appends per-case and summary metrics to `api/target/eval-results.csv` for tracking regressions over time.
+The citation and prompt-injection suites append per-case rows to `api/target/eval-results.csv` (via `EvalReporter`) for tracking regressions over time; the citation suite also appends a summary row. The absent-data and drug-safety suites do not report to the CSV, so their results are only in the surefire output.
 
 ## Evaluated models
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -35,6 +35,9 @@ This document captures the architectural decisions made for the Chart Search AI 
 - [Decision 27: Drug-safety parity follow-through — weight-aware dosing, curated cross-reactivity groups, prose warnings](#decision-27-drug-safety-parity-follow-through--weight-aware-dosing-curated-cross-reactivity-groups-prose-warnings)
 - [Decision 28: Query-scoped slice charts (chartMode=queryScoped)](#decision-28-query-scoped-slice-charts-chartmodequeryscoped)
 - [Decision 29: Module-extensible query-scope routing (QueryScopeContributor SPI)](#decision-29-module-extensible-query-scope-routing-queryscopecontributor-spi)
+- [Decision 30: One chip per substance — the contraindication ledger and its collapse key](#decision-30-one-chip-per-substance--the-contraindication-ledger-and-its-collapse-key)
+- [Decision 31: Name the class that explains the relationship, not the first one shared](#decision-31-name-the-class-that-explains-the-relationship-not-the-first-one-shared)
+- [Decision 32: Observable drug-reference load status](#decision-32-observable-drug-reference-load-status)
 - [Known limitations](#known-limitations)
 - [Planned future work](#planned-future-work)
 
@@ -83,7 +86,7 @@ Fine-tune a small model to generate SQL or API calls from natural language.
 #### Option C: Traditional search (no LLM at all)
 Full-text search index (Lucene/Solr/Elasticsearch) over patient data.
 
-**Now implemented as an alternative retrieval pipeline.** Solves 70% of the problem with 20% of the complexity. No hallucination risk from retrieval errors, no extra model files required, works offline. Weakness: no semantic understanding — relies on lexical matching with stemming. Implemented using Apache Lucene 8.11.2 (already on the classpath via Hibernate Search) with `EnglishAnalyzer` for Porter stemming. Selectable via the `chartsearchai.retrieval.pipeline` global property. See Decision 13 for details. An Elasticsearch pipeline (Decision 14) addresses the semantic gap by combining BM25 text search with kNN vector search via Reciprocal Rank Fusion.
+Solves 70% of the problem with 20% of the complexity. No hallucination risk from retrieval errors, no extra model files required, works offline. Weakness: no semantic understanding — relies on lexical matching with stemming. Was implemented in-process as a selectable alternative pipeline ([Decision 13](#decision-13-lucene-bm25-as-an-alternative-retrieval-pipeline)) and later removed with the rest of that stack in #51; BM25 now lives in querystore.
 
 #### Option D: Agent/tool-use pattern
 Give the LLM access to OpenMRS APIs as tools and let it autonomously decide what to call.
@@ -105,9 +108,11 @@ Retrieve relevant records first using deterministic search, then use the LLM onl
 
 ### Decision
 
-The initial plan was full RAG with a deterministic retrieval layer feeding a small subset of records to the LLM. Decision 10 refined this into the current architecture: a **single LLM approach** where all patient records are sent to the LLM (or narrowed by an optional embedding pre-filter). The two-step structure remains — retrieval then synthesis — but the LLM handles all queries, not just "hard" ones. See Decision 10 for the full rationale.
+The initial plan was full RAG with a deterministic retrieval layer feeding a small subset of records to the LLM. Decision 10 refined it into a **single LLM approach**, and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) settled where it landed: querystore assembles a query-scoped slice, and one LLM call reasons over it. The two-step structure remains — retrieval then synthesis — but the LLM handles all queries, not just "hard" ones.
 
 ## Decision 3: Embedding approach — semantic search index
+
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
 
 ### Options evaluated for retrieval
 
@@ -149,6 +154,8 @@ Semantic search index as the primary retrieval mechanism. Concept graph traversa
 
 ## Decision 4: Concise text as LLM input format
 
+**Status: Partly superseded** — the principle (flat, concise clinical text rather than FHIR JSON) still holds and is what querystore emits. The `ClinicalTextSerializer` implementations named below, and the OpenMRS service reads that fed them, were **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)); querystore produces record text now, and this module's `PatientChartSerializer` only numbers and date-labels it.
+
 ### Analysis
 
 Standard serialization formats (FHIR JSON, full OpenMRS domain objects) are poor formats for LLM context windows:
@@ -169,6 +176,8 @@ Serialized: "Systolic Blood Pressure: 120 mmHg (ABNORMAL)"  ~10 tokens
 
 ## Decision 5: Embedding granularity
 
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
+
 ### Options
 
 | Granularity | Pros | Cons |
@@ -183,6 +192,8 @@ Embed at the **individual record level**. Each record is serialized to concise c
 
 ## Decision 6: Embedding model
 
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
+
 ### Decision
 
 Semantic vectors via **all-MiniLM-L6-v2** running in-process through ONNX Runtime. ~90MB model file, runs on CPU, no GPU needed. Produces 384-dimensional vectors. Requires two files configured via `chartsearchai.embedding.modelFilePath` and `chartsearchai.embedding.vocabFilePath`. Captures semantic meaning — effective for clinical queries where synonyms and related concepts matter (e.g., "hypertension" and "high blood pressure" are recognized as related). Embedding dimensions are auto-detected from the model output on first use, so models with different dimensions (e.g., 768-dim pubmedbert-base-embeddings) work without code changes.
@@ -190,6 +201,8 @@ Semantic vectors via **all-MiniLM-L6-v2** running in-process through ONNX Runtim
 A term-frequency hashing approach was considered as a simpler alternative (no model file needed, keyword-overlap retrieval). It was rejected because it cannot capture semantic similarity — for a clinical question like "any infections?", it would find records containing the word "infection" but miss "tuberculosis", "malaria", or "UTI". This defeats the purpose of pre-filtering, since the LLM with the full chart would catch all of these.
 
 ## Decision 7: Vector storage — MySQL, not a vector database
+
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
 
 ### Analysis
 
@@ -224,6 +237,8 @@ Only one query store is active at a time, selected via the `chartsearchai.retrie
 
 ## Decision 8: Index population strategy
 
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
+
 ### Decision
 
 Three complementary strategies ensure embeddings stay current:
@@ -247,6 +262,8 @@ Three complementary strategies ensure embeddings stay current:
 - **Backfill**: A one-time scheduled task (`EmbeddingIndexTask`) indexes all patients that don't yet have embeddings. Handles initial population when the module is installed on a system with existing data. Skips already-indexed patients, so it is safe to re-run and picks up where it left off if stopped. Admins trigger it from the scheduler UI; it does not run automatically.
 
 ## Decision 9: Text serialization — ClinicalTextSerializer pattern
+
+**Status: Superseded** — every `*TextSerializer` class named here, and `PatientRecordLoader`, were **deleted** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Record text is now produced by querystore's own serializers; this module's `PatientChartSerializer` numbers records, attaches dates and obs-group labels, and strips synonyms. The per-record-type field lists below therefore describe **another module's** code and are not verifiable from this repo. Two further corrections for anyone reading the body: obs-group members are indexed **atomically**, not flattened into one record; and patient demographics are a numbered, citable record, the un-numbered header line being only a fallback. Kept as the record of *why*; **read as history.**
 
 ### Decision
 
@@ -461,6 +478,8 @@ Resource types (e.g., `"obs"`, `"condition"`, `"order"`) are defined as `public 
 `ArchitectureGuardTest` enforces API surface rules at build time by scanning all production source files for violations. If any code bypasses the required entry points — for example, calling `getEmbeddingPrefix()` directly instead of `buildPrefixedText()`, hardcoding prefix strings like `"Clinical observation: "`, reimplementing the cosine similarity formula, or duplicating test dataset helpers — the build fails. This prevents regression where a developer unfamiliar with the API contracts accidentally reimplements pipeline logic inline.
 
 ## Decision 10: Single LLM architecture with optional embedding pre-filter
+
+**Status: Partly superseded** — the single-LLM architecture stands and is what runs. Everything below about an embedding pre-filter narrowing the chart, and the whole "Embedding model selection" / "Similarity threshold algorithm" / "Retrieval precision improvements" / "Chunking strategy" tail, describes machinery **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Two claims to correct explicitly, because they are load-bearing and still repeated: the full chart is **not** what the LLM sees by default (`chartsearchai.chartMode` defaults to `queryScoped`, [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped)), and `chartsearchai.embedding.preFilter` **narrows nothing** — it adds a trailing focus hint to a full chart, in `fullChart` mode only.
 
 ### Context
 
@@ -756,7 +775,20 @@ No chunking is used. Each patient record (obs, condition, diagnosis, allergy, or
 
 ### REST endpoints
 
-The module exposes REST endpoints for chart search queries and user feedback. Query endpoints require the `AI Query Patient Data` privilege and are registered under the OpenMRS `webservices.rest` module namespace.
+The module exposes eight endpoints under `/ws/rest/v1/chartsearchai`, all on one controller (`ChartSearchAiRestController`), registered under the OpenMRS `webservices.rest` module namespace. Every one gates on a privilege as the first statement of its handler, so an unprivileged caller gets 401/403 before any argument is validated.
+
+| Method | Path | Privilege |
+|---|---|---|
+| POST | `/search` | `AI Query Patient Data` |
+| POST | `/search/stream` | `AI Query Patient Data` |
+| POST | `/warmup` | `AI Query Patient Data` |
+| POST | `/feedback` | `AI Query Patient Data` |
+| GET | `/auditlog` | `View AI Audit Logs` |
+| POST | `/prewarm` | `Manage AI Prewarm` |
+| GET | `/prewarmstatus` | `Manage AI Prewarm` |
+| GET | `/drugreferencestatus` | core `Get Global Properties` |
+
+`Manage AI Prewarm` is deliberately not the clinician privilege: a sweep prefills every patient's chart and monopolises the single inference slot, so it is a system operation. `/drugreferencestatus` gates on core's `Get Global Properties` because it discloses configuration, not patient data — see [Decision 32](#decision-32-observable-drug-reference-load-status).
 
 #### Synchronous endpoint
 
@@ -793,10 +825,15 @@ POST /ws/rest/v1/chartsearchai/search/stream
 }
 ```
 
-Returns a `text/event-stream` with three event types:
+Returns a `text/event-stream`. The event names are literals at the `writeSseEvent` call sites in `ChartSearchAiRestController`, and README's [Streaming search (SSE)](../README.md#streaming-search-sse) table documents each one's payload:
+- `thinking`, `preliminary` — reasoning chunks, rendered distinctly from the answer, never as it
 - `token` — a chunk of the answer text, streamed as generated
-- `done` — final JSON with the complete answer, references (with `index`, `resourceType`, `resourceUuid`, `date`, `grounded`, `group`, `source`, `withheldInteractions`), and disclaimer
+- `references` — the citations, as soon as the answer is complete and before any grounding verdict exists
+- `done` — final JSON: answer, references, `safetyWarnings`, `questionId`, disclaimer
+- `grounded` — a *trailing* event after `done`, only under async grounding, carrying the verdicts
 - `error` — an error message if something goes wrong
+
+A client must therefore keep reading past `done`, and must not assume `done` is terminal.
 
 Both search endpoints return a `questionId` (the audit log row ID as a string) that the frontend uses to submit user feedback.
 
@@ -809,7 +846,7 @@ POST /ws/rest/v1/chartsearchai/warmup
 }
 ```
 
-Pre-warms the LLM prompt cache for a patient's chart so the first AI query on that patient skips full prefill cost. The frontend hits this when a patient chart is opened. Returns `202 Accepted` immediately; the warmup runs on a background daemon thread. Requires the same `AI Query Patient Data` privilege as the search endpoints. No-op when the engine is remote and when `chartsearchai.embedding.preFilter` is `true`. Disabled globally by setting `chartsearchai.warmupEnabled=false`.
+Pre-warms the LLM prompt cache for a patient's chart so the first AI query on that patient skips full prefill cost. The frontend hits this when a patient chart is opened. Returns `202 Accepted` immediately; the warmup runs on a background daemon thread. Requires the same `AI Query Patient Data` privilege as the search endpoints. No-op when the engine is remote, and whenever `chartsearchai.chartMode` is `queryScoped` — the default — because a per-question slice has no reusable chart prefix to prime; `LlmInferenceService.shouldRunWarmup` is the gate. Disabled globally by setting `chartsearchai.warmupEnabled=false`.
 
 #### Feedback endpoint
 
@@ -839,8 +876,8 @@ Requires the `View AI Audit Logs` privilege. All query parameters are optional. 
   1. **Structured-output constraint (primary defense)**: Both engines send `response_format: {"type": "json_schema", "strict": true, ...}` declaring the exact `{answer: string, citations: int[]}` shape — extracted into the shared `ChartAnswerResponseFormat` helper. The local llama-server enforces it by deriving a GBNF grammar from the schema internally. Remote OpenAI-compatible providers enforce it server-side; this is also what Anthropic's OpenAI-compat endpoint requires (it rejects the older `json_object` form with HTTP 400). Either way, the LLM cannot emit arbitrary text — even if a prompt injection manipulates the model's reasoning it cannot produce system information, execute instructions, or output anything outside the declared shape. This is the primary defense because it operates at the output level regardless of what the model "wants" to say.
   2. **Input regex filter**: Questions are checked against a regex pattern that rejects common prompt injection phrases (e.g., "ignore previous instructions", "you are now", "system prompt:"). Rejected questions return a 400 error without reaching the LLM.
 - **AI disclaimer**: Every response includes a disclaimer stating the output is AI-generated and not a substitute for clinical judgment.
-- **Answer caching**: An in-memory LRU cache (`ChartSearchServiceRouter`) stores recent answers keyed by `patientUuid::preFilter::pipeline::topK::similarityRatio::keywordWeight::scoreGapMultiplier::minScoreGap::gapValidationCosine::grounding::groundingMinCosine::groundingEntailment::question`. The cache key includes all retrieval **and grounding** parameters so that changing any tuning setting (including a grounding flag, which changes a citation's `grounded` verdict) correctly invalidates cached results. Configurable TTL via `chartsearchai.cacheTtlMinutes` (default 0 = disabled). When enabled, identical queries with the same parameters within the TTL window return the cached answer without invoking the LLM. The cache uses an access-ordered `LinkedHashMap` with a fixed maximum size, automatically evicting the least-recently-used entry when the size limit is exceeded. Expired entries are cleaned up periodically (every 10 cache puts) rather than on every access, to avoid scanning the entire cache on each insertion. **Chart-write invalidation**: a chart write to a patient (obs, encounter, order, condition, diagnosis, allergy, program, medication dispense, patient demographics, merge) evicts that patient's cached answers via `ChartSearchServiceRouter.invalidatePatient`. Chart writes are detected through core #6084 service events (`ChartSearchEventListener` → `IndexingHelper.onChartWrite`), which replaced the former per-service AOP advice — see [Decision 26](#decision-26-chart-write-detection-via-core-service-events). This eviction is independent of the preFilter/querystore gating that governs embedding indexing, so a repeated identical question after an edit recomputes against the new chart rather than serving a stale answer — this is what makes the cache safe to enable. It is a backstop, not a guarantee for every path: writes that bypass the OpenMRS service layer (direct DAO, SQL load) do not publish these events, so the TTL must stay finite as the catch-all for those.
-- **Serialized chart sourcing**: Querystore's `getPatientChart(patientUuid)` (querystore Decision 15) is the supported full-chart shape when `chartsearchai.querystore.enabled=true` (default). The read store keeps per-type indices current via the events-first sync pipeline, so the chart returns at index-read latency without round-tripping core or maintaining a parallel serialization cache. The legacy `chartsearchai.querystore.enabled=false` + `chartsearchai.embedding.preFilter=false` configuration falls back to `chartSerializer.serialize(patient)` per request — the 300–500 ms of OpenMRS DB roundtrips and Hibernate work are paid on every call, which is the migration's accepted operational cost on the legacy path. The pre-Decision-15 in-memory `ChartCache` that amortized this cost was removed once querystore became the supported full-chart shape; the AOP-driven invalidation overhead exceeded the savings on a per-call serialize. The LLM-side prompt-prefix cache (KV cache reuse on llama-server, provider-managed caching on remote) is unaffected and continues to shave prefill cost on follow-up queries against the same patient.
+- **Answer caching**: An in-memory LRU cache (`ChartSearchServiceRouter`) stores recent answers keyed by every setting that changes what the LLM sees or what verdict a citation carries, so that changing one invalidates rather than serves a stale answer. `ChartSearchServiceRouter.buildCacheKey` is the definition; today that is the patient, `preFilter`, `chartMode`, `querystore.topK`, the three grounding GPs, and the question. `chartMode` is in the key because it swaps the entire context — the largest possible change to what the LLM sees. The legacy embedding/Lucene/Elasticsearch tuning GPs left the key when that pipeline was removed (#51). Configurable TTL via `chartsearchai.cacheTtlMinutes` (default 0 = disabled). When enabled, identical queries with the same parameters within the TTL window return the cached answer without invoking the LLM. The cache uses an access-ordered `LinkedHashMap` with a fixed maximum size, automatically evicting the least-recently-used entry when the size limit is exceeded. Expired entries are cleaned up periodically (every 10 cache puts) rather than on every access, to avoid scanning the entire cache on each insertion. **Chart-write invalidation**: a chart write to a patient (obs, encounter, order, condition, diagnosis, allergy, program, medication dispense, patient demographics, merge) evicts that patient's cached answers via `ChartSearchServiceRouter.invalidatePatient`. Chart writes are detected through core #6084 service events (`ChartSearchEventListener` → `IndexingHelper.onChartWrite`), which replaced the former per-service AOP advice — see [Decision 26](#decision-26-chart-write-detection-via-core-service-events). This eviction is independent of the preFilter/querystore gating that governs embedding indexing, so a repeated identical question after an edit recomputes against the new chart rather than serving a stale answer — this is what makes the cache safe to enable. It is a backstop, not a guarantee for every path: writes that bypass the OpenMRS service layer (direct DAO, SQL load) do not publish these events, so the TTL must stay finite as the catch-all for those.
+- **Serialized chart sourcing**: querystore is the only source of chart records — `getPatientChart(patientUuid)` for the whole chart, a typed/similarity slice for the default `queryScoped` mode. There is no in-process fallback and no toggle: the legacy path, and the in-memory `ChartCache` that amortized it, were removed in the querystore migration (#51). The read store keeps per-type indices current off core's events, so the chart returns at index-read latency without round-tripping core. The LLM-side prompt-prefix cache (KV reuse on llama-server, provider-managed caching on remote) is unaffected.
 - **Rate limiting**: Configurable per-user rate limit (`chartsearchai.rateLimitPerMinute`, default 10). Set to 0 to disable.
 - **Database audit logging**: Every query is recorded in the `chartsearchai_audit_log` table with:
   - The authenticated user and patient
@@ -903,6 +940,8 @@ For the initial release targeting small clinics with low concurrent usage, the s
 
 ## Decision 13: Lucene BM25 as an alternative retrieval pipeline
 
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
+
 ### Context
 
 The embedding pipeline (Decision 3) uses a custom scoring system: cosine similarity from an ONNX model combined with keyword matching, gap detection, and type boosting. This produces high-quality retrieval but requires downloading model files (~90MB ONNX model + vocabulary), and the custom scoring logic is complex with many tunable parameters.
@@ -925,6 +964,8 @@ Add Lucene BM25 as an alternative retrieval pipeline, selectable via the `charts
 **Why Lucene 8.11.2 with `scope: provided`?** OpenMRS Platform bundles this version via Hibernate Search. Using the same version with `provided` scope avoids classpath conflicts and doesn't increase the module's `.omod` size.
 
 ## Decision 14: Elasticsearch hybrid search pipeline with RRF
+
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
 
 ### Context
 
@@ -961,6 +1002,8 @@ Add an Elasticsearch hybrid search pipeline as a third retrieval option (`charts
 
 ## Decision 15: In-process hybrid pipeline (Lucene BM25 + embedding kNN with RRF)
 
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
+
 ### Context
 
 Each existing retrieval pipeline has a blind spot. The Lucene pipeline (Decision 13) provides fast keyword search with no external dependencies, but misses semantic matches — "any cancer?" returns nothing when the patient has Kaposi sarcoma records because no record contains the literal word "cancer." The embedding pipeline (Decision 3) captures these semantic relationships, but misses exact keyword matches — a search for a specific drug name may rank semantically similar but wrong medications higher than an exact match. The Elasticsearch pipeline (Decision 14) solves both problems with hybrid RRF search, but requires a running Elasticsearch 8.14+ instance — a dependency that many OpenMRS deployments do not have, especially in low-resource settings where the platform runs with only MySQL.
@@ -991,6 +1034,8 @@ Add an in-process hybrid retrieval pipeline (`chartsearchai.retrieval.pipeline=h
 **Trade-off vs. Elasticsearch pipeline**: The in-process kNN search is exact (brute-force cosine similarity over all patient embeddings), not approximate. This is fine for typical patient chart sizes (hundreds to low thousands of records) but would not scale to corpus-wide search. The Elasticsearch pipeline uses approximate kNN via HNSW, which scales better for large indexes.
 
 ## Decision 16: LangChain / LangChain4j not adopted
+
+**Status: Accepted; the comparison table is stale.** The decision stands. Several "existing implementation" entries below name code **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)) — `PatientRecordLoader`, the per-type text serializers, `OnnxEmbeddingProvider`, the `chartsearchai_embedding` table, and the three retrieval pipelines. Read the table as what the module had when the decision was taken.
 
 ### Context
 
@@ -1330,6 +1375,8 @@ Variant of GraphRAG worth knowing about for this specific case: **LazyGraphRAG**
 
 ## Decision 19: Retain all-MiniLM-L6-v2 as the embedding model
 
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
+
 **Status: Accepted** (April 2026)
 
 ### Problem
@@ -1397,6 +1444,8 @@ This reinforces the original finding: **the failure mode is not model capacity b
 
 ## Decision 20: MedCPT dual-encoder as an alternative embedding model
 
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
+
 **Status: Accepted** (April 2026)
 
 ### Problem
@@ -1441,6 +1490,8 @@ Each model has its own eval baseline (`enriched-retrieval-eval.json` for L6-v2, 
 MedCPT's ONNX models split weights into `model.onnx` + `model.onnx.data`. The ONNX runtime 1.24.3 has a bug where it resolves the data file path as `<model_path>/model.onnx.data` instead of `<model_dir>/model.onnx.data`. The workaround is to merge weights back into a single file using `onnx.save()`. A `createSessionWithExternalData()` method attempts canonical path resolution first, falling back to byte-array loading.
 
 ## Decision 21: Concept-name re-ranking for subword-tokenized queries
+
+**Status: Superseded** — the in-process retrieval stack this decision describes (embedding index, vector store, Lucene/Elasticsearch pipelines, the `chartsearchai.retrieval.pipeline` and `chartsearchai.embedding.*` global properties) was **removed** in the querystore migration ([#51](https://github.com/openmrs/openmrs-module-chartsearchai/issues/51)). Retrieval now belongs entirely to [openmrs-module-querystore](https://github.com/openmrs/openmrs-module-querystore) — see [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path) and [Decision 28](#decision-28-query-scoped-slice-charts-chartmodequeryscoped) for what runs today. Kept as the record of *why* the approach was taken; **read the body as history, not as current behaviour.**
 
 **Status: Accepted** (April 2026)
 
@@ -1561,7 +1612,7 @@ All query-expansion code was reverted. The lesson is captured here so future mai
 
 ### Context
 
-Decisions 19–21 cover the chartsearchai-side pre-filter pipeline — `all-MiniLM-L6-v2` + adaptive filtering (similarity ratio, gap detection, z-score gates, concept-name re-ranking) co-evolved against the 485-case eval baseline. That pipeline is **not** what runs when `chartsearchai.querystore.enabled=true` (the recommended deployment).
+Decisions 19–21 cover the chartsearchai-side pre-filter pipeline — `all-MiniLM-L6-v2` + adaptive filtering (similarity ratio, gap detection, z-score gates, concept-name re-ranking) co-evolved against the 485-case eval baseline. That pipeline no longer exists — it was removed in #51, and querystore is now the only retrieval path.
 
 In the querystore-backed path:
 
@@ -1578,7 +1629,7 @@ With the LLM doing the filtering, the embedder's job changes. It no longer needs
 
 ### Evaluation
 
-Three embedders were compared on the demo standalone (Betty Williams and Richard Jones charts, real OpenMRS data) with `chartsearchai.querystore.enabled=true`, `chartsearchai.querystore.topK=30`, and Gemma 4 E4B as the filtering LLM:
+Three embedders were compared on a standalone with real OpenMRS demo data, over the querystore path, with Gemma 4 E4B as the filtering LLM:
 
 | Embedder | Colloquial → clinical bridge | Source | Notes |
 |---|---|---|---|
@@ -1588,7 +1639,7 @@ Three embedders were compared on the demo standalone (Betty Williams and Richard
 
 ### Decision
 
-For deployments running `chartsearchai.querystore.enabled=true`, use `intfloat/e5-base-v2` as the querystore embedder. `backend-init.sh` provisions it automatically for Docker deployments; non-Docker installs should download it manually to `<openmrs-application-data-directory>/querystore/`.
+Use `intfloat/e5-base-v2` as the querystore embedder. `backend-init.sh` provisions it automatically for Docker deployments; non-Docker installs should download it manually to `<openmrs-application-data-directory>/querystore/`.
 
 ### Why this does not contradict Decision 19
 
@@ -1751,7 +1802,7 @@ The grounding pass is pure overhead on the user's critical path, and on CPU-only
 
 ### Model-dependent cosine floor
 
-`minCosine` is **not** a universal constant — it tracks the embedding model's score-spread geometry. `0.40` suits a wide-spread model like all-MiniLM-L6-v2 but is far too low for e5, whose grounded pairs sit much higher; on an e5/querystore deployment the floor must be ~`0.82`. When `chartsearchai.querystore.enabled=true` the verifier **reuses querystore's own e5 embedding provider** rather than loading a second model, so the floor must match that model. This is the same per-model-tuning stance as the retrieval pipeline (see [Decision 19](#decision-19-retain-all-minilm-l6-v2-as-the-embedding-model) / [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path)).
+`minCosine` is **not** a universal constant — it tracks the embedding model's score-spread geometry. `0.40` suits a wide-spread model like all-MiniLM-L6-v2 but is far too low for e5, whose grounded pairs sit much higher; on an e5/querystore deployment the floor must be ~`0.82`. The verifier **reuses querystore's own embedding provider** rather than loading a second model, so the floor must match whatever model querystore is configured with. This is the same per-model-tuning stance as the retrieval pipeline (see [Decision 19](#decision-19-retain-all-minilm-l6-v2-as-the-embedding-model) / [Decision 22](#decision-22-e5-base-v2-for-the-querystore-backed-retrieval-path)).
 
 ### Drug-reference citations: demote-only (July 2026)
 
@@ -1904,7 +1955,7 @@ Three additive, data-driven extensions:
 
 ## Decision 28: Query-scoped slice charts (chartMode=queryScoped)
 
-**Status: Accepted** (July 2026) — implemented behind `chartsearchai.chartMode`, initially default `fullChart` (unchanged behavior). Complements — and in scoped mode disengages — the warmup/prewarm/KV-persistence machinery of Decisions 12 and 26.
+**Status: Accepted** (July 2026) — implemented behind `chartsearchai.chartMode`, which now defaults to `queryScoped` (it shipped defaulting to `fullChart`; see the update below). Complements — and in scoped mode disengages — the warmup/prewarm/KV-persistence machinery of Decisions 12 and 26.
 
 **Update (2026-07, default flipped to `queryScoped`).** After validation, `queryScoped` became the default (`config.xml` defaultValue + the `CHART_MODE_DEFAULT` constant both readers use). Evidence: a 22-patient drift-metric A/B — scoped beat fullChart on meanF1 (0.748 vs 0.668), abstention (0.86 vs 0.74), and off-topic drift (181 vs 477: the focused slice keeps the small model from citing a whole chart's worth of noise) — plus a CPU latency check where scoped's cold first answer was ~3× faster (no full-chart prefill). Consequences: (1) the full-chart prefill machinery (warmup, prewarm bootstrap, per-patient KV persistence, progressive-reasoning preview) is now dormant by default — it re-engages only when an operator sets `chartMode=fullChart`; (2) the fail-safe direction reverses — an *absent or unreadable* `chartMode` GP now resolves to `queryScoped`, though a GP set to any non-`queryScoped` value (including a typo) still resolves to fullChart, so a mistyped value fails toward the whole chart. `fullChart` remains supported for many-questions-per-patient sessions where its warm-cache reuse and completeness-over-focus are preferred.
 
@@ -1938,11 +1989,11 @@ Add a second chart-assembly mode. `QueryScopeRouter` matches the question agains
 
 The gates were re-run on the current build; the fullChart baseline reproduced **exactly** (meanF1 0.733, abstention 0.89, off-topic 51), and scoped reproduced **exactly** (0.800 / 1.00 / 2), confirming the harness and the reported numbers. The four scoped cells that score below fullChart were then diagnosed from the actual cited records: three are **recall losses where scoped keeps perfect precision** (the missed records are in the slice but uncited — the model answers more conservatively, which is the same property that yields the abstention and off-topic-drift wins), and one is an over-citation of a borderline-relevant condition. They pull in **opposite directions**, so no single lever fixes them as a set. Three levers were measured and all net-regress:
 
-- **`querystore.topK` (the one no-code dial).** Curve on the 40-cell gate: topK=20 → meanF1 0.865 / abstention 0.94 / off-topic **25**; topK=25 → 0.813 / 1.00 / 16; **topK=30 (shipped) → 0.800 / 1.00 / 2**; topK=50 → 0.771 / 1.00 / 7. Lowering topK raises present-cell F1 but **reintroduces off-topic drift** — at topK=20 an *absent* cardiac cell dumped 21 irrelevant citations instead of abstaining. **topK=30 uniquely minimizes drift with perfect abstention**; it is a safety optimum, not a max-F1 point, and stays the default.
+- **`querystore.topK` (the one no-code dial).** Curve on the 40-cell gate: topK=20 → meanF1 0.865 / abstention 0.94 / off-topic **25**; topK=25 → 0.813 / 1.00 / 16; **topK=30 (shipped) → 0.800 / 1.00 / 2**; topK=50 → 0.771 / 1.00 / 7. Lowering topK raises present-cell F1 but **reintroduces off-topic drift** — at topK=20 an *absent* cardiac cell dumped 21 irrelevant citations instead of abstaining. **topK=30 uniquely minimized drift with perfect abstention** on that gate, so it shipped as a safety optimum rather than a max-F1 point. **Superseded:** a later, wider sweep (the 22-patient drift-metric gold plus 36 patients on demo data) lowered the default to **12**, which holds F1 at the plateau while *improving* abstention and roughly halving drift, and cuts CPU time-to-first-token. `ChartSearchAiConstants.DEFAULT_QUERYSTORE_TOP_K` is the current default and records that measurement; do not read 30 out of this section as the shipped value.
 - **Subtype-aware routing.** Routing domain-qualified conditions questions ("mental health or psychiatric *conditions*?") to TOPICAL instead of the full CONDITIONS dump fixed the *under-cited* mental cell (0.67 → 0.92) but **broke the *over-cited* one** (0.67 → 0.50) and raised off-topic 2 → 9 — net worse; reverted. Both cells are the identical question; they differ only by patient chart shape, which a text router cannot see.
 - **Deeper retrieval** (topK=50 above) adds noise without net benefit.
 
-Conclusion: the four cell-level regressions are a genuine Pareto cost of the precision/abstention rebalance that drives the aggregate win; no tested change improves the net. Ship at `chartMode=queryScoped`, `querystore.topK=30`.
+Conclusion: the four cell-level regressions are a genuine Pareto cost of the precision/abstention rebalance that drives the aggregate win; no change tested *at that time* improved the net. Shipped at `chartMode=queryScoped`. The `querystore.topK` half of that conclusion was later overturned — see the note above.
 
 ## Decision 29: Module-extensible query-scope routing (QueryScopeContributor SPI)
 
@@ -1964,15 +2015,82 @@ Add a Spring SPI, `QueryScopeContributor` (in `chartsearchai-api`): a module reg
 - **−** A contributor is a slice-composition change, which this project gates on BOTH the scope eval and the temporal probe (they pull in opposite directions — see Decision 28). The SPI cannot enforce that a contributor was gated; the interface javadoc states the expectation, and an unvalidated contributor can silently regress its own domain's answer quality. Union also means a careless, over-broad contributor enlarges the slice for its questions (the same over-cite risk Decision 28 measured) — hence the contract's "match conservatively; prefer to under-claim."
 - **−** The answer cache key (Decision 28) folds in `chartMode` and the question but not the registered contributor set. Contributors are resolved live per query, so a *newly started* contributor module immediately affects fresh answers; but answers already cached for its domain's questions are served until the cache TTL expires. Adding or removing a contributor module at runtime should therefore be followed by a cache flush (or accepted as bounded by the TTL) — keying the cache on the contributor set would add a `getRegisteredComponents` call to every cache-key computation for a rare, lifecycle-only change.
 
+## Decision 30: One chip per substance — the contraindication ledger and its collapse key
+
+**Status: Accepted** (August 2026) — implemented. Extends [Decision 24](#decision-24-drug-reference-as-a-pluggable-consumer-of-authoritative-datasets) ([#145](https://github.com/openmrs/openmrs-module-chartsearchai/issues/145) / [#160](https://github.com/openmrs/openmrs-module-chartsearchai/pull/160)).
+
+### Context
+
+Both contraindication arms were keyed on a reference **entry**, and DDInter files one substance as several route/formulation rows. One clinician-facing name resolves all of them, so one clinical fact produced one chip per row. The duplication was the visible symptom; the real defect was that only the row the allergen resolved to by *identity* said the true thing. Its siblings fell through to the class comparison and reported the substance as cross-reactive with the patient's allergy **to itself**. And since [#110](https://github.com/openmrs/openmrs-module-chartsearchai/issues/110) every chip is also injected as a citable record, so each duplicate spent prompt budget too.
+
+### Decision
+
+`DrugSafetyValidator` keeps a validate-scoped ledger that both contraindication arms and both of their call sites feed. It keys on `(subject substance, recorded finding)`, keeps the most specific relationship, and writes the survivor back into the position the group's first candidate held, so no client sees the chip order reshuffle.
+
+### Why a ledger and not a filter over the finished list
+
+Decisively: the sibling's chip is **wrong**, not merely duplicated, so the collapse must *choose which relationship survives* — and by the time only rendered text is left, the reasons that justify that choice are gone. The chips also differ in text, each naming its own route, so no text-level dedup would have caught them.
+
+### Why the collapse key is substance name **plus** display-name stem
+
+`rxnorm_name` equality alone was rejected: it is not populated for every row, and where it is, route variants of one substance do not reliably share it — so the key would silently fail to collapse exactly the rows that motivated the work, while also risking collapsing two genuinely different substances that share an ingredient name. Requiring agreement on both the substance name and the display-name stem makes the key hold on the rows that exist rather than on the rows the schema promises.
+
+## Decision 31: Name the class that explains the relationship, not the first one shared
+
+**Status: Accepted** (August 2026) — implemented. Refines [Decision 24](#decision-24-drug-reference-as-a-pluggable-consumer-of-authoritative-datasets)'s level-4 class matching ([#161](https://github.com/openmrs/openmrs-module-chartsearchai/issues/161) / [#166](https://github.com/openmrs/openmrs-module-chartsearchai/pull/166)).
+
+### Context
+
+`sharedClass` returned the first shared ATC level-4 subgroup in the allergen's own code array. A corticosteroid carries one code per route it is marketed in, so a systemic cross-reactivity concern was justified by a topical class — methylprednisolone against a dexamethasone allergy read as anti-acne preparations. The finding was right and the reason it gave was not, which is precisely what a clinician checks before deciding whether to trust the feature.
+
+This was a systematic bias, not an arbitrary list position: every ATC array in the shipped KB is in ascending code order, and ATC's alphabet front-loads the locally applied groups, so "first" reliably meant "most topical".
+
+### Decision
+
+Prefer the shared subgroup that classifies the **substance** over one that classifies a **locally applied formulation**, falling back to the locally applied one when that is all the pair shares. Candidates are examined in code order rather than array order, so the answer is a function of the two code sets rather than of where a dataset happened to write a code.
+
+The route/site knowledge is two prefix lists on `DrugReference`: the locally applied groups, each justified by the route or site in the ATC group's own published name, minus the groups nested inside those that ATC itself names *"for systemic use"*. That exception is not hypothetical — without it, a pair sharing both a topical and a systemic subgroup is reported under the topical one.
+
+### Why not the two alternatives
+
+- **Match the route of the active order.** The route is not available at this seam and could only ever be available at one of the two call sites: the arm also runs for a drug the *question* names, which has no route at all. Nothing carries the route that far.
+- **Fall back to ATC level 3.** Widening the class breadth to make the label read better trades a wrong reason for a vaguer one and reopens the false-positive cost [Decision 24](#decision-24-drug-reference-as-a-pluggable-consumer-of-authoritative-datasets) settled. The grain stays level 4; only the *choice among* shared level-4 codes changed.
+
+## Decision 32: Observable drug-reference load status
+
+**Status: Accepted** (August 2026) — implemented ([#149](https://github.com/openmrs/openmrs-module-chartsearchai/issues/149) / [#154](https://github.com/openmrs/openmrs-module-chartsearchai/pull/154)).
+
+### Context
+
+A `sourceFormat` / `dataFilePath` mismatch loads **zero** entries and was reported at INFO exactly like a successful load: a count of 0 printed as cheerfully as 2283. The module starts clean — no startup error, no WARN — and the whole drug-safety layer is inert, every safety question answering as though there were nothing to find. Neither existing loud path covers it: they fire when the bundled dataset is missing or unparseable, not when a file is present, readable and simply the wrong shape for the configured parser.
+
+This is not a hypothetical operator error. It silently produced a wrong result inside this project: a verification pass flipped `sourceFormat` while leaving `dataFilePath` on the other dataset, saw every probe return zero chips, and could not distinguish that from "the fix does not work".
+
+### Decision
+
+Two parts, and the second is why the first can be trusted.
+
+1. **Loud on empty.** The service warns when a load it just performed produced no entries, naming both global properties, the parser in use and the file actually read. The rule lives in the service rather than in a source adapter, so one rule covers all three formats and cannot drift per source.
+2. **Observable after the load.** `DrugReferenceLoad` retains the outcome — effective format, configured format, configured path, the origin actually read, entry count, and the inert verdict — captured at the instant the load populates the cache, so it can never describe a different dataset than the one the safety layer is using. Exposed by `GET /chartsearchai/drugreferencestatus` under core's `Get Global Properties`; no new privilege.
+
+### Why the status must be observable *after* a lazy load
+
+The load is lazy and cached for the life of the module, so "which dataset is in force?" cannot be answered from the log at all: the most recent `Loaded N …` line may pre-date the global properties as they now read, or belong to a process a failed restart left running. That is exactly how the pass above was fooled. Reading the endpoint therefore **performs** the load if it has not happened yet, so the answer is current by construction rather than a historical line that may be stale — the property that makes any source-flip verification, including that PR's own, trustworthy.
+
+`origin` is reported separately from `configuredDataFilePath` because a configured path that cannot be read falls back to the bundled dataset and yields a perfectly plausible non-zero count. In that state "the count is non-zero, so my file loaded" is false, and the count alone cannot distinguish it. One `isInert()` verdict drives both the WARN and the reported status, so the two cannot disagree.
+
+Reading the status when the feature is disabled deliberately does **not** trigger a load: polling a status endpoint must not be what starts a large parse, or manufactures the warning, on an install that does not use the feature.
+
+> **A fourth decision in this area is pending, not yet merged.** [#173](https://github.com/openmrs/openmrs-module-chartsearchai/pull/173) carries the "one substance, one row" follow-through — the interaction subject, the injected reference record, and the self-pair parse guard. It is deliberately not written up here while it is open; add it when it lands.
+
 ## Known limitations
 
 - **Counting questions**: LLMs are unreliable at precise counting tasks (e.g., "how many weight records in the last 10 years?"). The model may undercount or overcount even when all relevant records are provided. Larger, more capable models perform better at counting but are still not perfectly reliable. This is a fundamental limitation of LLM inference, not a retrieval issue. Questions that require exact counts are better suited to structured queries.
 
 ## Planned future work
 
-- **Incremental embedding indexing**: The `EncounterService` AOP hook already uses an incremental strategy (indexes only new/changed encounters), but other data types (`ObsService`, `ConditionService`, etc.) still use `indexPatient()` which deletes all embeddings for a patient and recomputes from scratch. A fully incremental approach would track which record maps to which embedding row across all data types and only add, update, or delete the specific embeddings affected. This matters for patients with large charts where AOP hooks fire frequently.
 - **Concept graph traversal**: Complement embedding search with OpenMRS concept relationship traversal to improve retrieval for queries involving related concepts (e.g., finding NSAID allergies when asking about ibuprofen).
 - **Pre-computed summaries**: Cache LLM-generated summaries for common query patterns (e.g., "current medications", "active problems") to reduce inference latency for frequently asked questions.
 - **Agent/tool-use pattern**: Enable multi-step reasoning where the LLM can request additional data or perform follow-up queries. Deferred until local models with reliable tool-use capabilities are available.
-- **Multimodal medical image interpretation**: Extend the pipeline to pass complex observations (X-rays, dermatology photos, ultrasounds, pathology slides, scanned documents) alongside text to multimodal LLMs like MedGemma 1.5 4B. The main changes are: extend `ObsTextSerializer` to handle `ValueComplex` obs, add an optional image field to `SerializedRecord`, and update `LlmProvider`/`LlmEngine` implementations to construct multimodal content arrays (text + base64 image blocks) for the OpenAI-compatible `/chat/completions` API. Both engines already speak this protocol — the embedded llama-server supports multimodal via libmtmd, and remote backends (vLLM, OpenAI, Anthropic) accept the same content-array format. No new serializers are needed — complex obs are still observations.
+- **Multimodal medical image interpretation**: Extend the pipeline to pass complex observations (X-rays, dermatology photos, ultrasounds, pathology slides, scanned documents) alongside text to multimodal LLMs like MedGemma 1.5 4B. The main changes are: have querystore's obs serializer carry complex-value obs, add an optional image field to `SerializedRecord`, and update `LlmProvider`/`LlmEngine` implementations to construct multimodal content arrays (text + base64 image blocks) for the OpenAI-compatible `/chat/completions` API. Both engines already speak this protocol — the embedded llama-server supports multimodal via libmtmd, and remote backends (vLLM, OpenAI, Anthropic) accept the same content-array format. No new serializers are needed — complex obs are still observations.
 - **Unstructured data / image OCR**: Extract text from photos of paper forms at write time so the content flows through the existing serializer and embedding pipeline.


### PR DESCRIPTION
Converts the trickle of incidental stale-doc findings into one pass with a denominator. Scope was exactly three files: `README.md`, `docs/adr.md`, `ONBOARDING.md`. `CLAUDE.md` untouched. No javadoc under `api/src/main` or `omod/src/main` touched, because #173 is open over four of those files. No test touched. No production behaviour changed.

Closes #159
Closes #169

## The audit denominator

Every factual, checkable claim — a default, a path, a class or method name, a count, a command, an endpoint, a privilege, a patient name, a behaviour statement — enumerated and then checked against the code, `config.xml`, the poms, or the live demo.

| File | Claims audited | Found false |
|---|---|---|
| `README.md` | 168 | 24 |
| `docs/adr.md` | 268 | 131 |
| `ONBOARDING.md` | 61 | 9 |
| **Total** | **497** | **164** |

A further 41 claims are **unverifiable from this repo** and were left alone, not counted as either: external facts (model licences, HuggingFace URLs, benchmark scores, hardware figures) and `docs/adr.md` Decision 9's per-record-type field lists, which describe querystore's serializers and cannot be checked here.

The single largest cause, 105 of the 131 in `docs/adr.md`: **Decisions 3–21 describe the in-process retrieval stack that #51 removed, in the present tense, with no marker.** Decision 10 still called it "the current architecture"; Decision 3 still said "CHOSEN". Nine `chartsearchai.embedding.*` / `chartsearchai.retrieval.pipeline` global properties, the `chartsearchai_embedding` table, `ClinicalTextSerializer` and its seven subclasses, `EmbeddingIndexer`, `EmbeddingIndexTask`, `HybridRetriever`, `QueryClassifier`, `PatientRecordLoader`, `capPerConcept`, `groupByConcept`, `filterEsResults`, three z-score constants — all named as live code. None exists.

## What I deleted rather than corrected, and why

The house rule applied throughout: a corrected number can go stale again; a deleted claim cannot.

**Deleted outright**
- README's two long caveat paragraphs built on `chartsearchai.querystore.enabled`. That is not a global property this module has — zero hits in `api/src`, `omod/src` and `config.xml` — yet the README used it as a live toggle six times. A GP that does not exist has no correct value, so there was nothing to fix.
- README's claim that the demo "calls a remote LLM" and that its first-query latency reflects a remote cold start. Measured: the demo has `chartsearchai.llm.engine=local`. Replaced with a statement that does not assert the demo's configuration at all, because that is the kind of fact that drifts silently.
- ONBOARDING's "Run it locally" standalone path and its `MODELS/` directory. Neither exists, and neither is tracked in git.
- ONBOARDING's duplicated API-surface list, which had drifted from `CLAUDE.md`'s authoritative one. Cross-referenced instead — a second copy is a second thing to go stale.
- ADR's planned-future-work item on incremental indexing of embeddings that no longer exist.
- ADR's `--cache-reuse 256`, `topK=30 stays the default`, and the six removed tuning parameters in the documented cache key.

**Stated and pinned to code instead** (the brief's other branch, for facts that are load-bearing and stable)
- `chartsearchai.querystore.topK` = `12`, pointing at `ChartSearchAiConstants.DEFAULT_QUERYSTORE_TOP_K`, which carries the measurement.
- `chartsearchai.chartMode` = `queryScoped`, pointing at ADR Decision 28. It was **undocumented in both README and ONBOARDING** despite deciding whether the LLM sees a slice or the whole chart, which is what made a dozen surrounding claims false.
- Warmup's real no-op condition, pointing at `LlmInferenceService.shouldRunWarmup`.

**Marked superseded rather than rewritten.** For the eleven ADR decisions describing removed machinery I did *not* rewrite the bodies. An ADR exists to record *why*, and rewriting that much superseded rationale would destroy the record while generating a large volume of new prose to be newly wrong in. Each carries a one-line status marker naming what was removed, pointing at what runs today, and saying to read the body as history — the convention Decision 18 already used in this file. That marker states a completed fact, so it cannot rot. Decisions 4, 10 and 16 are only partly superseded and say which half stands; Decision 10's marker additionally corrects the two false claims that are load-bearing and still repeated elsewhere.

## #169: the diagnosis

Not an unlucky patient. **The README described the standalone's patient set as if it were the demo's.**

Resolved by name against the live demo, never from a uuid in a document:

```
$ curl -s -H "Authorization: Basic $A" --get --data-urlencode "q=Betty" \
      "https://chartsearchai.openmrs.org/openmrs/ws/rest/v1/patient"
{"results":[{"uuid":"dda99123-...","display":"9290KT-2 - Betty Njagi Kittur"}]}

$ ... --data-urlencode "q=Mary Smith"      -> {"results":[]}
$ ... --data-urlencode "q=Agnes Adams"     -> {"results":[]}
$ ... --data-urlencode "q=Joshua Johnson"  -> {"results":[]}
```

There is no Betty Williams on the demo, and none of the O3 reference patients are there either. The demo carries a different demo dataset — `Betty Njagi Kittur`, `Corretty Williams Meli`, `Emacculate Williams Nyamumba`. Betty Williams is real, but in the **standalone**'s RefApp data (`a7090f70-99b7-4fd9-b60d-f8e0cdee07f6`, confirmed by name lookup there). So the README's "the standard O3 reference patient set" was itself the false claim, and the missing patient was its symptom.

**I made the instruction patient-independent rather than swapping in another name.** Two reasons. First, the demo's population has demonstrably already changed out from under this document once, so any name I hardcode fails the same way; naming a patient is the defect, not the choice of patient. Second, the walkthrough does not actually need a specific patient — it needs a chart with records in it, which the reader can see in the search results. The README now says so plainly, including that the demo carries whatever it was last seeded with. On what the walkthrough needs: the demo steps ask only the medications / allergies / vitals questions, so a patient with an active order and an interaction partner is not required — that shape belongs to the drug-safety feature, which the demo walkthrough does not exercise.

Worth recording for whoever reads #169 next: the premise that Betty Williams has 0 active orders is **no longer true on the standalone**. She currently has two (`Bupivacaine`, `Lidocaine`, activated 2026-08-03, uuids `h1730000-...a1/a2`) plus an expired Simvastatin. Those look like a previous agent's fixtures. It reinforces the conclusion rather than changing it: that data is mutable developer test-bed data, and the demo's is different again.

## The walkthrough, executed

Run against the live demo exactly as the README now words it — search by surname, pick one whose chart has records, ask the README's own first example question. Verbatim:

```
# step 2: search a patient BY NAME (surname 'Williams', as the README suggests)
$ curl -s -H "Authorization: Basic $A" --get --data-urlencode "q=Williams" "$D/patient"
{
    "results": [
        { "uuid": "dd749903-1691-11df-97a5-7038c432aabf", "display": "2064KP-7 - Corretty Williams Meli" },
        { "uuid": "dd93959d-1691-11df-97a5-7038c432aabf", "display": "6365KP-4 - Bilar Williams Kobulo" },
        { "uuid": "dd976c1a-1691-11df-97a5-7038c432aabf", "display": "6886CH-5 - Emacculate Williams Nyamumba" }
    ]
}

# step 2: pick one whose chart has records. Emacculate Williams Nyamumba: 24 active drug orders.
# step 4: ask the README's own example question.
# start 2026-08-06T16:26:37Z
{"questionId":"557",
 "answer":"The patient has been prescribed or ordered the following medications:\n
   1. Lamivudine [1], [33], [36], [70], [172]\n
   2. Stavudine [2], [37], [39], [105]\n
   3. Trimethoprim and sulfamethoxazole [3], [34], [103], [137], [169]\n
   4. Nevirapine [4], [35], [38], [106], [171]",
 "references":[ 23 entries, all "resourceType":"drug_order", "group":"chart",
                "grounded":null, "source":null, "withheldInteractions":0 ],
 "safetyWarnings":[],
 "disclaimer":"This response is AI-generated and may not be accurate. ..."}
# HTTP 200, 104.476489s
# end 2026-08-06T16:28:21Z
```

Four medications, each cited to real `drug_order` records, references grouped `chart`-first, `grounded: null` because grounding is off on that deployment. The earlier run of the same walkthrough on a different demo patient (`Betty Njagi Kittur`) also returned HTTP 200 in 27.7 s, so the instruction is not load-bearing on one chart.

`/drugreferencestatus` is **not** available on the demo (`Unknown resource: v1/chartsearchai`), so that deployment predates #154; its GPs are readable and show `drugReference.enabled=true`. On the standalone the endpoint confirms the expected state rather than inferring it from logs:

```
$ curl -s -H "Authorization: Basic $A" http://localhost:8081/openmrs/ws/rest/v1/chartsearchai/drugreferencestatus
{"enabled":true,"loaded":true,"inert":false,"entryCount":2283,"sourceFormat":"ddinter",
 "configuredSourceFormat":"ddinter","configuredDataFilePath":"chartsearchai/ddi_knowledge_base.json",
 "origin":"appdata:chartsearchai/ddi_knowledge_base.json"}
```

## #101

**Still true when I started, and this PR fixes it.** README documented `chartsearchai.querystore.topK` as `30`; `config.xml` and `ChartSearchAiConstants.DEFAULT_QUERYSTORE_TOP_K` both say `12`. The stale description was fixed too — in the default `queryScoped` mode `topK` sizes the slice the LLM actually sees, it is not a candidate set the LLM then filters. The same `30` was also asserted in `docs/adr.md` Decision 28 as "stays the default" and "Ship at `querystore.topK=30`", which #101 does not mention; both are corrected there and pointed at the constant. Not closing it myself.

## #159

Both halves. The endpoint list now has all eight endpoints with their privileges (`/prewarm`, `/prewarmstatus`, `/drugreferencestatus` were missing), and the stream section's "three event types" is now the seven actually emitted, with the note that `grounded` arrives *after* `done`. The three unrecorded decisions are added as **Decision 30** (#145/#160 — the chip ledger; why substance-name-plus-stem and not `rxnorm_name` equality; why a ledger and not a filter over finished chips), **Decision 31** (#161/#166 — substance over locally-applied ATC class, the two prefix lists, why route and level-3 were both rejected) and **Decision 32** (#149/#154 — the load-status endpoint and why the loaded source must be observable *after* a lazy load). Reason-focused; measurements deliberately left in the javadoc where they already live.

A fourth is pending: #173's "one substance, one row". It is recorded as **pending and unmerged**, not written up as though it had landed.

## Verification

`mvn -o clean install`, measured myself on this branch, and on `main` before touching anything:

| | api | omod | total |
|---|---|---|---|
| `main` (45c1cc4) | 892 | 61 | **953** |
| this branch | 892 | 61 | **953** |

0 failures, 34 skipped, `BUILD SUCCESS`, both. A docs-only change, so a no-op for tests as expected. Every internal link and heading anchor across all three files was checked to resolve.

No standalone deploy: nothing in `src/main` changed. The demo run above exists because #169's whole point is that a documented walkthrough had never been executed.

## Reported, not fixed

Out of scope for a docs PR, and none of it touched here.

**Code defects**
1. `ChartSearchAiRestController:218` and `:460` — the audit log's `searchMode` is `preFilterEnabled ? "pre-filter" : "full-chart"`, so it never records `queryScoped`. On a default install every row is logged `full-chart` while the prompt carried a slice, making the audit trail wrong about which context produced an answer.
2. `pom.xml:35` sets `surefire.excludedGroups=eval`, but no `@Tag` annotation exists anywhere in `api/src/test` or `omod/src/test`, so the exclusion filters nothing and the eval suites run in every build. Either the tag was never applied or it was removed; the property reads as an active gate that is inert.
3. `AbsentDataEvalTest` and `DrugSafetyEvalTest` never call `EvalReporter`, so neither appears in `eval-results.csv`. Combined with the prompt-injection suite skipping by default, only the citation suite lands in the metrics artifact.
4. Three duplicated method pairs with identical names and signatures, which the "never reimplement" rule exists to prevent: `normalizeSlashCitations` (`LlmAnswerExtractor:185,210` vs `LlmProvider:809,813`), `stripQueryStopwords` (`QueryPreprocessor:216` vs `LlmInferenceService:546`), `extractRecencyCap` (`QueryPreprocessor:142` vs `LlmInferenceService:542`).
5. `TestDatasetHelper` is package-private in `...api.impl`, so the tests under `...reference` cannot reach it and use `DrugReferenceTestSupport` instead — the API-surface rule naming it is unreachable for roughly forty test classes.
6. Three orphaned eval datasets with no reader: `enriched-retrieval-eval.json`, `medcpt-retrieval-eval.json`, `retrieval-eval-dataset.json` (~185 KB), left over from the removed retrieval pipeline.

**False claims in production javadoc / `config.xml`** — queued for a pass after #173 lands, per the brief. Not edited.
- `omod/src/main/resources/config.xml:204` — `chartsearchai.progressiveReasoning.enabled`'s description says the preview streams "to the `thinking` channel". The controller uses the 7-arg `searchStreaming`, so it goes to the dedicated `preliminary` channel. Only the 6-arg overloads alias it onto the reasoning consumer.
- `api/src/main/java/.../api/ChartSearchService.java:21` — "When `chartsearchai.embedding.preFilter` is `true` (default)". It defaults to `false`.
- `api/src/main/java/.../api/impl/LlmInferenceService.java:200-217` — the `shouldRunWarmup(boolean)` javadoc is correct that warmup stays viable under `preFilter=true`, and is what proves README/ADR wrong; flagging it only because the surrounding prose still frames `fullChart` as the ordinary case.

**Environment** — no sign of the #165 `~/.m2` problem: `mvn -o clean install` compiled and ran clean twice on the Aug-3 snapshot.

## What I could not verify
- Decision 9's seven per-record-type field lists, and the `Included fields` tables, describe **querystore's** serializers. Not checkable from this repo; left in place with a marker saying so rather than guessed at.
- Core API member claims (`Obs.referenceRange`, `Program.getDescription`, `AllergyService`, `ValueComplex`) — would need decompiling core artifacts.
- `QueryStoreConstants.BM25_DESCRIPTION_BOOST = 0.5` — the constant exists in the querystore jar; the value was not read.
- External facts throughout: model licences, RAM and tokens/sec figures, benchmark scores, HuggingFace URLs. Not checkable here and not counted in the denominator.
- Two internal contradictions in `docs/adr.md` Decision 9 that cannot both be true and that I could not settle from this repo: line 283 says `Obs.referenceRange` was added in OpenMRS 2.7.0, line 313 says reference range is "not exposed in OpenMRS 2.8.x". Both are given as the reason for the same omission. Left for the querystore-side pass.

## Provenance

Measured myself: the 953/892/61 test counts on both `main` and this branch; the root `mvn test` MDEP-98 failure; every demo and standalone REST call quoted above, including all patient name lookups and both walkthrough runs; `config.xml`'s 47 global properties and their defaults; the absence of `chartsearchai.querystore.enabled`; `shouldRunWarmup`'s body; the link/anchor check.

Relayed from read-only subagents and spot-checked, not independently re-derived in full: the per-file claim tallies, the endpoint/privilege/SSE inventory, and the identifier-existence verdicts. I re-verified the load-bearing ones directly — the missing classes, the missing GPs, the missing `test/` path, the omod pom phase.

One correction to my briefing: #169 was filed by **Ariho-Seth**, not the repo owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
