### PR TITLE
test(#165): bind the querystore double to the interface at runtime, not at compile time

### DIFF
--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CountingQueryStoreStub.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CountingQueryStoreStub.java
@@ -9,21 +9,60 @@
  */
 package org.openmrs.module.chartsearchai.api.impl;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.openmrs.module.querystore.api.QueryStoreService;
-import org.openmrs.module.querystore.backend.WriteResult;
 import org.openmrs.module.querystore.model.QueryDocument;
 
 /**
- * Shared counting {@link QueryStoreService} stub for the chart-builder tests
+ * Shared counting {@link QueryStoreService} double for the chart-builder tests
  * ({@code QueryStoreChartBuilderTest}, {@code QueryStoreChartBuilderScopedTest}) — one
- * implementation of the interface's read surface plus write-method stubs, so an interface
- * change is absorbed once and the two files cannot quietly pin different builder contracts.
- * Same consolidation rationale as {@code TestDatasetHelper}.
+ * implementation of the interface's read surface, so an interface change is absorbed once and
+ * the two files cannot quietly pin different builder contracts. Same consolidation rationale as
+ * {@code TestDatasetHelper}.
+ *
+ * <p><strong>Why a dynamic proxy and not {@code implements QueryStoreService}</strong> (#165):
+ * retrieval belongs to openmrs-module-querystore (#51) and its API is expected to keep moving.
+ * A class that implements the interface must override every abstract method it declares, so each
+ * method querystore gained stopped chartsearchai's tests <em>compiling</em> — and only for whoever
+ * had built querystore locally, since CI resolves an older remote snapshot. The error named this
+ * test class rather than the dependency that changed. A proxy is bound to the interface at
+ * runtime, so it names no method set at compile time and interface growth cannot break the build.
+ *
+ * <p>An abstract adapter with no-op defaults — the other obvious shape — does not fix this:
+ * a concrete subclass must still override every abstract method inherited from anywhere, so the
+ * identical "is not abstract and does not override abstract method" error just moves to the
+ * subclass. That shape only helps when upstream adds methods as {@code default}, which is not
+ * what happened.
+ *
+ * <p><strong>Tolerating growth must not mean answering silently.</strong> Every method this
+ * double does not deliberately serve is refused with an {@link UnsupportedOperationException}
+ * naming it. A default-returning double is a worse failure than a compile break: a test would
+ * pass while exercising nothing, and nobody would be told. Note the direction of the safety —
+ * refusing loudly can only fail a test that has started depending on a new querystore call,
+ * which is a decision a human should make; returning an empty list where the real service
+ * returns data would silently weaken every downstream assertion.
+ *
+ * <p>Growth is absorbed; a counted method being <em>removed or resignatured</em> is not, and
+ * deliberately so — the counts those tests assert would no longer mean anything. That case fails
+ * when the double is constructed, with a message naming querystore, which is where the cause is.
  */
-final class CountingQueryStoreStub implements QueryStoreService {
+final class CountingQueryStoreStub {
+
+	/** Resolved per instance rather than in a static initialiser on purpose: a failed static
+	 *  initialiser reports the real cause once and then {@code NoClassDefFoundError} for every
+	 *  later test in the class, which buries exactly the message #165 wants surfaced. */
+	private final Method searchByPatientMethod =
+			interfaceMethod("searchByPatient", String.class, String.class, int.class);
+
+	private final Method getPatientChartMethod = interfaceMethod("getPatientChart", String.class);
+
+	private final Method onStartupMethod = interfaceMethod("onStartup");
+
+	private final Method onShutdownMethod = interfaceMethod("onShutdown");
 
 	int searchByPatientCalls = 0;
 
@@ -39,14 +78,45 @@ final class CountingQueryStoreStub implements QueryStoreService {
 
 	boolean throwOnSearch = false;
 
+	/** One proxy per double, so its identity and hash are stable across {@link #asService()} calls. */
+	private final QueryStoreService service = (QueryStoreService) Proxy.newProxyInstance(
+			CountingQueryStoreStub.class.getClassLoader(),
+			new Class<?>[] { QueryStoreService.class }, this::answer);
+
 	/** Aggregate counter — pre-focus-hint tests assert on total querystore calls
 	 *  without caring which method. */
 	int getCallCount() {
 		return searchByPatientCalls + getPatientChartCalls;
 	}
 
-	@Override
-	public List<QueryDocument> searchByPatient(String patientUuid, String question, int topK) {
+	/** The double as the interface the builder consumes. Counters stay readable on the stub. */
+	QueryStoreService asService() {
+		return service;
+	}
+
+	/**
+	 * Matches on the resolved {@link Method}, not on its name: an overload of a counted method
+	 * ({@code searchByPatient} gaining a filter argument, say) is a method this double has never
+	 * been taught, and name matching would answer it with the wrong semantics instead of refusing.
+	 */
+	private Object answer(Object proxy, Method method, Object[] arguments) {
+		if (searchByPatientMethod.equals(method)) {
+			return searchByPatient((String) arguments[0], (String) arguments[1],
+					((Integer) arguments[2]).intValue());
+		}
+		if (getPatientChartMethod.equals(method)) {
+			return getPatientChart((String) arguments[0]);
+		}
+		if (onStartupMethod.equals(method) || onShutdownMethod.equals(method)) {
+			return null;
+		}
+		if (Object.class.equals(method.getDeclaringClass())) {
+			return answerObjectMethod(proxy, method, arguments);
+		}
+		throw refusal(method);
+	}
+
+	private List<QueryDocument> searchByPatient(String patientUuid, String question, int topK) {
 		searchByPatientCalls++;
 		lastSearchTopK = topK;
 		lastSearchQuery = question;
@@ -56,37 +126,47 @@ final class CountingQueryStoreStub implements QueryStoreService {
 		return stubHits;
 	}
 
-	@Override
-	public List<QueryDocument> getPatientChart(String patientUuid) {
+	private List<QueryDocument> getPatientChart(String patientUuid) {
 		getPatientChartCalls++;
 		return stubChart;
 	}
 
-	@Override
-	public List<QueryDocument> search(String question, int topK) {
-		throw new UnsupportedOperationException("not used by chartsearchai");
+	/**
+	 * {@code toString}, {@code hashCode} and {@code equals} route through the handler too, and a
+	 * double that explodes when it is logged or compared fails a long way from its cause. Identity
+	 * semantics: a double has no value to compare, and hashCode must agree with equals.
+	 */
+	private Object answerObjectMethod(Object proxy, Method method, Object[] arguments) {
+		if ("toString".equals(method.getName())) {
+			return "CountingQueryStoreStub(searchByPatientCalls=" + searchByPatientCalls
+					+ ", getPatientChartCalls=" + getPatientChartCalls + ")";
+		}
+		if ("hashCode".equals(method.getName())) {
+			return Integer.valueOf(System.identityHashCode(proxy));
+		}
+		if ("equals".equals(method.getName())) {
+			return Boolean.valueOf(proxy == arguments[0]);
+		}
+		throw refusal(method);
 	}
 
-	@Override
-	public WriteResult index(QueryDocument doc) {
-		throw new UnsupportedOperationException("not used by chartsearchai");
+	private static UnsupportedOperationException refusal(Method method) {
+		return new UnsupportedOperationException("CountingQueryStoreStub does not answer "
+				+ method.getDeclaringClass().getSimpleName() + "." + method.getName()
+				+ " — chartsearchai did not call it when this double was written. If it does now, "
+				+ "teach the double about it, and decide whether it should be counted, rather than "
+				+ "letting a default answer stand in.");
 	}
 
-	@Override
-	public void delete(String resourceType, String resourceUuid) {
-		throw new UnsupportedOperationException("not used by chartsearchai");
-	}
-
-	@Override
-	public void bulkDeleteByPatient(String patientUuid) {
-		throw new UnsupportedOperationException("not used by chartsearchai");
-	}
-
-	@Override
-	public void onStartup() {
-	}
-
-	@Override
-	public void onShutdown() {
+	private static Method interfaceMethod(String name, Class<?>... parameterTypes) {
+		try {
+			return QueryStoreService.class.getMethod(name, parameterTypes);
+		}
+		catch (NoSuchMethodException e) {
+			throw new IllegalStateException("QueryStoreService no longer declares " + name
+					+ " with this signature, so the call counts the chart-builder tests assert are "
+					+ "no longer meaningful — update this double against the current querystore API",
+					e);
+		}
 	}
 }

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CountingQueryStoreStubTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CountingQueryStoreStubTest.java
@@ -1,0 +1,231 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.api.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.querystore.api.QueryStoreService;
+import org.openmrs.module.querystore.model.QueryDocument;
+
+/**
+ * Specification for {@link CountingQueryStoreStub} — the shared chart-builder double.
+ *
+ * <p>Issue #165: the double used to {@code implement QueryStoreService} directly, so every
+ * method querystore added to that interface broke chartsearchai's <em>test compile</em>. That
+ * is a build property, and this test cannot assert it: proving it needs a second querystore jar
+ * whose interface carries a method this source does not name, which no single build can supply.
+ * The PR demonstrates it by building against such a jar instead. What IS asserted here is the
+ * mechanism the demonstration rests on, plus the two properties that make interface tolerance
+ * safe rather than merely convenient:
+ *
+ * <ul>
+ *   <li>{@link #stub_shouldNotImplementTheQuerystoreInterfaceAtCompileTime()} — the regression
+ *       guard. Re-adding {@code implements QueryStoreService} reinstates the defect and nothing
+ *       else in the suite would notice.</li>
+ *   <li>{@link #asService_shouldAnswerOnlyTheMethodsItDeclares_andThrowLoudlyForEveryOther()} —
+ *       tolerating interface growth must not mean answering silently. A double that returns a
+ *       plausible empty value for a method it has never heard of lets a test pass while
+ *       exercising nothing, which is a worse failure than the compile break.</li>
+ *   <li>{@link #asService_shouldRouteCountedCallsToTheCounters()} and
+ *       {@link #asService_shouldPropagateTheSimulatedRpcFailureUnwrapped()} — the counting and
+ *       failure-simulation the double exists to do still work through the indirection.</li>
+ * </ul>
+ */
+public class CountingQueryStoreStubTest {
+
+	/**
+	 * The {@code QueryStoreService} methods the double answers on purpose — the two it counts
+	 * plus the {@code OpenmrsService} lifecycle pair, which a double has no work to do for.
+	 *
+	 * <p>Deliberately spelled out here rather than read from the double: this list is the
+	 * specification. Asserting against a constant the double itself exports would pass no matter
+	 * which methods it decided to answer, which is exactly the change that needs a human to look
+	 * at it.
+	 */
+	private static final Set<String> ANSWERED_ON_PURPOSE = new TreeSet<>(
+			Arrays.asList("searchByPatient", "getPatientChart", "onStartup", "onShutdown"));
+
+	@Test
+	public void stub_shouldNotImplementTheQuerystoreInterfaceAtCompileTime() {
+		// #165's regression guard, and the closest an in-process test gets to the build property:
+		// a class that names the interface's method set in its own source is a class that stops
+		// compiling when the set changes. Whether the double survives a GROWN interface can only
+		// be shown by compiling against one; that it cannot be broken THIS way can be shown here.
+		assertFalse(QueryStoreService.class.isAssignableFrom(CountingQueryStoreStub.class),
+				"CountingQueryStoreStub must not implement QueryStoreService at compile time — a "
+						+ "direct implementor must override every abstract method the interface "
+						+ "declares, so #165 (a querystore API addition breaking chartsearchai's "
+						+ "test compile) returns the moment this holds again");
+	}
+
+	@Test
+	public void asService_shouldAnswerOnlyTheMethodsItDeclares_andThrowLoudlyForEveryOther() throws Exception {
+		CountingQueryStoreStub stub = new CountingQueryStoreStub();
+		QueryStoreService service = stub.asService();
+
+		Set<String> answeredWithoutThrowing = new TreeSet<>();
+		for (Method method : QueryStoreService.class.getMethods()) {
+			if (Modifier.isStatic(method.getModifiers()) || method.isSynthetic()) {
+				continue;
+			}
+			try {
+				method.invoke(service, zeroArguments(method));
+				answeredWithoutThrowing.add(method.getName());
+			}
+			catch (InvocationTargetException e) {
+				if (!(e.getCause() instanceof UnsupportedOperationException)) {
+					fail("an unanswered QueryStoreService method must refuse with "
+							+ "UnsupportedOperationException, but " + method.getName() + " threw "
+							+ e.getCause());
+				}
+				assertTrue(e.getCause().getMessage() != null
+						&& e.getCause().getMessage().contains(method.getName()),
+						"the refusal must name the method so the failure points at the querystore "
+								+ "API that moved rather than at this test class; message was: "
+								+ e.getCause().getMessage());
+			}
+		}
+
+		assertEquals(ANSWERED_ON_PURPOSE, answeredWithoutThrowing,
+				"the double must answer exactly the methods it deliberately serves and refuse every "
+						+ "other one. A method that returns a plausible default instead — an "
+						+ "interface `default` the double inherits, or a no-op nobody chose — lets a "
+						+ "test pass while exercising nothing");
+	}
+
+	@Test
+	public void asService_shouldRouteCountedCallsToTheCounters() {
+		CountingQueryStoreStub stub = new CountingQueryStoreStub();
+		stub.stubHits.add(doc("Obs", "obs-1"));
+		stub.stubChart.add(doc("Condition", "cond-1"));
+		QueryStoreService service = stub.asService();
+
+		assertSame(stub.stubHits, service.searchByPatient("patient-uuid", "blood pressure?", 7),
+				"searchByPatient must return the stub's hit list itself — a copy would let a test "
+						+ "mutate stubHits after the call and see stale content");
+		assertSame(stub.stubChart, service.getPatientChart("patient-uuid"),
+				"getPatientChart must return the stub's chart list itself");
+
+		assertEquals(1, stub.searchByPatientCalls, "searchByPatient must increment its counter");
+		assertEquals(1, stub.getPatientChartCalls, "getPatientChart must increment its counter");
+		assertEquals(2, stub.getCallCount(), "the aggregate counter must see both calls");
+		assertEquals(7, stub.lastSearchTopK, "the requested topK must be recorded");
+		assertEquals("blood pressure?", stub.lastSearchQuery, "the question must be recorded");
+	}
+
+	@Test
+	public void asService_shouldPropagateTheSimulatedRpcFailureUnwrapped() {
+		// throwOnSearch exists so the builder's degradation paths can be exercised. The builder
+		// catches RuntimeException broadly, so a wrapped throw would still degrade and those tests
+		// would still pass — but the double would no longer resemble a querystore RPC failure,
+		// and the next caller to inspect the cause would be misled.
+		CountingQueryStoreStub stub = new CountingQueryStoreStub();
+		stub.throwOnSearch = true;
+		QueryStoreService service = stub.asService();
+
+		RuntimeException thrown = assertThrows(RuntimeException.class,
+				() -> service.searchByPatient("patient-uuid", "any allergies?", 5));
+
+		assertFalse(thrown instanceof UndeclaredThrowableException,
+				"the simulated RPC failure must reach the caller as itself, not wrapped");
+		assertEquals("simulated similarity RPC failure", thrown.getMessage(),
+				"the simulated failure must arrive unchanged");
+		assertEquals(1, stub.searchByPatientCalls,
+				"the call must be counted before it fails — the builder tests assert it was reached");
+	}
+
+	@Test
+	public void asService_shouldReturnAStableProxyThatSupportsObjectMethods() {
+		// Object's methods route through the same handler as the interface's, so an over-eager
+		// refusal arm would make the double explode when it is logged, compared, or put in a
+		// collection — surprising failures a long way from the cause.
+		CountingQueryStoreStub stub = new CountingQueryStoreStub();
+		QueryStoreService service = stub.asService();
+
+		assertSame(service, stub.asService(),
+				"asService must hand out one stable instance — two proxies over the same counters "
+						+ "would compare unequal and hash differently");
+		assertNotNull(service.toString(), "toString must work; the double gets logged");
+		assertEquals(service.hashCode(), stub.asService().hashCode(), "hashCode must be stable");
+		assertTrue(service.equals(stub.asService()), "equals must be reflexive");
+		assertFalse(service.equals(new Object()), "equals must reject a foreign object");
+	}
+
+	private static QueryDocument doc(String resourceType, String resourceUuid) {
+		QueryDocument document = new QueryDocument();
+		document.setResourceType(resourceType);
+		document.setResourceUuid(resourceUuid);
+		return document;
+	}
+
+	/**
+	 * Zero/null arguments for a reflective sweep of the interface.
+	 *
+	 * <p>These are also the inputs under which an inherited {@code default} is likeliest to
+	 * return a plausible empty result rather than fail — {@code bulkIndex(null)} short-circuits
+	 * to an empty {@code BulkWriteResult} upstream — so they are the values that actually
+	 * discriminate a refusal from a silent answer. Every primitive is handled so the sweep keeps
+	 * working as the interface grows, which is the point of the change under test.
+	 */
+	private static Object[] zeroArguments(Method method) {
+		Class<?>[] parameterTypes = method.getParameterTypes();
+		Object[] arguments = new Object[parameterTypes.length];
+		for (int i = 0; i < parameterTypes.length; i++) {
+			arguments[i] = zeroValue(parameterTypes[i]);
+		}
+		return arguments;
+	}
+
+	private static Object zeroValue(Class<?> type) {
+		if (!type.isPrimitive()) {
+			return null;
+		}
+		if (type == boolean.class) {
+			return Boolean.FALSE;
+		}
+		if (type == char.class) {
+			return Character.valueOf('\0');
+		}
+		if (type == byte.class) {
+			return Byte.valueOf((byte) 0);
+		}
+		if (type == short.class) {
+			return Short.valueOf((short) 0);
+		}
+		if (type == int.class) {
+			return Integer.valueOf(0);
+		}
+		if (type == long.class) {
+			return Long.valueOf(0L);
+		}
+		if (type == float.class) {
+			return Float.valueOf(0f);
+		}
+		if (type == double.class) {
+			return Double.valueOf(0d);
+		}
+		throw new IllegalStateException("no zero value for parameter type " + type);
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderScopedTest.java
@@ -69,7 +69,7 @@ public class QueryStoreChartBuilderScopedTest {
 	@BeforeEach
 	public void setUp() {
 		queryStore = new CountingQueryStoreStub();
-		builder = new TestableScopedBuilder(queryStore);
+		builder = new TestableScopedBuilder(queryStore.asService());
 		builder.setChartSerializer(new PatientChartSerializer());
 		// A chart in date-desc order: patient record, then interleaved types.
 		queryStore.stubChart = new ArrayList<QueryDocument>(Arrays.asList(

--- a/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/api/impl/QueryStoreChartBuilderTest.java
@@ -52,7 +52,7 @@ public class QueryStoreChartBuilderTest {
 	@BeforeEach
 	public void setUp() {
 		queryStore = new CountingQueryStoreStub();
-		builder = new TestableQueryStoreChartBuilder(queryStore);
+		builder = new TestableQueryStoreChartBuilder(queryStore.asService());
 		builder.setChartSerializer(new PatientChartSerializer());
 	}
 


### PR DESCRIPTION
## The defect

`CountingQueryStoreStub` — the shared double behind `QueryStoreChartBuilderTest` and
`QueryStoreChartBuilderScopedTest` — implemented `QueryStoreService` directly. A class that
implements an interface must override every abstract method it declares, so **every method
querystore adds to that interface stops chartsearchai's test sources from compiling.** Not
failing, not skipping: the test sources do not build.

Reproduced on `main` (45c1cc4) against the locally-built querystore jar that carries
`ContextSlice getContextSlice(String, String, ContextSliceRequest)` — one error, and it is the
whole build:

```
[ERROR] .../api/src/test/java/org/openmrs/module/chartsearchai/api/impl/CountingQueryStoreStub.java:[26,7]
        org.openmrs.module.chartsearchai.api.impl.CountingQueryStoreStub is not abstract and does not
        override abstract method getContextSlice(java.lang.String,java.lang.String,
        org.openmrs.module.querystore.model.ContextSliceRequest)
        in org.openmrs.module.querystore.api.QueryStoreService
[INFO] 1 error
[INFO] Chart Search AI Module - API ....................... FAILURE
[INFO] Chart Search AI Module - OMOD ...................... SKIPPED
```

`1 error` is worth noting on its own: this stub was the *only* class in the module that broke, so
fixing it fixes the failure mode rather than the first instance of it.

## Why the failure mode is invisible in CI

CI resolves the **remote** querystore snapshot, which predates the change. A developer who has run
`mvn install` in openmrs-module-querystore resolves their **local** one. So `main` is green in CI
and broken on that developer's machine, and the javac error names a *chartsearchai test class*
rather than the dependency that moved — the reader's first instinct is to look at code that did
not change. It happened three times on the development box in one day; an agent had to detect it,
swap artifacts to measure anything at all, and restore them afterwards.

Retrieval is owned by querystore (#51) and its API is expected to keep moving, so this recurs on
every addition.

## Which of the three options, and why over the other two

**Option 2, the dynamic proxy.** The double is no longer a `QueryStoreService`; it holds the
counters and fixture lists, and `asService()` hands out a `java.lang.reflect.Proxy` bound to the
interface **at runtime**. It names no method set at compile time, so interface growth cannot break
the build.

**Option 1 (abstract adapter with no-op defaults) does not work.** This is the issue's first
suggestion and it is structurally incapable of fixing the defect: a concrete subclass must
override every abstract method inherited from *anywhere*, so an abstract superclass cannot satisfy
a method the interface adds later — the identical "is not abstract and does not override abstract
method" error simply moves to the subclass. Measured with a minimal javac reproduction rather than
argued from memory:

```
Stub.java:1: error: Stub is not abstract and does not override abstract method grown(String) in Svc
public final class Stub extends Adapter {
```

An adapter only helps when upstream adds methods as `default`, and `getContextSlice` is abstract —
the case that actually occurred. That split is the deeper problem with any compile-time
implementor, adapter or not: it **fails loudly on an abstract addition and absorbs a `default` one
silently**. Both halves are visible in this one jar — `getContextSlice` (abstract) breaks the
build, `getPatientChartRead` (default) would be inherited with nobody deciding what it should do —
and the silent half is exactly how `bulkIndex` slipped past unnoticed below.

**Option 3 (pin the querystore version) was rejected**, though it is the only option that makes a
local build and CI agree, which is a real benefit this PR does not deliver:

- It **changes what CI resolves** — a build-wide decision affecting how *production* code is
  compiled, not just one test double. That is a bigger commitment than #165 needs, and it should be
  a deliberate dependency-policy choice, not a side effect of fixing a stub.
- Pinning to a **timestamped snapshot** (`1.0.0-20260803.120447-81`) is reproducible but goes stale
  silently: chartsearchai stops compiling against querystore's current API, so genuine
  incompatibilities are discovered in one batch whenever someone bumps it, rather than continuously.
  It also freezes what production code may use — adopting a querystore fix would need a pom change.
- Pinning a **range** does not solve the problem at all: a range still resolves to whatever is
  newest, including a local install.
- It leaves the stub exactly as fragile. The next deliberate bump reintroduces this break, so the
  work has to be done anyway.
- It does nothing about the silent-default hazard below.

Option 3 remains available and is orthogonal to this change; nothing here precludes it.

## The silent-default trade

A double that tolerates interface growth must not tolerate it *quietly*. The stub exists to count
calls; if a method it has never heard of returns a plausible empty value, a test can pass while
exercising nothing and nobody is told. So every method the double does not deliberately serve is
refused with an `UnsupportedOperationException` naming it.

The argument for refusing rather than defaulting is asymmetric, not aesthetic. Refusing can only
fail a test that has started depending on a new querystore call — a change a human should look at.
Returning an empty list where the real service returns data would silently weaken every downstream
assertion, which the repo rules call out as worse than a compile break.

This is not hypothetical either. The pre-fix double already answered one method silently:
`bulkIndex`, an interface `default` it inherited, which short-circuits to an empty
`BulkWriteResult`. The new reflective sweep caught it:

```
expected: <[getPatientChart, onShutdown, onStartup, searchByPatient]>
 but was: <[bulkIndex, getPatientChart, onShutdown, onStartup, searchByPatient]>
```

Two deliberate consequences:

- Dispatch matches on the resolved `Method`, not on a name, so an **overload** of a counted method
  (`searchByPatient` gaining a filter argument, say) is refused rather than answered with the wrong
  semantics.
- Growth is absorbed, but a counted method being **removed or resignatured** is not, and
  deliberately so — the call counts those tests assert would no longer mean anything. That case
  fails when the double is constructed, with a message naming querystore. Resolution is per
  instance rather than in a static initialiser for exactly this reason: a failed static initialiser
  reports the real cause once and then `NoClassDefFoundError` for every later test in the class,
  burying the message that matters.

## TDD, and what could not be tested

`CountingQueryStoreStubTest` (5 tests) was written first and measured failing. The seam
(`asService()`) was introduced returning `this` so the finished test compiled against the old
double; the test file was not touched again once the implementation changed behind it:

```
[ERROR] Tests run: 5, Failures: 2
  stub_shouldNotImplementTheQuerystoreInterfaceAtCompileTime:76
      expected: <false> but was: <true>
  asService_shouldAnswerOnlyTheMethodsItDeclares_andThrowLoudlyForEveryOther:103
      the refusal must name the method ... message was: not used by chartsearchai
      expected: <true> but was: <false>
```

**The compile-survival property itself cannot honestly be unit-tested.** Asserting it needs a
second querystore jar whose interface carries a method this source does not name, which no single
build can supply — a test that merely compiles proves nothing, and a test that stood up a
hand-written "future interface" would be asserting against a fiction. So it is demonstrated by
building against the real jar (below), and the test file says so rather than implying coverage it
does not have. What the tests *do* pin is the mechanism the demonstration rests on
(`CountingQueryStoreStub` must not be assignable to `QueryStoreService` — re-adding
`implements` reinstates the defect and nothing else in the suite would notice), that no interface
method answers silently, that counting still reaches the counters, that the simulated RPC failure
arrives unwrapped, and that `toString`/`equals`/`hashCode` still work through the proxy.

## Demonstration: the double survives a grown interface

The locally-built querystore jar (`md5 6286600c1923c68e4447becb71499b41`) declares two methods the
remote snapshot does not — abstract `getContextSlice(String, String, ContextSliceRequest)` and
default `getPatientChartRead(String)`. Swapping it in for the resolved
`querystore-api-1.0.0-SNAPSHOT.jar` and building both trees:

| tree | querystore jar | result |
|---|---|---|
| `main` @ 45c1cc4 | local (grown) | **FAILURE** — 1 error, `CountingQueryStoreStub.java:[26,7]`, OMOD skipped |
| this branch | local (grown) | **SUCCESS** — 897 api + 61 omod, 0 failures, 34 skipped |
| this branch | remote snapshot | **SUCCESS** — 897 api + 61 omod, 0 failures, 34 skipped |

The last two rows being identical is the point: the double refuses `getContextSlice` (nothing calls
it), so the grown interface changes no test's behaviour — it just no longer breaks the build.

The jar was restored afterwards to the exact bytes that were there before (`md5
e9917ab5aa895199fa395d7b932b795b`, byte-identical to
`querystore-api-1.0.0-20260803.120447-81.jar`), and `getContextSlice` verified absent from the
restored interface. Nothing was deleted.

## Build numbers

`mvn -o clean install`, full reactor, against the **remote** snapshot
`querystore-api-1.0.0-20260803.120447-81.jar` (`md5 e9917ab5aa895199fa395d7b932b795b`, the jar
resolved as `querystore-api-1.0.0-SNAPSHOT.jar`):

| | api | omod | total | failures | errors | skipped |
|---|---|---|---|---|---|---|
| `main` @ 45c1cc4 | 892 | 61 | **953** | 0 | 0 | 34 |
| this branch | 897 | 61 | **958** | 0 | 0 | 34 |

+5 is the new test class; no test was lost or newly skipped.

The counting this double exists to do is still asserted by **`QueryStoreChartBuilderTest` (25/25)**
and **`QueryStoreChartBuilderScopedTest` (25/25)** — the two classes that read
`searchByPatientCalls`, `getPatientChartCalls`, `getCallCount()`, `lastSearchTopK` and
`lastSearchQuery`. Both pass unchanged, under both jars.

**No production code is touched** — the diff is four files, all under `api/src/test`. A test-only
change needs no standalone deploy, so none was run. No assertion was modified; the only edits to
existing tests are the two constructor arguments that hand the double to the builder
(`new TestableQueryStoreChartBuilder(queryStore.asService())`).

## Limitations, honestly

- **Scoped to the double.** If querystore changes a method chartsearchai's *production* code calls,
  the local build still breaks while CI stays green — correctly, but just as invisibly. That
  residual half of the failure mode is what option 3 would have addressed. A CI job that builds
  against the latest querystore snapshot would surface it in CI instead of on a developer's box;
  that is a separate change and not filed here.
- **The double loses compile-time checking of its own dispatch.** javac no longer verifies that the
  methods it counts exist; a rename upstream becomes a runtime failure at construction instead of a
  compile error. That is the deliberate cost of the fix, mitigated by resolving the methods eagerly
  and failing with a message that names querystore.
- Unrelated to #96: this adds no dependency and the new test loads no `ApplicationContext`.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
