### PR TITLE
fix(drug-safety): decide identity by substance, and name the patient's own record

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
@@ -49,7 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * entries, which is what the validator's from-either-side matching expects.
  *
  * <p>One class of row is deliberately NOT expanded: a row pairing a drug with itself, or with another
- * route/formulation row of the same substance — see {@link #isSelfPair} (issue #152).
+ * row of the same substance — see {@link #isSelfPair} (issues #152, #164).
  *
  * <p>Memory: there are far fewer distinct mechanism descriptions than pairs, so the
  * per-partner notes are interned (one shared {@link String} per {@code severity + group}),
@@ -255,15 +255,20 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 	 * <ul>
 	 *   <li>the same row on both sides — exactly one in the shipped 19 MB KB, {@code DDInter225}
 	 *       (botulinum toxin type A) of 295,184 rows. Its mechanism text is about administering
-	 *       different botulinum SEROTYPES together, and the KB files that same mechanism on genuine
-	 *       cross-row pairs of its own — {@code Botulinum toxin type A} against
-	 *       {@code Botulinum Toxin Type B}, and {@code Daxibotulinumtoxina} against each of them — none
-	 *       of which this guard touches. So the self-pair is an artifact of the KB's granularity that
-	 *       carries no clinical content its siblings do not, while what it puts in front of a clinician
-	 *       is "Botulinum toxin type A interacts with active order botulinum toxin type A".</li>
-	 *   <li>two ROUTE/FORMULATION rows of one substance — 25 more, {@code Lidocaine} against
-	 *       {@code Lidocaine (topical)} and the like (measured 2026-08-06; re-measure before relying on
-	 *       the figures). Also unrenderable rather than merely redundant: every row of a substance
+	 *       different botulinum SEROTYPES together, and the KB files that same mechanism on a genuine
+	 *       cross-SUBSTANCE pair of its own — {@code Botulinum toxin type A} against
+	 *       {@code Botulinum Toxin Type B}, a different {@code rxnorm_name}, which this guard leaves
+	 *       loaded. So the self-pair is an artifact of the KB's granularity that carries no clinical
+	 *       content its sibling does not, while what it puts in front of a clinician is
+	 *       "Botulinum toxin type A interacts with active order botulinum toxin type A".</li>
+	 *   <li>two rows of one substance — 27 more, {@code Lidocaine} against
+	 *       {@code Lidocaine (topical)} and the like (measured 2026-08-07 through this parser;
+	 *       re-measure before relying on the figures). 25 of the 27 are route/formulation variants; the
+	 *       other 2 are rows of one substance whose display names diverge, which the guard only sees
+	 *       since issue #164 widened what {@link DrugReference#substanceKey} counts as one substance —
+	 *       {@code Daxibotulinumtoxina} against {@code Botulinum toxin type A} (Moderate) and two
+	 *       influenza B strain antigens (Minor). Also unrenderable rather than merely redundant: every
+	 *       row of a substance
 	 *       publishes the same {@code rxnorm_name}, which is the match token a rule carries and the label
 	 *       a chip prints, so such a pair can ONLY read as a substance interacting with itself. The
 	 *       systemic-plus-topical exposure the KB row is about cannot be stated by anything this module
@@ -275,15 +280,18 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 	 *       whose two entries share a name. So this guard makes a decision that arm already took, at the
 	 *       boundary where it covers every arm.
 	 *
-	 *       <p>The accepted cost, named rather than left general: two of the 25 are rated Major —
+	 *       <p>The accepted cost, named rather than left general: two of the 27 are rated Major —
 	 *       {@code Bupivacaine} against {@code Bupivacaine (liposome)} and {@code Aminolevulinic acid}
-	 *       against {@code Aminolevulinic acid (topical)}. Those are real product-level warnings, and
+	 *       against {@code Aminolevulinic acid (topical)}, both route variants and both there before
+	 *       #164. Those are real product-level warnings, and
 	 *       under-warning is the direction this module is otherwise careful about; they are dropped
 	 *       because a chip reading "Bupivacaine interacts with active order bupivacaine" is not that
 	 *       warning. Stating them needs the route vocabulary that is the data-side half of issue #115.</li>
 	 * </ul>
-	 * Through {@link DrugReference#substanceKey(String, String)} rather than a local comparison, so this
-	 * guard and the chip grouping mean the same thing by "one substance". A row publishing no substance
+	 * Through {@link DrugReference#substanceKey(String, String, String)} rather than a local comparison,
+	 * so this guard and the chip grouping mean the same thing by "one substance" — which is why issue
+	 * #164 needed no change on the interaction arm at all: widening that key widened this guard with it.
+	 * A row publishing no substance
 	 * name keys null and is then only caught by the id test — the conservative direction: with no
 	 * substance identity to compare, two different ids are two different drugs.
 	 *

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
@@ -14,9 +14,12 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -147,6 +150,10 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 			}
 		}
 
+		// Which rows are one substance is a property of the DATASET, not of a row, so it is settled here
+		// once, before anything reads it — see substanceIds.
+		Map<String, String> substanceIds = substanceIds(order);
+
 		// mechanisms table (text stored once); note strings interned per severity+group.
 		// Severity strings are interned too: the vocabulary is four values across ~300k
 		// full-KB rows, and Jackson allocates a fresh String per row — without this cache the
@@ -170,7 +177,7 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 			if (!byId.containsKey(a) || !byId.containsKey(b)) {
 				continue;
 			}
-			if (isSelfPair(byId.get(a), byId.get(b))) {
+			if (isSelfPair(byId.get(a), byId.get(b), substanceIds)) {
 				selfPairs++;
 				continue;
 			}
@@ -216,6 +223,11 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 			// identically: setId above already spends the RxCUI on entry identity, where a shared one is
 			// precisely what it must NOT be.
 			ref.setSubstanceName(row.rxnormName);
+			// And WHICH substance of that name, where the dataset's substance registry can say — the
+			// veto that keeps Omeprazole and Esomeprazole two substances while letting Tozinameran and
+			// its brand row be one (issue #164). Resolved over the whole drugs table above, because no
+			// row can answer it alone.
+			ref.setSubstanceId(substanceIds.get(DrugReference.normalizeName(row.rxnormName)));
 			// Chip-label synonym (never renaming): when the DDInter display name diverges from
 			// the RxNorm generic the question and chart use ("Acetylsalicylic acid" vs
 			// "aspirin"), carry the generic so safety chips can show both vocabularies. A name
@@ -290,12 +302,78 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 	 * hand-authored curated file is the operator's own data, and the {@code atc} adapter carries no
 	 * rules at all.
 	 */
-	private static boolean isSelfPair(DrugRow a, DrugRow b) {
+	private static boolean isSelfPair(DrugRow a, DrugRow b, Map<String, String> substanceIds) {
 		if (a.id.equals(b.id)) {
 			return true;
 		}
-		Object substance = DrugReference.substanceKey(a.name, a.rxnormName);
-		return substance != null && substance.equals(DrugReference.substanceKey(b.name, b.rxnormName));
+		Object substance = DrugReference.substanceKey(a.name, a.rxnormName, substanceIdOf(a, substanceIds));
+		return substance != null && substance.equals(
+				DrugReference.substanceKey(b.name, b.rxnormName, substanceIdOf(b, substanceIds)));
+	}
+
+	private static String substanceIdOf(DrugRow row, Map<String, String> substanceIds) {
+		return substanceIds.get(DrugReference.normalizeName(row.rxnormName));
+	}
+
+	/**
+	 * Which substance each {@code rxnorm_name} in this dataset stands for, where the dataset can say —
+	 * the value {@link DrugReference#getSubstanceId()} carries, keyed by the normalized substance name
+	 * the rows publishing it share.
+	 *
+	 * <p><b>Why the DrugBank id, and why resolved per family rather than per row.</b> A
+	 * {@code rxnorm_name} over-merges: the KB files {@code Omeprazole} and {@code Esomeprazole} under
+	 * one, with one {@code rxcui} and one ATC code, and they are two substances (issue #121's
+	 * {@code enalapril}/{@code enalaprilat} decision). Something has to veto that claim, and the
+	 * {@code drugbank_id} is the dataset's own substance-level registry — an identifier of a SUBSTANCE
+	 * rather than of a presentation, which is exactly the distinction a display name cannot make. So:
+	 * <ul>
+	 *   <li>the rows of a substance name that carry <b>at most one</b> DrugBank id between them are one
+	 *       substance, and every one of them takes that id — including the rows carrying none, which is
+	 *       what lets {@code Pfizer-BioNTech Covid-19 Vaccine} (no id) be the same substance as
+	 *       {@code Tozinameran} ({@code DB15696}) and {@code Daxibotulinumtoxina} (no id) the same as
+	 *       {@code Botulinum toxin type A} ({@code DB00083}), the two shapes issue #164 measured;</li>
+	 *   <li>the rows of a substance name that carry <b>two or more</b> get no id at all, and
+	 *       {@link DrugReference#substanceKey()} falls back to the display stem exactly as before. The
+	 *       whole family falls back together, not just the rows carrying an id: {@code Atropine}
+	 *       ({@code DB00572}), {@code Atropine (ophthalmic)} (none) and {@code Hyoscyamine}
+	 *       ({@code DB00424}) are one family, and a row-by-row rule would key the first two differently
+	 *       and split a route variant off its own substance.</li>
+	 * </ul>
+	 * A name shared by rows that name no DrugBank substance at all is in the first case, keyed on the
+	 * substance name itself: the data offers nothing finer, so it is not distinguishing anything, and
+	 * that is what merges {@code Thallous Chloride}/{@code Thallous chloride tl-201} and
+	 * {@code Typhoid vaccine (live)}/{@code Typhoid vaccine live}.
+	 *
+	 * <p>Measured over the shipped 19 MB KB (2283 rows; re-measure before relying on the figures): 142
+	 * substance names are shared by more than one row, 19 of them naming two or more DrugBank
+	 * substances and 123 naming at most one. No group the resulting key produces holds two DrugBank
+	 * substances.
+	 */
+	private static Map<String, String> substanceIds(List<DrugRow> rows) {
+		Map<String, Set<String>> byName = new LinkedHashMap<String, Set<String>>();
+		for (DrugRow row : rows) {
+			String substance = DrugReference.normalizeName(row.rxnormName);
+			if (substance == null) {
+				continue;
+			}
+			Set<String> ids = byName.get(substance);
+			if (ids == null) {
+				ids = new LinkedHashSet<String>();
+				byName.put(substance, ids);
+			}
+			String id = DrugReference.normalizeName(row.drugbankId);
+			if (id != null) {
+				ids.add(id);
+			}
+		}
+		Map<String, String> out = new HashMap<String, String>();
+		for (Map.Entry<String, Set<String>> family : byName.entrySet()) {
+			Set<String> ids = family.getValue();
+			if (ids.size() <= 1) {
+				out.put(family.getKey(), ids.isEmpty() ? family.getKey() : ids.iterator().next());
+			}
+		}
+		return out;
 	}
 
 	private static List<DrugReference.Interaction> interactionsFor(List<Link> links, Map<String, DrugRow> byId) {
@@ -365,15 +443,21 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 
 		final String rxnormName;
 
+		/** The dataset's substance-registry id for this row, or null — read only by
+		 *  {@link DdiDrugReferenceSource#substanceIds}, which is where its meaning is recorded. */
+		final String drugbankId;
+
 		final List<String> atc;
 
 		final List<String> aliases;
 
-		private DrugRow(String id, String name, String rxcui, String rxnormName, List<String> atc, List<String> aliases) {
+		private DrugRow(String id, String name, String rxcui, String rxnormName, String drugbankId,
+				List<String> atc, List<String> aliases) {
 			this.id = id;
 			this.name = name;
 			this.rxcui = rxcui;
 			this.rxnormName = rxnormName;
+			this.drugbankId = drugbankId;
 			this.atc = atc;
 			this.aliases = aliases;
 		}
@@ -389,6 +473,7 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 			// synonym all see the same clean value — a padded name would defeat the guard and
 			// leak padding into the label.
 			String rxnormName = d.path("rxnorm_name").isTextual() ? d.get("rxnorm_name").asText().trim() : null;
+			String drugbankId = d.path("drugbank_id").isTextual() ? d.get("drugbank_id").asText().trim() : null;
 			List<String> atc = new ArrayList<String>();
 			for (JsonNode a : d.path("atc")) {
 				atc.add(a.asText());
@@ -404,7 +489,7 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 					addAlias(aliases, c.get("name").asText());
 				}
 			}
-			return new DrugRow(id, name, rxcui, rxnormName, atc, aliases);
+			return new DrugRow(id, name, rxcui, rxnormName, drugbankId, atc, aliases);
 		}
 
 		private static void addAlias(List<String> aliases, String value) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -187,9 +187,9 @@ public class DrugReference {
 	 *       values are shared by more than one entry, across 332 entries, and the {@code rxcui}
 	 *       partitions those entries identically (0 families disagreeing in either direction), so this
 	 *       is the dataset's substance identity rather than a spelling coincidence.</li>
-	 *   <li>{@link #getSubstanceId()} — the data's own IDENTITY for that substance, as a VETO on the
-	 *       claim, because the claim over-merges. Among those 142 families sit pairs of genuinely
-	 *       different substances: {@code Omeprazole}/{@code Esomeprazole} (one
+	 *   <li>{@link #getSubstanceId()} — the data's own IDENTITY for that substance, which either
+	 *       CONFIRMS the claim or withdraws it, because the claim over-merges. Among those 142 families
+	 *       sit pairs of genuinely different substances: {@code Omeprazole}/{@code Esomeprazole} (one
 	 *       {@code rxnorm_name}, one {@code rxcui}, one ATC code),
 	 *       {@code Amphetamine}/{@code Dextroamphetamine}, {@code Fenfluramine}/{@code Dexfenfluramine},
 	 *       {@code Gabapentin}/{@code Gabapentin enacarbil}, {@code Netupitant}/{@code Fosnetupitant},
@@ -197,8 +197,10 @@ public class DrugReference {
 	 *       {@code Atropine}/{@code Hyoscyamine}, {@code Hydrocortisone}/{@code Hydrocortisone butyrate},
 	 *       {@code Estrone}/{@code Estrone sulfate} — each of them the
 	 *       {@code enalapril}/{@code enalaprilat} shape issue #121 decided must stay two chips. 19 of the
-	 *       142 families name two or more DrugBank substances and are exactly these; in each, the id is
-	 *       null and the veto falls to the DISPLAY STEM below, which separates every one of them.</li>
+	 *       142 families name two or more DrugBank substances and are exactly these. There the id is
+	 *       withheld — {@link DdiDrugReferenceSource} sets none, because it cannot say which of the two
+	 *       a given row is — and the veto falls to the DISPLAY STEM, which separates every one of
+	 *       them.</li>
 	 * </ul>
 	 *
 	 * <p><b>Why the stem is the fallback and not the veto (issue #164).</b> It used to be the veto, and
@@ -287,10 +289,10 @@ public class DrugReference {
 	 *         the data-side gap issue #115 records), so the only route it can honestly assert is none.
 	 *
 	 *         <p>Consumed by {@link #canonicalRow}, which is where the two collapses that need it agree
-	 *         on one answer. Measured over the shipped 19 MB KB (2026-08-06; re-measure before relying
-	 *         on the figures): of the 121 substances filed as more than one row, 110 have such a row and
-	 *         11 do not — {@code Oxymetazoline (nasal)}/{@code (ophthalmic)}/{@code (topical)},
-	 *         {@code Iobenguane (I-123)}/{@code (I-131)} — and in 7 of the 110 it is NOT the family's
+	 *         on one answer. Measured over the shipped 19 MB KB (2026-08-07; re-measure before relying
+	 *         on the figures): of the 129 substances filed as more than one row, 119 have such a row and
+	 *         10 do not — {@code Oxymetazoline (nasal)}/{@code (ophthalmic)}/{@code (topical)},
+	 *         {@code Iobenguane (I-123)}/{@code (I-131)} — and in 7 of the 119 it is NOT the family's
 	 *         first row, which is why the choice cannot be left to dataset order.
 	 */
 	boolean namesNoRoute() {
@@ -311,7 +313,7 @@ public class DrugReference {
 	 *
 	 * @return {@code candidate} when it {@link #namesNoRoute()} and {@code incumbent} does not, else
 	 *         {@code incumbent} — so the route-unspecified row wins wherever the family has one, and
-	 *         otherwise the first row seen keeps the role. For the 11 shipped families that name no
+	 *         otherwise the first row seen keeps the role. For the 10 shipped families that name no
 	 *         unqualified row the survivor therefore still carries a qualifier: the KB publishes no
 	 *         unqualified name for those substances, and manufacturing one by stripping a display name
 	 *         is the pattern-match-a-label mistake issue #148 had to undo.

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -49,6 +49,9 @@ public class DrugReference {
 	 *  {@link #getSubstanceName()}. */
 	private String substanceName;
 
+	/** The reference data's own IDENTITY for that substance, or null — see {@link #getSubstanceId()}. */
+	private String substanceId;
+
 	private String drugClass;
 
 	private List<String> aliases = Collections.emptyList();
@@ -137,6 +140,29 @@ public class DrugReference {
 		this.substanceName = substanceName;
 	}
 
+	/**
+	 * @return the identity the reference data gives the SUBSTANCE this row is a row of, at a
+	 *         granularity {@link #getSubstanceName()} does not have — or {@code null} where the data
+	 *         cannot supply one. Written by the loading source, not by the dataset: it is a
+	 *         determination over all the rows sharing a substance name, so no row can carry it on its
+	 *         own. {@link DdiDrugReferenceSource} resolves it from the DDInter {@code drugbank_id};
+	 *         {@link AtcDrugReferenceSource} and the curated {@code json} dataset publish no substance
+	 *         registry and leave it null, which is why the fallback below has to be the one that was
+	 *         there before.
+	 *
+	 *         <p>Deliberately package-private, unlike {@link #getSubstanceName()}: that field is part
+	 *         of the curated schema and a hand-authored file may set it, while this one is a
+	 *         source-side derivation and binding it from a file would let a dataset assert a
+	 *         resolution nothing had made.
+	 */
+	String getSubstanceId() {
+		return substanceId;
+	}
+
+	void setSubstanceId(String substanceId) {
+		this.substanceId = substanceId;
+	}
+
 	/** A trailing parenthesized qualifier on a display name — the route or formulation a DDInter row
 	 *  is distinguished from its siblings by ({@code Dexamethasone (nasal)},
 	 *  {@code Amphotericin B (lipid complex)}, {@code Tozinameran (5y-11y)}). Anchored at the END, so a
@@ -159,57 +185,76 @@ public class DrugReference {
 	 * <ul>
 	 *   <li>{@link #getSubstanceName()} — the data's own claim that two rows are one substance. 142
 	 *       values are shared by more than one entry, across 332 entries, and the {@code rxcui}
-	 *       partitions those entries identically, so this is the dataset's substance identity rather
-	 *       than a spelling coincidence.</li>
-	 *   <li>The <b>display stem</b> — the name with trailing qualifiers removed — as a VETO on that
+	 *       partitions those entries identically (0 families disagreeing in either direction), so this
+	 *       is the dataset's substance identity rather than a spelling coincidence.</li>
+	 *   <li>{@link #getSubstanceId()} — the data's own IDENTITY for that substance, as a VETO on the
 	 *       claim, because the claim over-merges. Among those 142 families sit pairs of genuinely
 	 *       different substances: {@code Omeprazole}/{@code Esomeprazole} (one
 	 *       {@code rxnorm_name}, one {@code rxcui}, one ATC code),
 	 *       {@code Amphetamine}/{@code Dextroamphetamine}, {@code Fenfluramine}/{@code Dexfenfluramine},
 	 *       {@code Gabapentin}/{@code Gabapentin enacarbil}, {@code Netupitant}/{@code Fosnetupitant},
 	 *       {@code Ketoconazole}/{@code Levoketoconazole}, {@code Fenofibrate}/{@code Fenofibric acid},
-	 *       {@code Atropine}/{@code Hyoscyamine} — each of them the {@code enalapril}/{@code enalaprilat}
-	 *       shape issue #121 decided must stay two chips. The stem separates every one of them.</li>
+	 *       {@code Atropine}/{@code Hyoscyamine}, {@code Hydrocortisone}/{@code Hydrocortisone butyrate},
+	 *       {@code Estrone}/{@code Estrone sulfate} — each of them the
+	 *       {@code enalapril}/{@code enalaprilat} shape issue #121 decided must stay two chips. 19 of the
+	 *       142 families name two or more DrugBank substances and are exactly these; in each, the id is
+	 *       null and the veto falls to the DISPLAY STEM below, which separates every one of them.</li>
 	 * </ul>
-	 * Neither half works alone. Where one stem covers two substances the stem alone merges them and the
-	 * substance name is what refuses: {@code Varicella Zoster Vaccine (Recombinant)} against
+	 *
+	 * <p><b>Why the stem is the fallback and not the veto (issue #164).</b> It used to be the veto, and
+	 * it cannot tell a second SUBSTANCE from a second NAME: it separates the two PPIs correctly and
+	 * separates {@code Tozinameran} from {@code Pfizer-BioNTech Covid-19 Vaccine} — one {@code rxcui},
+	 * one {@code rxnorm_name}, one DrugBank substance — incorrectly, and likewise
+	 * {@code Botulinum toxin type A} from {@code Daxibotulinumtoxina}. Both were reported live as a
+	 * substance cross-reactive, or interacting, with itself. A substance registry can tell them apart
+	 * and a display name cannot, so where the reference data supplies one it decides, and the stem is
+	 * left to the families it cannot speak for. Widening the substance NAME alone was never the
+	 * alternative: it merges the two PPIs.
+	 *
+	 * <p>Neither half works alone. Where one stem covers two substances the stem alone merges them and
+	 * the substance name is what refuses: {@code Varicella Zoster Vaccine (Recombinant)} against
 	 * {@code (live/attenuated)} — a distinction that decides whether an immunocompromised patient may
 	 * have it at all — and likewise {@code Manganese (chloride)}/{@code (sulfate)},
 	 * {@code Dextran (-1)}/{@code (low molecular weight)}, {@code Insulin human}/{@code (isophane)},
 	 * {@code Insulin lispro}/{@code (protamine)}, {@code Iron}/{@code (polysaccharide)}. A few more
 	 * one-stem groups are kept apart because a row publishes NO substance name rather than a differing
 	 * one ({@code Typhoid vaccine (live)}/{@code (inactivated)}) — that is the null-key fallback below,
-	 * not this comparison. Together the two reduce those 332 entries to 177 substances.
+	 * not this comparison. Together the three reduce those 332 entries to 163 substances (177 while the
+	 * stem was the veto), and no resulting group holds two DrugBank substances.
 	 *
-	 * <p>Conservative where it cannot tell, in BOTH directions. A name that extends the family's stem
-	 * by a WORD rather than a qualifier ({@code Hydrocortisone butyrate}, {@code Estrone sulfate},
-	 * {@code Procaine benzylpenicillin}) keeps its own key and so its own chip — including where the KB
-	 * is in fact naming one substance two ways ({@code Thallous Chloride}/{@code Thallous chloride
-	 * tl-201}, {@code Typhoid vaccine (live)}/{@code Typhoid vaccine live}). Over-reporting one chip is
-	 * the safe direction for a non-blocking advisory; dropping a real one is not.
+	 * <p>Conservative where it cannot tell, and now in ONE direction rather than both. A name that
+	 * extends the family's stem by a WORD rather than a qualifier keeps its own key, and so its own
+	 * chip, only where the registry agrees it is another substance ({@code Hydrocortisone butyrate},
+	 * {@code Estrone sulfate}, {@code Procaine benzylpenicillin}); where the KB is naming one substance
+	 * two ways it no longer does ({@code Thallous Chloride}/{@code Thallous chloride tl-201},
+	 * {@code Typhoid vaccine (live)}/{@code Typhoid vaccine live}). Over-reporting one chip is still the
+	 * safe direction for a non-blocking advisory, and dropping a real one is not — but a chip reporting
+	 * a substance against ITSELF is not a real one, which is what makes those merges a gain rather than
+	 * a relaxation.
 	 *
 	 * @return an opaque key, equal exactly for two entries this module treats as one substance
 	 */
 	Object substanceKey() {
-		return substanceKey(name, substanceName);
+		return substanceKey(name, substanceName, substanceId);
 	}
 
 	/**
-	 * {@link #substanceKey()} over the two fields it reads, for a caller holding those fields but no
+	 * {@link #substanceKey()} over the three fields it reads, for a caller holding those fields but no
 	 * {@link DrugReference} yet: {@link DdiDrugReferenceSource}'s parse-time rows, which have to answer
 	 * "are these two rows one substance?" before any entry exists (issue #152's self-pair guard). One
 	 * definition, so a load-time guard and the chip grouping cannot come to disagree about what one
 	 * substance is — the failure that would leave a self-pair loaded for exactly the rows the chips then
-	 * merge.
+	 * merge, and the reason issue #164's interaction arm needed no change of its own.
 	 *
 	 * @return the key described at {@link #substanceKey()}, or null when {@code substanceName} is blank
 	 */
-	static Object substanceKey(String name, String substanceName) {
+	static Object substanceKey(String name, String substanceName, String substanceId) {
 		String substance = normalizeName(substanceName);
 		if (substance == null) {
 			return null;
 		}
-		return Arrays.asList(substance, displayStem(name));
+		String identity = normalizeName(substanceId);
+		return Arrays.asList(substance, identity != null ? identity : displayStem(name));
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -2245,10 +2245,15 @@ public class DrugSafetyValidator {
 			if (allergen == null || !seenAllergens.add(allergen)) {
 				continue;
 			}
-			if (allergen == ref) {
+			// Identity is decided by SUBSTANCE, and the chip names the patient's own record (issue #164).
+			// substanceGroupKey answers both halves at once: it is the row's substance where the data
+			// publishes one and the row itself where it does not, so this subsumes the entry comparison
+			// it replaces rather than sitting beside it. It is also the key the ledger below groups on,
+			// so a substance whose rows arrive from several call sites cannot raise this chip twice.
+			if (allergen.substanceGroupKey().equals(ref.substanceGroupKey())) {
 				chips.add(ref, allergen, ContraindicationChips.IDENTITY,
-						new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, ref.displayLabel(),
-								"The patient has a recorded allergy to " + ref.displayLabel() + "."));
+						new SafetyWarning(SafetyWarning.TYPE_CONTRAINDICATION, allergen.displayLabel(),
+								"The patient has a recorded allergy to " + allergen.displayLabel() + "."));
 				continue;
 			}
 			if (refClasses.isEmpty() && refGroups.isEmpty()) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -662,11 +662,11 @@ public class DrugSafetyValidator {
 	 * is not the dataset's first (7 of the shipped KB's multi-row families) can have an interaction chip
 	 * naming it and a contraindication chip naming one of its routes in the same response. That is the
 	 * route-qualifier residue this javadoc's last paragraph already accepts, now visible against a
-	 * canonicalized sibling arm rather than against another per-row one; widening it here would change
-	 * which variant an allergy is reported against, which is the decision issue #164 holds. The
-	 * surviving chip is written back into the position
-	 * the group's first candidate took, so no client sees the chip sequence reshuffle when a later,
-	 * stronger row replaces an earlier one.
+	 * canonicalized sibling arm rather than against another per-row one. It no longer reaches the
+	 * IDENTITY chip, which since issue #164 is named after the patient's own recorded allergen rather
+	 * than after whichever row of the substance raised it. The surviving chip is written back into the
+	 * position the group's first candidate took, so no client sees the chip sequence reshuffle when a
+	 * later, stronger row replaces an earlier one.
 	 *
 	 * <p>Resolving a tie by position is lossless rather than merely tidier, and that rests on the rows
 	 * of one substance publishing the SAME ATC codes — which the shipped KB does for every group this
@@ -676,25 +676,30 @@ public class DrugSafetyValidator {
 	 * so equal codes are equal membership. What is left for a tie to choose between is then only the
 	 * route qualifier in the subject's own label.
 	 *
-	 * <p><b>Why replacing an incumbent is not dead code.</b> It is tempting to read this ledger as
-	 * first-wins, and on the dexamethasone family the two would agree: {@code lookupByToken} resolves an
-	 * allergy to the EARLIEST matching entry, every dexamethasone row carries the bare substance name
-	 * among its aliases, and both subject sets are iterated in dataset order — so there the identity
-	 * match IS the group's first candidate. That premise does not hold generally. Where no alias of a
-	 * row is the bare substance name, the allergy skips that row and resolves a LATER member of its own
-	 * group, and the earlier members raise their class chips first: {@code Tozinameran} behind the
-	 * {@code Pfizer-BioNTech} presentations, {@code Insulin aspart (aspart)},
-	 * {@code Iobenguane (I-131)}. First-wins answers those with the vacuous "in the same ATC class as
-	 * your allergy to &lt;this same substance&gt;" chip this ledger exists to remove, which is what
-	 * {@code ContraindicationRouteVariantTest.theIdentityChipSurvivesWhenTheAllergenRowIsNotItsGroupsFirst}
-	 * pins. How many groups the shipped KB reaches it through is a property of that dataset — measure it
-	 * rather than trusting a number here.
+	 * <p><b>Replacing an incumbent, and what still reaches it.</b> This ledger used to be reachably
+	 * order-dependent: {@code lookupByToken} resolves an allergy to the EARLIEST matching entry, so
+	 * where no alias of a row is the bare substance name the allergy skipped that row and resolved a
+	 * LATER member of its own group, and the earlier members — matching by class rather than by
+	 * identity — raised the weaker chip first ({@code Tozinameran} behind the {@code Pfizer-BioNTech}
+	 * presentations, {@code Insulin aspart (aspart)}, {@code Iobenguane (I-131)}). Issue #164 removed
+	 * that route: identity is now decided by SUBSTANCE, so every row of one group answers the identity
+	 * question the same way and an identity chip can no longer arrive after a class one for the same
+	 * key. What is left to replace is a class chip by a more specific class chip — a group whose rows
+	 * publish DIFFERENT ATC codes, so that one shares only a curated group with the allergen while
+	 * another shares a level-4 subgroup. The shipped KB has no such group (0 of the 129 it files as
+	 * more than one row; measured 2026-08-07 and the same 0 before this key widened), so the branch is
+	 * currently unexercised rather than wrong, and it is kept because "the most specific relationship
+	 * survives" is this arm's contract and first-wins is not: a refresh that diverges one row's codes
+	 * would otherwise silently report the weaker relationship. Re-measure that 0 rather than trusting
+	 * it — it is a property of the dataset, not of this code.
 	 */
 	private static final class ContraindicationChips {
 
 		/** A recorded allergy to this very substance — needs no ATC code and outranks both class
 		 *  comparisons (the precedence {@link #addAllergyContraindications} already applies per
-		 *  allergen, extended across the rows of one substance). */
+		 *  allergen, extended across the rows of one substance). Since issue #164 the comparison behind
+		 *  it is the substance rather than the reference row, so it is uniform across the rows this
+		 *  ledger groups: every row of one substance answers it alike. */
 		static final int IDENTITY = 3;
 
 		/** A shared ATC level-4 chemical subgroup with the allergen. */
@@ -887,10 +892,11 @@ public class DrugSafetyValidator {
 		//
 		// The class arm reads the CANONICAL row alone, not the whole group, and that is lossless only
 		// while every row of a substance publishes the same ATC list — which the shipped KB does, across
-		// all 121 of its multi-row families, and which is the same premise ContraindicationChips'
+		// all 129 of its multi-row families, and which is the same premise ContraindicationChips'
 		// positional tie-break rests on. It is a DATA invariant, not a code-gated one: a KB refresh that
 		// gave one route variant a code its siblings lack would silently drop a duplicate-therapy chip
 		// this arm used to raise, so re-measure it on a refresh as well as before widening substanceKey.
+		// (Re-measured for issue #164's widening: still 0 divergent, at 129 families rather than 121.)
 		// Reading the group instead would produce one sentence per row, each naming its own label, which
 		// is the duplication being removed.
 		Map<SubjectRule, String> folded = new LinkedHashMap<SubjectRule, String>();
@@ -2149,9 +2155,10 @@ public class DrugSafetyValidator {
 
 	/**
 	 * Allergy-driven contraindication reasoning: for the drug {@code ref} being checked, each recorded
-	 * allergy token is resolved to a reference drug and a warning fires when that allergen <em>is</em>
-	 * {@code ref} (a recorded allergy to the very drug being checked), shares {@code ref}'s ATC level-4
-	 * subgroup (cross-reactivity), or — failing both — shares a curated {@link CrossReactivityGroup}
+	 * allergy token is resolved to a reference drug and a warning fires when that allergen is the same
+	 * SUBSTANCE as {@code ref} (a recorded allergy to the very drug being checked), shares {@code ref}'s
+	 * ATC level-4 subgroup (cross-reactivity), or — failing both — shares a curated
+	 * {@link CrossReactivityGroup}
 	 * (cross-<em>branch</em> cross-reactivity, e.g. aspirin vs an ibuprofen allergy, which ATC's tree
 	 * cannot express). At most one warning per (SUBSTANCE, resolved allergen): the most specific match
 	 * wins, several aliases of one allergy warn once ({@code seenAllergens} below), and the several
@@ -2164,7 +2171,7 @@ public class DrugSafetyValidator {
 	 * <p><b>Identity is not classification (issue #135).</b> The three comparisons were all gated on
 	 * one early return taken when {@code ref} had neither an ATC subgroup nor a curated group. That
 	 * guard is right for the two class comparisons — without a subgroup or a group there is nothing to
-	 * compare against — but {@code allergen == ref} is a comparison of two object references: it needs
+	 * compare against — but the identity comparison is between the two drugs themselves: it needs
 	 * no ATC code, no group, and no dataset support of any kind, and gating it on classification data
 	 * silently skipped the most basic check the module makes. Measured over the full
 	 * openmrs-ddi-knowledge-base DDInter 2.0 dataset (2283 drugs) on 2026-08-05: <b>444 entries

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ContraindicationRouteVariantTest.java
@@ -271,9 +271,10 @@ public class ContraindicationRouteVariantTest {
 		// bare substance name, lookupByToken's earliest-match rule skips it and the allergy resolves a
 		// LATER member of the same collapsed group, so the earlier members chip first. `Tozinameran`,
 		// `Insulin aspart (aspart)` and `Iobenguane (I-131)` were each verified this way through
-		// validate() over the full 19 MB KB. A first-wins ledger answers this case with "Tozinameran
-		// (12y+) … is in the same ATC class (J07BN) as the patient's allergy to Tozinameran" — the
-		// vacuous self-cross-reactivity issue #145 exists to remove, kept instead of removed.
+		// validate() over the full 19 MB KB. This case no longer discriminates a first-wins ledger from
+		// replace-in-place: since issue #164 the identity test matches on the substance, so the allergen
+		// raises IDENTITY whichever member of the group is reached first. What it still pins is that the
+		// surviving chip is the identity one and that it names the allergen as the chart records it.
 		List<SafetyWarning> warnings = fixtureValidator(FIXTURE).validate("",
 				"Is it safe to give the Pfizer-BioNTech COVID-19 vaccine?",
 				DrugReferenceTestSupport.ctx(60, null, null, null,

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/SelfInteractionTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/SelfInteractionTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.Test;
  * No drug is reported as interacting with itself (issue #152).
  *
  * <p>The shipped DDInter 2.0 knowledge base carries one row pairing a drug with ITSELF —
- * {@code DDInter225}, botulinum toxin type A, 1 of 295,184 — and 25 more pairing two ROUTE VARIANTS of
- * one substance with each other (measured 2026-08-06; re-measure before relying on the figures). The
+ * {@code DDInter225}, botulinum toxin type A, 1 of 295,184 — plus further rows pairing two ROUTE
+ * VARIANTS of one substance with each other. The total the guard drops is not restated here because
+ * it moves whenever substance identity widens: it was 26 when issue #152 shipped and 28 after issue
+ * #164 resolved two more pairs to one substance by registry id. The parser logs the live count in a
+ * WARN at load, which is the figure to read. The
  * parser loaded both kinds, so a substance could be raised as interacting with itself: a chip reading
  * "Lidocaine interacts with active order lidocaine", and the same partner listed inside the drug's own
  * injected reference record.
@@ -88,9 +91,10 @@ public class SelfInteractionTest {
 	@Test
 	public void aRowPairingADrugWithItselfIsNotLoaded() throws IOException {
 		// DDInter225 x DDInter225. The mechanism text is about administering different botulinum
-		// SEROTYPES together — which the KB also files on genuine cross-row pairs (type A against type B,
-		// and Daxibotulinumtoxina against each), all of which the guard leaves loaded — so the self-pair
-		// is an artifact of the KB's granularity that costs no clinical content, and as rendered it reads
+		// SEROTYPES together — which the KB also files on genuine cross-row pairs. Type A against type B
+		// is one substance against another and stays loaded; Daxibotulinumtoxina against type A is NOT,
+		// since issue #164 resolved them to one substance by registry id. So the self-pair is an artifact
+		// of the KB's granularity that costs no clinical content, and as rendered it reads
 		// "Botulinum toxin type A interacts with active order botulinum toxin type A".
 		DrugReference botulinum = entry(DrugReferenceTestSupport.ddiFixtureEntries(FIXTURE),
 				"Botulinum toxin type A");

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/SubstanceIdentityTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/SubstanceIdentityTest.java
@@ -1,0 +1,251 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * A substance is not reported as cross-reactive, or interacting, with ITSELF (issue #164) — and two
+ * substances the reference data files under one substance NAME still get a chip each (issues #121,
+ * #145).
+ *
+ * <p><b>The defect, two routes.</b> Both were measured live on the 3.7.1 standalone and both survive
+ * the substance key #145/#160/#173 built, because neither is a key that was too wide — one is a test
+ * that was too narrow and the other is a key that was too conservative.
+ * <ul>
+ *   <li><b>The mirror path.</b> {@code IDENTITY} was awarded on ENTRY identity
+ *       ({@code allergen == ref}). When the row an allergy resolves to is a SIBLING that the question
+ *       does not itself put in play, the group holds no identity candidate at all, so the best
+ *       available relationship is the class comparison — against the same substance. Measured as
+ *       "Is Tetryzoline (nasal) safe?" against an allergy recorded as {@code Tetryzoline
+ *       (ophthalmic)}, and as the Pfizer/Tozinameran pair below.</li>
+ *   <li><b>Stem divergence.</b> {@code Pfizer-BioNTech Covid-19 Vaccine} and {@code Tozinameran}
+ *       publish one {@code rxnorm_name} and one {@code rxcui} but no display stem in common, so the
+ *       stem VETO kept them apart — and the resulting chip reads as a self-reference anyway. The same
+ *       shape sits in the interaction arm: {@code Daxibotulinumtoxina} against
+ *       {@code Botulinum toxin type A}.</li>
+ * </ul>
+ *
+ * <p><b>What decides that two rows are one substance</b>, and why the stem alone could not. The
+ * reference data's substance name over-merges — {@code Omeprazole}/{@code Esomeprazole} publish one
+ * {@code rxnorm_name}, one {@code rxcui} and one ATC code and are two substances — so something has
+ * to veto it. The stem was that veto, and it is a display-name heuristic: it separates the two PPIs
+ * correctly and separates {@code Tozinameran} from its own brand row incorrectly, because it cannot
+ * tell a second SUBSTANCE from a second NAME. The reference data can: each row carries a
+ * {@code drugbank_id}, an identifier of a substance rather than of a presentation. So the veto is now
+ * that identifier — a substance-name family that names TWO OR MORE DrugBank substances holds more
+ * than one substance and keeps the stem in force; one that names at most one is a single substance
+ * and has nothing for the stem to veto. See {@link DrugReference#substanceKey()} for the
+ * measurements.
+ *
+ * <p>Both directions are asserted here, against slices taken verbatim from the shipped KB, through
+ * the real {@link DdiDrugReferenceSource} parser and the real
+ * {@link DrugSafetyValidator#validate(String, String, PatientClinicalContext)}.
+ */
+public class SubstanceIdentityTest {
+
+	/** Verbatim KB rows and interaction rows — see the fixture's own {@code metadata.note}. */
+	private static final String FIXTURE = "chartsearchai-test/ddi-substance-identity.json";
+
+	/** The must-NOT-collapse pair, in the slice that already carries it: {@code Omeprazole} and
+	 *  {@code Esomeprazole} under one {@code rxnorm_name}. Read from there rather than copied here, so
+	 *  the two files cannot come to disagree about what the KB says. */
+	private static final String PPI_FIXTURE = "chartsearchai-test/ddi-contra-route-variants.json";
+
+	private static DrugReference row(List<DrugReference> entries, String name) {
+		for (DrugReference entry : entries) {
+			if (name.equals(entry.getName())) {
+				return entry;
+			}
+		}
+		throw new AssertionError("the fixture must carry the " + name + " row, was: "
+				+ DrugReferenceTestSupport.names(entries));
+	}
+
+	@Test
+	public void oneSubstanceNameAndTwoDrugbankIdsIsTwoSubstancesWhileOneOfEachIsOne() throws IOException {
+		// The criterion itself, on the two families that show it is not the stem: BOTH are one
+		// rxnorm_name spread over rows whose display stems differ, and they must resolve OPPOSITE ways.
+		// Without this contrast either half alone is satisfiable by a key that ignores the registry id
+		// (the stem separates both pairs) or by one that ignores the stem (neither pair is separated).
+		List<DrugReference> vaccine = DrugReferenceTestSupport.ddiFixtureEntries(FIXTURE);
+		DrugReference tozinameran = row(vaccine, "Tozinameran");
+		DrugReference pfizer = row(vaccine, "Pfizer-BioNTech Covid-19 Vaccine");
+		assertEquals(DrugReference.normalizeName(tozinameran.getSubstanceName()),
+				DrugReference.normalizeName(pfizer.getSubstanceName()),
+				"precondition: the two vaccine rows must publish ONE substance name");
+		assertNotEquals(DrugReference.normalizeName(tozinameran.getName()),
+				DrugReference.normalizeName(pfizer.getName()),
+				"precondition: with different display names, or the stem would have merged them anyway");
+		assertEquals(tozinameran.substanceKey(), pfizer.substanceKey(),
+				"a substance-name family naming ONE DrugBank substance is one substance");
+
+		List<DrugReference> ppis = DrugReferenceTestSupport.ddiFixtureEntries(PPI_FIXTURE);
+		DrugReference omeprazole = row(ppis, "Omeprazole");
+		DrugReference esomeprazole = row(ppis, "Esomeprazole");
+		assertEquals(DrugReference.normalizeName(omeprazole.getSubstanceName()),
+				DrugReference.normalizeName(esomeprazole.getSubstanceName()),
+				"precondition: the two PPI rows must publish ONE substance name too");
+		assertNotEquals(omeprazole.substanceKey(), esomeprazole.substanceKey(),
+				"while a family naming TWO DrugBank substances is two substances — the enalapril/"
+						+ "enalaprilat decision of issue #121, which the widening must not undo");
+	}
+
+	@Test
+	public void theFixtureReallyCarriesTheMirrorShape() throws IOException {
+		// The premise of the case below, through the production resolvers: the allergy must resolve to a
+		// row the QUESTION does not put in play. Without that the identity test would already fire on
+		// entry identity and the case would assert nothing.
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+
+		List<DrugReference> inPlay = service.findByQuery("Is Tetryzoline (nasal) safe for her?");
+		assertEquals(1, inPlay.size(), "the question must resolve exactly one row, was: "
+				+ DrugReferenceTestSupport.names(inPlay));
+		assertEquals("Tetryzoline (nasal)", inPlay.get(0).getName());
+
+		DrugReference allergen = service.lookupByToken("Tetryzoline (ophthalmic)");
+		assertNotNull(allergen, "the allergy must resolve to a row");
+		assertEquals("Tetryzoline (ophthalmic)", allergen.getName());
+		assertNotSame(inPlay.get(0), allergen,
+				"and it must be a DIFFERENT row from the one in play — the mirror shape");
+		assertEquals(allergen.substanceGroupKey(), inPlay.get(0).substanceGroupKey(),
+				"while the two are one substance, which is what the identity test has to see");
+	}
+
+	@Test
+	public void anAllergenRowThatIsNotItselfInPlayIsADirectAllergyNotCrossReactivity() throws IOException {
+		// The mirror path. Pre-fix this raised "Tetryzoline (nasal) (tetrahydrozoline) is in the same ATC
+		// class (R01AA) as the patient's allergy to Tetryzoline (ophthalmic) (tetrahydrozoline) —
+		// possible cross-reactivity": one substance, reported as cross-reactive with itself, because the
+		// only row that could have matched by identity was not among the drugs in play.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport
+				.validator(DrugReferenceTestSupport.ddiFixtureService(FIXTURE))
+				.validate("", "Is Tetryzoline (nasal) safe for her?", DrugReferenceTestSupport.ctx(60, null,
+						null, null, DrugReferenceTestSupport.set("Tetryzoline (ophthalmic)"), null));
+
+		assertEquals(1, warnings.size(), "one substance, one finding, was: " + warnings);
+		assertEquals(SafetyWarning.TYPE_CONTRAINDICATION, warnings.get(0).getType());
+		assertEquals("The patient has a recorded allergy to Tetryzoline (ophthalmic) (tetrahydrozoline).",
+				warnings.get(0).getDetail(),
+				"an allergy to the same substance is a DIRECT allergy, and the chip names the patient's "
+						+ "own record rather than the row the question resolved to");
+		assertEquals("Tetryzoline (ophthalmic) (tetrahydrozoline)", warnings.get(0).getDrug(),
+				"including on the chip's drug field, so the two cannot name different things");
+	}
+
+	@Test
+	public void theFixtureReallyCarriesTheStemDivergentPair() throws IOException {
+		// The premise of the case below: the brand row must be in play on its own, and the allergy must
+		// resolve to the row whose display stem differs from it.
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+
+		List<DrugReference> inPlay = service
+				.findByQuery("Is the Pfizer-BioNTech Covid-19 Vaccine safe for him?");
+		assertTrue(DrugReferenceTestSupport.names(inPlay).contains("Pfizer-BioNTech Covid-19 Vaccine"),
+				"the brand row must be in play, was: " + DrugReferenceTestSupport.names(inPlay));
+
+		DrugReference allergen = service.lookupByToken("Tozinameran");
+		assertNotNull(allergen, "the allergy must resolve to a row");
+		assertEquals("Tozinameran", allergen.getName());
+		assertNotEquals(DrugReference.normalizeName(allergen.getName()),
+				DrugReference.normalizeName("Pfizer-BioNTech Covid-19 Vaccine"),
+				"and the two display names must diverge, or the stem would already have merged them");
+	}
+
+	@Test
+	public void aStemDivergentRowOfTheAllergensOwnSubstanceIsADirectAllergyNotCrossReactivity()
+			throws IOException {
+		// Kevin Brown's live shape: a coded Tozinameran allergy, asked about the Pfizer vaccine. Pre-fix
+		// this raised the correct identity chip AND "Pfizer-BioNTech Covid-19 Vaccine (sars-cov-2
+		// (covid-19) vaccine, mrna spike protein) is in the same ATC class (J07BN) as the patient's
+		// allergy to Tozinameran (sars-cov-2 (covid-19) vaccine, mrna spike protein) — possible
+		// cross-reactivity": the KB's own rxcui and rxnorm_name say those are one substance.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport
+				.validator(DrugReferenceTestSupport.ddiFixtureService(FIXTURE))
+				.validate("", "Is the Pfizer-BioNTech Covid-19 Vaccine safe for him?",
+						DrugReferenceTestSupport.ctx(60, null, null, null,
+								DrugReferenceTestSupport.set("Tozinameran"), null));
+
+		assertEquals(1, warnings.size(),
+				"one substance under two names is one clinical fact, was: " + warnings);
+		assertEquals("The patient has a recorded allergy to Tozinameran (sars-cov-2 (covid-19) vaccine,"
+				+ " mrna spike protein).", warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void aStemDivergentPairOfOneSubstanceIsNotAnInteraction() throws IOException {
+		// The same shape on the interaction arm, and the reason the fix is one key rather than one patch
+		// per arm: the parse-time self-pair guard of issue #152 already asks "are these two rows one
+		// substance?", so widening what that means removes the row before any arm can render it. Pre-fix
+		// this raised "Daxibotulinumtoxina (botulinum toxin type a) interacts with active order botulinum
+		// toxin type a — Moderate. …", a drug interacting with itself.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport
+				.validator(DrugReferenceTestSupport.ddiFixtureService(FIXTURE))
+				.validate("", "Is it safe to give daxibotulinumtoxina?",
+						DrugReferenceTestSupport.ctx(60, null,
+								DrugReferenceTestSupport.set("Botulinum toxin type A 100 units"), null, null,
+								null));
+
+		assertEquals(0, warnings.size(),
+				"two rows of one substance are not an interacting pair, was: " + warnings);
+	}
+
+	@Test
+	public void aGenuineCrossSubstancePairInTheSameSliceIsStillReported() throws IOException {
+		// The negative control, without which the case above passes on a guard that drops everything.
+		// Botulinum Toxin Type B publishes a DIFFERENT rxnorm_name, so it is a different substance and
+		// the KB's Moderate pair with it must survive — the serotype-pair distinction #173's hardening
+		// found the old javadoc denying.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport
+				.validator(DrugReferenceTestSupport.ddiFixtureService(FIXTURE))
+				.validate("", "Is it safe to give daxibotulinumtoxina?",
+						DrugReferenceTestSupport.ctx(60, null,
+								DrugReferenceTestSupport.set("Botulinum Toxin Type B 5000 units"), null, null,
+								null));
+
+		assertEquals(1, warnings.size(), "the genuine pair must still chip, was: " + warnings);
+		assertEquals(SafetyWarning.TYPE_INTERACTION, warnings.get(0).getType());
+		assertTrue(warnings.get(0).getDetail().startsWith("Daxibotulinumtoxina (botulinum toxin type a) "
+				+ "interacts with active order botulinum toxin type b — Moderate. "),
+				"was: " + warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void twoSubstancesTheKbGivesTwoRegistryIdsStayTwoInteractionChips() throws IOException {
+		// Issue #121's decision, on the arm where the widening could have undone it: enalapril and
+		// enalaprilat are a prodrug and its active metabolite, they share 376 of the shipped KB's
+		// interaction partners, and they must stay two subjects. The KB gives them two rxnorm_names as
+		// well as two drugbank_ids, so they are not the sharp edge — that is Omeprazole/Esomeprazole
+		// above — but they are the case #121 named, and a key that merged on either would answer this
+		// with one chip.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport
+				.validator(DrugReferenceTestSupport.ddiFixtureService(FIXTURE))
+				.validate("", "Is it safe to give enalapril or enalaprilat?",
+						DrugReferenceTestSupport.ctx(60, null,
+								DrugReferenceTestSupport.set("Potassium chloride 600mg"), null, null, null));
+
+		assertEquals(2, warnings.size(), "a prodrug and its metabolite are two drugs, was: " + warnings);
+		assertTrue(warnings.get(0).getDetail().startsWith(
+				"Enalapril interacts with active order potassium chloride — Major. "),
+				"was: " + warnings.get(0).getDetail());
+		assertTrue(warnings.get(1).getDetail().startsWith(
+				"Enalaprilat interacts with active order potassium chloride — Major. "),
+				"was: " + warnings.get(1).getDetail());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/SubstanceIdentityTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/SubstanceIdentityTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -93,6 +94,10 @@ public class SubstanceIdentityTest {
 		assertNotEquals(DrugReference.normalizeName(tozinameran.getName()),
 				DrugReference.normalizeName(pfizer.getName()),
 				"precondition: with different display names, or the stem would have merged them anyway");
+		assertNotNull(tozinameran.getSubstanceId(),
+				"the family names exactly one DrugBank substance, so the parser resolves an id for it");
+		assertEquals(tozinameran.getSubstanceId(), pfizer.getSubstanceId(),
+				"and BOTH rows take it, including the one carrying no drugbank_id of its own");
 		assertEquals(tozinameran.substanceKey(), pfizer.substanceKey(),
 				"a substance-name family naming ONE DrugBank substance is one substance");
 
@@ -102,6 +107,10 @@ public class SubstanceIdentityTest {
 		assertEquals(DrugReference.normalizeName(omeprazole.getSubstanceName()),
 				DrugReference.normalizeName(esomeprazole.getSubstanceName()),
 				"precondition: the two PPI rows must publish ONE substance name too");
+		assertNull(omeprazole.getSubstanceId(),
+				"but that family names TWO DrugBank substances, so the parser resolves no id for it and "
+						+ "the display stem stays in force");
+		assertNull(esomeprazole.getSubstanceId());
 		assertNotEquals(omeprazole.substanceKey(), esomeprazole.substanceKey(),
 				"while a family naming TWO DrugBank substances is two substances — the enalapril/"
 						+ "enalaprilat decision of issue #121, which the widening must not undo");
@@ -224,6 +233,33 @@ public class SubstanceIdentityTest {
 		assertTrue(warnings.get(0).getDetail().startsWith("Daxibotulinumtoxina (botulinum toxin type a) "
 				+ "interacts with active order botulinum toxin type b — Moderate. "),
 				"was: " + warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void aFamilyThatNamesNoRegistrySubstanceAtAllIsStillOneSubstance() throws IOException {
+		// The criterion's third branch, and the one the two cases above cannot reach: the KB files
+		// `Typhoid vaccine (live)` and `Typhoid vaccine live` under one rxnorm_name and one rxcui with NO
+		// drugbank_id on either, so the registry distinguishes nothing and the family is one substance.
+		// Neither row carries an ATC code, so the class arms are provably silent for them — before this
+		// change an allergy to one of them, asked about the other, produced NO chip at all rather than a
+		// wrong one, which is issue #135's direct-allergy gap reached through stem divergence.
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+		List<DrugReference> inPlay = service.findByQuery("Is Typhoid vaccine (live) safe for her?");
+		assertEquals(1, inPlay.size(), "precondition: the question must resolve exactly one row, was: "
+				+ DrugReferenceTestSupport.names(inPlay));
+		DrugReference allergen = service.lookupByToken("Typhoid vaccine live");
+		assertNotNull(allergen, "precondition: the allergy must resolve to a row");
+		assertNotSame(inPlay.get(0), allergen, "precondition: and to the OTHER row");
+		assertTrue(inPlay.get(0).atcSubgroups().isEmpty() && allergen.atcSubgroups().isEmpty(),
+				"precondition: neither row may carry an ATC subgroup, or a class chip could mask this");
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(service).validate("",
+				"Is Typhoid vaccine (live) safe for her?", DrugReferenceTestSupport.ctx(60, null, null,
+						null, DrugReferenceTestSupport.set("Typhoid vaccine live"), null));
+
+		assertEquals(1, warnings.size(), "the direct allergy must be reported, was: " + warnings);
+		assertEquals("The patient has a recorded allergy to Typhoid vaccine live (salmonella typhi ty21a"
+				+ " live antigen).", warnings.get(0).getDetail());
 	}
 
 	@Test

--- a/api/src/test/resources/chartsearchai-test/ddi-substance-identity.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-substance-identity.json
@@ -1,0 +1,460 @@
+{
+ "metadata": {
+  "note": "Verbatim DDInter 2.0 slice for issue #164 — a substance reported as cross-reactive, or interacting, with ITSELF. Three shapes, all taken unedited from the shipped 19 MB KB. (1) The mirror path: Tetryzoline (nasal) and Tetryzoline (ophthalmic) are one substance to the collapse key already, so an allergy resolving to one of them and a question resolving the other exercise the IDENTITY test alone. (2) Stem divergence, contraindication arm: Pfizer-BioNTech Covid-19 Vaccine and Tozinameran share rxcui 2468231 and one rxnorm_name but no display stem; only Tozinameran carries a drugbank_id. (3) Stem divergence, interaction arm: Daxibotulinumtoxina and Botulinum toxin type A share rxcui 1712 and one rxnorm_name but no display stem; only Botulinum toxin type A carries a drugbank_id. Botulinum Toxin Type B is the negative control on that arm — a different rxnorm_name, so the pair must still be reported. Enalapril and Enalaprilat with their shared Major partner Potassium chloride are the must-NOT-collapse control issue #121 decided: two rxnorm_names, two rxcuis, two drugbank_ids, and so two chips. The Omeprazole/Esomeprazole control — one rxnorm_name, one rxcui, TWO drugbank_ids — lives in ddi-contra-route-variants.json and is asserted from there."
+ },
+ "mechanisms": {
+  "2264": {
+   "text": "Concomitant use of angiotensin converting enzyme (ACE) inhibitors and potassium salts may increase the risk of hyperkalemia. Inhibition of ACE results in decreased aldosterone secretion, which in turn causes potassium retention.",
+   "categories": [
+    "synergistic_effect"
+   ]
+  },
+  "2935": {
+   "text": "The effect of administering different botulinum neurotoxin serotypes concurrently or within several months of one another is unknown. Excessive weakness may be exacerbated by another administration of botulinum toxin prior to the resolution of the effects of a previously administered botulinum toxin.",
+   "categories": [
+    "synergistic_effect"
+   ]
+  },
+  "5973": {
+   "text": "Concomitant use of angiotensin converting enzyme (ACE) inhibitors and potassium salts may increase the risk of hyperkalemia.  Inhibition of ACE results in decreased aldosterone secretion, which in turn causes potassium retention.",
+   "categories": [
+    "synergistic_effect"
+   ]
+  },
+  "7257": {
+   "text": "The effect of administering different botulinum neurotoxin serotypes concurrently or within several months of one another is unknown.  Excessive weakness may be exacerbated by another administration of botulinum toxin prior to the resolution of the effects of a previously administered botulinum toxin.",
+   "categories": [
+    "others"
+   ]
+  }
+ },
+ "drugs": [
+  {
+   "id": "DDInter2164",
+   "name": "Tozinameran",
+   "rxcui": "2468231",
+   "rxnorm_name": "SARS-CoV-2 (COVID-19) vaccine, mRNA spike protein",
+   "drugbank_id": "DB15696",
+   "atc": [
+    "J07BN01",
+    "J07BN04"
+   ],
+   "ciel": [
+    {
+     "code": "166154",
+     "uuid": "166154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Moderna COVID-19 vaccine"
+    },
+    {
+     "code": "166155",
+     "uuid": "166155AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine"
+    },
+    {
+     "code": "167039",
+     "uuid": "167039AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine (adolescent)"
+    },
+    {
+     "code": "167040",
+     "uuid": "167040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine (child)"
+    },
+    {
+     "code": "167041",
+     "uuid": "167041AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine (infant)"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1436",
+   "name": "Pfizer-BioNTech Covid-19 Vaccine",
+   "rxcui": "2468231",
+   "rxnorm_name": "SARS-CoV-2 (COVID-19) vaccine, mRNA spike protein",
+   "drugbank_id": null,
+   "atc": [
+    "J07BN01",
+    "J07BN04"
+   ],
+   "ciel": [
+    {
+     "code": "166154",
+     "uuid": "166154AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Moderna COVID-19 vaccine"
+    },
+    {
+     "code": "166155",
+     "uuid": "166155AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine"
+    },
+    {
+     "code": "167039",
+     "uuid": "167039AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine (adolescent)"
+    },
+    {
+     "code": "167040",
+     "uuid": "167040AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine (child)"
+    },
+    {
+     "code": "167041",
+     "uuid": "167041AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Pfizer-BioNtech COVID-19 vaccine (infant)"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1787",
+   "name": "Tetryzoline (nasal)",
+   "rxcui": "37935",
+   "rxnorm_name": "tetrahydrozoline",
+   "drugbank_id": null,
+   "atc": [
+    "R01AA06",
+    "R01AB03",
+    "S01GA02"
+   ],
+   "ciel": [
+    {
+     "code": "105188",
+     "uuid": "105188AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Polyethylene glycols / tetrahydrozoline"
+    },
+    {
+     "code": "105193",
+     "uuid": "105193AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Polyvinyl alcohol / povidone / tetrahydrozoline"
+    },
+    {
+     "code": "105214",
+     "uuid": "105214AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Povidone / tetrahydrozoline"
+    },
+    {
+     "code": "105291",
+     "uuid": "105291AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Tetrahydrozoline / zinc sulfate"
+    },
+    {
+     "code": "84898",
+     "uuid": "84898AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Tetrahydrozoline"
+    },
+    {
+     "code": "84899",
+     "uuid": "84899AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Tetrahydrozoline hydrochloride"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1788",
+   "name": "Tetryzoline (ophthalmic)",
+   "rxcui": "37935",
+   "rxnorm_name": "tetrahydrozoline",
+   "drugbank_id": null,
+   "atc": [
+    "R01AA06",
+    "R01AB03",
+    "S01GA02"
+   ],
+   "ciel": [
+    {
+     "code": "105188",
+     "uuid": "105188AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Polyethylene glycols / tetrahydrozoline"
+    },
+    {
+     "code": "105193",
+     "uuid": "105193AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Polyvinyl alcohol / povidone / tetrahydrozoline"
+    },
+    {
+     "code": "105214",
+     "uuid": "105214AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Povidone / tetrahydrozoline"
+    },
+    {
+     "code": "105291",
+     "uuid": "105291AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Tetrahydrozoline / zinc sulfate"
+    },
+    {
+     "code": "84898",
+     "uuid": "84898AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Tetrahydrozoline"
+    },
+    {
+     "code": "84899",
+     "uuid": "84899AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Tetrahydrozoline hydrochloride"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2169",
+   "name": "Daxibotulinumtoxina",
+   "rxcui": "1712",
+   "rxnorm_name": "botulinum toxin type A",
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": [
+    {
+     "code": "72303",
+     "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum toxin type A"
+    },
+    {
+     "code": "72305",
+     "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum type A toxin-haemagglutinin complex"
+    }
+   ]
+  },
+  {
+   "id": "DDInter225",
+   "name": "Botulinum toxin type A",
+   "rxcui": "1712",
+   "rxnorm_name": "botulinum toxin type A",
+   "drugbank_id": "DB00083",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "72303",
+     "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum toxin type A"
+    },
+    {
+     "code": "72305",
+     "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum type A toxin-haemagglutinin complex"
+    }
+   ]
+  },
+  {
+   "id": "DDInter226",
+   "name": "Botulinum Toxin Type B",
+   "rxcui": "2167673",
+   "rxnorm_name": "botulinum toxin type B",
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": [
+    {
+     "code": "72304",
+     "uuid": "72304AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum toxin type B"
+    }
+   ]
+  },
+  {
+   "id": "DDInter638",
+   "name": "Enalapril",
+   "rxcui": "3827",
+   "rxnorm_name": "enalapril",
+   "drugbank_id": "DB00584",
+   "atc": [
+    "C09AA02"
+   ],
+   "ciel": [
+    {
+     "code": "104493",
+     "uuid": "104493AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Diltiazem / enalapril"
+    },
+    {
+     "code": "104568",
+     "uuid": "104568AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Enalapril / felodipine"
+    },
+    {
+     "code": "104569",
+     "uuid": "104569AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Enalapril / hydrochlorothiazide"
+    },
+    {
+     "code": "75633",
+     "uuid": "75633AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Enalapril"
+    },
+    {
+     "code": "75634",
+     "uuid": "75634AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Enalapril maleate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2026",
+   "name": "Enalaprilat",
+   "rxcui": "3829",
+   "rxnorm_name": "enalaprilat",
+   "drugbank_id": "DB09477",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "75635",
+     "uuid": "75635AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Enalaprilat"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1497",
+   "name": "Potassium chloride",
+   "rxcui": "8591",
+   "rxnorm_name": "potassium chloride",
+   "drugbank_id": "DB00761",
+   "atc": [
+    "A12BA01",
+    "B05XA01"
+   ],
+   "ciel": [
+    {
+     "code": "103804",
+     "uuid": "103804AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Bendroflumethiazide / potassium chloride"
+    },
+    {
+     "code": "103988",
+     "uuid": "103988AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Calcium / chloride ion / glucose / lactate / potassium / sodium"
+    },
+    {
+     "code": "103989",
+     "uuid": "103989AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Calcium / chloride ion / potassium / sodium"
+    },
+    {
+     "code": "104045",
+     "uuid": "104045AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Calcium carbonate / potassium chloride / sodium chloride"
+    },
+    {
+     "code": "104057",
+     "uuid": "104057AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Calcium chloride / magnesium chloride / potassium chloride / sodium acetate / sodium chloride"
+    },
+    {
+     "code": "104058",
+     "uuid": "104058AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Calcium chloride / potassium chloride / sodium chloride"
+    },
+    {
+     "code": "104083",
+     "uuid": "104083AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Calcium phosphate / magnesium carbonate / potassium chloride"
+    },
+    {
+     "code": "104664",
+     "uuid": "104664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Flumethiazide / potassium chloride / rauwolfia preparation"
+    },
+    {
+     "code": "104730",
+     "uuid": "104730AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Glucose / lactated ringer's solution"
+    },
+    {
+     "code": "104740",
+     "uuid": "104740AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Glucose / potassium chloride"
+    },
+    {
+     "code": "104741",
+     "uuid": "104741AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Glucose / potassium chloride / sodium chloride"
+    },
+    {
+     "code": "105004",
+     "uuid": "105004AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Lysine / potassium bicarbonate / potassium chloride"
+    },
+    {
+     "code": "105008",
+     "uuid": "105008AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Magnesium chloride / potassium chloride / sodium acetate / sodium chloride / sodium gluconate"
+    },
+    {
+     "code": "105017",
+     "uuid": "105017AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Magnesium sulfate / potassium chloride / potassium phosphate / sodium chloride / sodium phosphate, dibasic"
+    },
+    {
+     "code": "105183",
+     "uuid": "105183AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Polyethylene glycol 3350 / potassium chloride / sodium bicarbonate / sodium chloride / sodium sulfate"
+    },
+    {
+     "code": "105200",
+     "uuid": "105200AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Potassium chloride / potassium gluconate"
+    },
+    {
+     "code": "105202",
+     "uuid": "105202AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Potassium chloride / sodium chloride"
+    },
+    {
+     "code": "162855",
+     "uuid": "162855AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Potassium chloride 20 mmol/L in normal saline"
+    },
+    {
+     "code": "162856",
+     "uuid": "162856AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Normal saline + KCL 40 mmol/L"
+    },
+    {
+     "code": "82350",
+     "uuid": "82350AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Potassium chloride"
+    },
+    {
+     "code": "82351",
+     "uuid": "82351AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Potassium chloride-potassium gluconate"
+    }
+   ]
+  }
+ ],
+ "interactions": [
+  [
+   "DDInter1497",
+   "DDInter2026",
+   "Major",
+   "5973"
+  ],
+  [
+   "DDInter1497",
+   "DDInter638",
+   "Major",
+   "2264"
+  ],
+  [
+   "DDInter2169",
+   "DDInter225",
+   "Moderate",
+   "7257"
+  ],
+  [
+   "DDInter2169",
+   "DDInter226",
+   "Moderate",
+   "7257"
+  ],
+  [
+   "DDInter225",
+   "DDInter225",
+   "Moderate",
+   "7257"
+  ],
+  [
+   "DDInter225",
+   "DDInter226",
+   "Moderate",
+   "2935"
+  ]
+ ]
+}

--- a/api/src/test/resources/chartsearchai-test/ddi-substance-identity.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-substance-identity.json
@@ -1,8 +1,14 @@
 {
  "metadata": {
-  "note": "Verbatim DDInter 2.0 slice for issue #164 — a substance reported as cross-reactive, or interacting, with ITSELF. Three shapes, all taken unedited from the shipped 19 MB KB. (1) The mirror path: Tetryzoline (nasal) and Tetryzoline (ophthalmic) are one substance to the collapse key already, so an allergy resolving to one of them and a question resolving the other exercise the IDENTITY test alone. (2) Stem divergence, contraindication arm: Pfizer-BioNTech Covid-19 Vaccine and Tozinameran share rxcui 2468231 and one rxnorm_name but no display stem; only Tozinameran carries a drugbank_id. (3) Stem divergence, interaction arm: Daxibotulinumtoxina and Botulinum toxin type A share rxcui 1712 and one rxnorm_name but no display stem; only Botulinum toxin type A carries a drugbank_id. Botulinum Toxin Type B is the negative control on that arm — a different rxnorm_name, so the pair must still be reported. Enalapril and Enalaprilat with their shared Major partner Potassium chloride are the must-NOT-collapse control issue #121 decided: two rxnorm_names, two rxcuis, two drugbank_ids, and so two chips. The Omeprazole/Esomeprazole control — one rxnorm_name, one rxcui, TWO drugbank_ids — lives in ddi-contra-route-variants.json and is asserted from there."
+  "note": "Verbatim DDInter 2.0 slice for issue #164 — a substance reported as cross-reactive, or interacting, with ITSELF. Three shapes, all taken unedited from the shipped 19 MB KB. (1) The mirror path: Tetryzoline (nasal) and Tetryzoline (ophthalmic) are one substance to the collapse key already, so an allergy resolving to one of them and a question resolving the other exercise the IDENTITY test alone. (2) Stem divergence, contraindication arm: Pfizer-BioNTech Covid-19 Vaccine and Tozinameran share rxcui 2468231 and one rxnorm_name but no display stem; only Tozinameran carries a drugbank_id. (3) Stem divergence, interaction arm: Daxibotulinumtoxina and Botulinum toxin type A share rxcui 1712 and one rxnorm_name but no display stem; only Botulinum toxin type A carries a drugbank_id. Botulinum Toxin Type B is the negative control on that arm — a different rxnorm_name, so the pair must still be reported. Enalapril and Enalaprilat with their shared Major partner Potassium chloride are the must-NOT-collapse control issue #121 decided: two rxnorm_names, two rxcuis, two drugbank_ids, and so two chips. The Omeprazole/Esomeprazole control — one rxnorm_name, one rxcui, TWO drugbank_ids — lives in ddi-contra-route-variants.json and is asserted from there. The Typhoid vaccine rows are the third branch of the criterion: one rxnorm_name and NO drugbank_id anywhere in the family, so the data distinguishes nothing and the family is one substance. They carry no ATC code either, so before #164 an allergy to one of them asked about the other produced no chip at all rather than a wrong one."
  },
  "mechanisms": {
+  "1476": {
+   "text": "INTERVAL: The safety, immunogenicity, and efficacy of SARS-CoV-2 (COVID-19) vaccines when administered concurrently with other vaccines have not been assessed.",
+   "categories": [
+    "others"
+   ]
+  },
   "2264": {
    "text": "Concomitant use of angiotensin converting enzyme (ACE) inhibitors and potassium salts may increase the risk of hyperkalemia. Inhibition of ACE results in decreased aldosterone secretion, which in turn causes potassium retention.",
    "categories": [
@@ -23,6 +29,12 @@
   },
   "7257": {
    "text": "The effect of administering different botulinum neurotoxin serotypes concurrently or within several months of one another is unknown.  Excessive weakness may be exacerbated by another administration of botulinum toxin prior to the resolution of the effects of a previously administered botulinum toxin.",
+   "categories": [
+    "others"
+   ]
+  },
+  "7957": {
+   "text": "The safety, immunogenicity, and efficacy of SARS-CoV-2 (COVID-19) vaccines when administered concurrently with other vaccines have not been adequately assessed.  Extensive experience with non-COVID-19 vaccines has demonstrated that immunogenicity and adverse event profiles are generally similar when vaccines are administered simultaneously compared to when they are administered alone.",
    "categories": [
     "others"
    ]
@@ -417,9 +429,45 @@
      "name": "Potassium chloride-potassium gluconate"
     }
    ]
+  },
+  {
+   "id": "DDInter1894",
+   "name": "Typhoid vaccine (live)",
+   "rxcui": "762595",
+   "rxnorm_name": "Salmonella typhi Ty21a live antigen",
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": [
+    {
+     "code": "169171",
+     "uuid": "f04559cf-0168-4dec-abc9-05a49ad633f4",
+     "name": "Salmonella typhi Ty21a live antigen"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2138",
+   "name": "Typhoid vaccine live",
+   "rxcui": "762595",
+   "rxnorm_name": "Salmonella typhi Ty21a live antigen",
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": [
+    {
+     "code": "169171",
+     "uuid": "f04559cf-0168-4dec-abc9-05a49ad633f4",
+     "name": "Salmonella typhi Ty21a live antigen"
+    }
+   ]
   }
  ],
  "interactions": [
+  [
+   "DDInter1436",
+   "DDInter1894",
+   "Moderate",
+   "1476"
+  ],
   [
    "DDInter1497",
    "DDInter2026",
@@ -431,6 +479,12 @@
    "DDInter638",
    "Major",
    "2264"
+  ],
+  [
+   "DDInter2138",
+   "DDInter2164",
+   "Moderate",
+   "7957"
   ],
   [
    "DDInter2169",


### PR DESCRIPTION
## The defect

A substance was reported as cross-reactive, or interacting, **with itself**, by two routes the
substance key of #145/#160/#173 does not cover. Neither is a key that was too wide.

**The mirror path.** `IDENTITY` was awarded on ENTRY identity — `allergen == ref`. When the row an
allergy resolves to is a sibling the question does not itself put in play, the group holds no
identity candidate at all, so the best available relationship is the class comparison, against the
same substance.

**Stem divergence.** `Pfizer-BioNTech Covid-19 Vaccine` and `Tozinameran` publish one `rxcui`
(2468231) and one `rxnorm_name` but no display stem in common, so the stem VETO kept them apart —
correctly, as far as a display name can tell — and the chip read as a self-reference anyway. The
same shape sits in the interaction arm: `Daxibotulinumtoxina` and `Botulinum toxin type A` share
`rxcui` 1712 and one `rxnorm_name` and differ in stem.

## What distinguishes two rows of one substance from two substances under one name

The reference data's substance name over-merges. #160 measured that `rxnorm_name` and `rxcui`
partition the 2283 entries identically — 142 families, 332 entries, 0 families disagreeing in either
direction — and rejected that partition as the collapse key, because among those 142 families sit
`Omeprazole`/`Esomeprazole`: one `rxnorm_name` (`esomeprazole`), one `rxcui` (283742), one ATC code
(`A02BC05`), and two substances. That refusal was right and stands.

What was wrong was the veto. The display stem is a **display-name heuristic**: it cannot tell a
second SUBSTANCE from a second NAME, so it separates the two PPIs correctly and separates
`Tozinameran` from its own brand row incorrectly.

The reference data can tell them apart, and does, in a field the module was not reading: a
**`drugbank_id`**, an identifier of a *substance* rather than of a presentation. 2077 of the 2283
rows carry one; a row that carries none makes no claim to be a substance of its own, which is what
the rule below turns on.

```
Tozinameran                       rxcui 2468231  rxnorm_name "SARS-CoV-2 …"  drugbank DB15696
Pfizer-BioNTech Covid-19 Vaccine  rxcui 2468231  rxnorm_name "SARS-CoV-2 …"  drugbank null
Botulinum toxin type A            rxcui 1712     rxnorm_name "botulinum …"   drugbank DB00083
Daxibotulinumtoxina               rxcui 1712     rxnorm_name "botulinum …"   drugbank null
Omeprazole                        rxcui 283742   rxnorm_name "esomeprazole"  drugbank DB00338
Esomeprazole                      rxcui 283742   rxnorm_name "esomeprazole"  drugbank DB00736
```

So the criterion is: **a substance-name family that names TWO OR MORE DrugBank substances holds more
than one substance, and the display stem stays in force to separate them; a family that names AT
MOST ONE is a single substance, and the stem has nothing to veto.** It is resolved per family at
load, not per row, because no row can answer it alone — `Atropine` (`DB00572`),
`Atropine (ophthalmic)` (none) and `Hyoscyamine` (`DB00424`) are one family, and a row-by-row rule
would key the first two differently and split a route variant off its own substance.

### How it was pinned

Measured over the shipped 19 MB KB, and by mutation sweep on a throwaway worktree:

| | |
|---|---|
| substance-name families of more than one row | 142 |
| …naming two or more DrugBank substances (stem stays in force) | **19** |
| …naming at most one (family is one substance) | **123** |
| substances over the 332 multi-row entries | 177 → **163** |
| families that newly merge | **12** |
| resulting groups holding two DrugBank substances | **0** |
| merged groups whose rows publish divergent ATC sets | **0** (was 0; the re-measurement `ContraindicationChips`' javadoc demands before any widening) |
| self-pair interaction rows dropped at load | **26 → 28** (both read off the production parser's WARN on the standalone) |

The strongest evidence that the criterion is the right one is that I did not curate its output.
**All eight** of the pairs the existing javadoc names as "genuinely different substances the KB files
under one substance name" fall among the 19 — `Omeprazole`/`Esomeprazole`,
`Amphetamine`/`Dextroamphetamine`, `Fenfluramine`/`Dexfenfluramine`,
`Gabapentin`/`Gabapentin enacarbil`, `Netupitant`/`Fosnetupitant`,
`Ketoconazole`/`Levoketoconazole`, `Fenofibrate`/`Fenofibric acid`, `Atropine`/`Hyoscyamine`. The
other eleven are the same shape and were not previously enumerated:
`Hydrocortisone`/`Hydrocortisone butyrate`, `Estrone`/`Estrone sulfate`,
`Mometasone`/`Mometasone furoate`, `Benzylpenicillin`/`Procaine benzylpenicillin`,
`Iodine`/`Iodide I-131`, `Antithrombin Alfa`/`Antithrombin III human` and five more.

The criterion also gets the *route variants inside those families* right, which is the part a
per-row rule would break: `Atropine (ophthalmic)` (no id) stays with `Atropine` rather than
splitting off, `Hydrocortisone (ophthalmic)`/`(topical)` stay with `Hydrocortisone`,
`Benzylpenicillin (potassium)`/`(sodium)` stay with `Benzylpenicillin`.

`Enalapril` (rxcui 3827) and `Enalaprilat` (3829) are in **different** families and were never at
risk under any variant of this key — they are the case #121 named, not the sharp edge. The sharp
edge is `Omeprazole`/`Esomeprazole`, and it is held apart by the registry, live and in tests.

**Mutation sweep** (throwaway worktree, discarded; the tree this PR was pushed from was never
mutated):

- remove the contested-family veto → **8 failures in 4 classes**: `Omeprazole`/`Esomeprazole` merge
  in the contraindication arm, the interaction arm and the injected reference record, and
  `Hydrocortisone butyrate` merges into `Hydrocortisone`.
- remove the no-registry-at-all branch → **1 failure**, the typhoid case.
- revert the identity test to `allergen == ref` → **2 failures**, including the mirror-path chip
  text verbatim. (Note the Pfizer/Tozinameran case still passes under this one: the widened key
  alone collapses it, because the row that IS the allergen then raises IDENTITY into the same
  ledger entry. So the two halves fix one path each, and both are needed.)

## What changed

- `DdiDrugReferenceSource` parses `drugbank_id`, resolves it per substance-name family, and stamps
  the result on each entry. One resolution, read by both consumers.
- `DrugReference.substanceKey()` takes that identity as its second component, falling back to the
  display stem when the data supplies none — which is every entry of the curated `json` dataset and
  the `atc` adapter, so their behaviour is byte-for-byte what it was.
- `DrugSafetyValidator.addAllergyContraindications` decides identity by
  `substanceGroupKey()` rather than by object identity, and the chip **names the allergen as the
  patient's record resolves it** on both the drug field and the detail. That is what dissolves the
  objection this issue was held on: the chip no longer names the row the question matched, so it
  cannot misreport which variant the allergy was recorded against.
- The interaction arm needed **no change**. #152's self-pair guard already asks "are these two rows
  one substance?" through the same `substanceKey`, so widening the key widened the guard with it.
  No third dedup mechanism, and nothing keyed on rendered text.

## Live evidence

Standalone 3.7.1, `sourceFormat=ddinter`, 2283 entries, `origin=appdata:chartsearchai/ddi_knowledge_base.json`
(read from `GET /chartsearchai/drugreferencestatus`, both runs). BEFORE is `main` at `078a3d5`,
AFTER is this branch; each was a full-JVM restart via `standalone-verify.sh`, and every patient was
resolved by name lookup against the live DB. Chip text below is verbatim.

### Stem divergence, contraindication arm — Kevin Brown, coded `Tozinameran` allergy

BEFORE — **3 chips**:
```
Pfizer-BioNTech Covid-19 Vaccine (sars-cov-2 (covid-19) vaccine, mrna spike protein) is in the same
  ATC class (J07BN) as the patient's allergy to Tozinameran (sars-cov-2 (covid-19) vaccine, mrna
  spike protein) — possible cross-reactivity
The patient has a recorded allergy to Tozinameran (sars-cov-2 (covid-19) vaccine, mrna spike protein).
The patient has a recorded allergy to Clarithromycin.
```
AFTER — **2 chips**:
```
The patient has a recorded allergy to Tozinameran (sars-cov-2 (covid-19) vaccine, mrna spike protein).
The patient has a recorded allergy to Clarithromycin.
```
Counterfactual: had the identity chip kept naming `ref` — the row the question resolved — the
survivor would read "The patient has a recorded allergy to **Pfizer-BioNTech Covid-19 Vaccine**
(sars-cov-2 …)", asserting an allergy against a variant the chart does not record. It names
Tozinameran, which is what the chart records. That is the whole reason this issue was held open, and
it is why the remedy is to stop naming the matched row rather than to widen `IDENTITY` alone.

### The mirror path — Susan Young, coded `Tetryzoline (ophthalmic)` allergy, asked about `(nasal)`

BEFORE — **2 chips**:
```
Tetryzoline (nasal) (tetrahydrozoline) is in the same ATC class (R01AA) as the patient's allergy to
  Tetryzoline (ophthalmic) (tetrahydrozoline) — possible cross-reactivity
The patient has a recorded allergy to Tiotropium.
```
AFTER — **2 chips**:
```
The patient has a recorded allergy to Tetryzoline (ophthalmic) (tetrahydrozoline).
The patient has a recorded allergy to Tiotropium.
```
These two rows were already one substance to the old key, so this probe isolates the identity test
alone — nothing about the key change could have moved it. Counterfactual: had the chip kept naming
`ref`, it would read "The patient has a recorded allergy to **Tetryzoline (nasal)**
(tetrahydrozoline)", against a variant the chart does not record. It names `(ophthalmic)`, which the
chart does. Fixture created for this probe and left in place: concept `Tetryzoline (ophthalmic)`
(`405e580f-7c34-401a-9c58-ba92721ecf3e`) and Susan Young's coded allergy to it
(`7d30e0ea-c534-4e02-912b-7f047da64d4b`), both tagged as agent-created in their comments.

### Stem divergence, interaction arm — Susan Young, active `Botulinum toxin type A` order

BEFORE — **5 chips**, two of them self-reading and two of them one substance reported twice:
```
Daxibotulinumtoxina (botulinum toxin type a) interacts with active order neomycin — Major. …
Daxibotulinumtoxina (botulinum toxin type a) interacts with active order botulinum toxin type a — Moderate. …
Botulinum toxin type A interacts with active order neomycin — Major. …
Botulinum toxin type A interacts with active order botulinum toxin type a — Moderate. …
The patient has a recorded allergy to Tiotropium.
```
AFTER — **2 chips**:
```
Daxibotulinumtoxina (botulinum toxin type a) interacts with active order neomycin — Major. …
The patient has a recorded allergy to Tiotropium.
```
Four chips became one: the two self-references are dropped at the parse boundary, and the two
neomycin chips are one because the two rows are now one subject. The genuine cross-substance pair
survives — `Botulinum Toxin Type B` publishes a different `rxnorm_name`, and the unit fixture pins
that it still chips.

### Must-not-collapse — George Anderson, `Pantoprazole` allergy, asked about esomeprazole

BEFORE and AFTER, **2 chips, identical**:
```
Omeprazole is in the same ATC class (A02BC) as the patient's allergy to Pantoprazole — possible cross-reactivity
Esomeprazole is in the same ATC class (A02BC) as the patient's allergy to Pantoprazole — possible cross-reactivity
```
This is the sharp edge. Had substance identity been taken from `rxcui`/`rxnorm_name` alone, one of
these two would be gone.

### Must-not-collapse — the prodrug/metabolite pair, question-pair arm

BEFORE and AFTER, **2 chips, identical** — the #121 decision, upheld on the arm where the widening
could have undone it:
```
Potassium chloride interacts with Enalaprilat, also named in the question — Major. …
Potassium chloride interacts with Enalapril, also named in the question — Major. …
```

### Controls, all exact

Every control was run on BOTH builds and every one is chip-for-chip identical between them.

| patient | question | expected | before | after |
|---|---|---|---|---|
| Mary Smith | clarithromycin | 1 Major ×simvastatin | 1 | 1 |
| Agnes Adams | warfarin | 1 Major ×aspirin | 1 | 1 |
| Joshua Johnson | ibuprofen | 2 | 2 | 2 |
| Mary Smith | paracetamol | 0 | 0 | 0 |
| Betty Williams | bupivacaine | exactly 1 | 1 | 1 |
| Sarah Taylor | hydrocortisone | 9 | 9 | 9 |

Sarah Taylor's 9 is worth reading as evidence rather than as a box ticked: 4 chips named
`Hydrocortisone` (1 contraindication via `H02AB` plus one interaction chip per NSAID order —
celecoxib, diclofenac, ibuprofen), and **`Hydrocortisone butyrate` still holds a chip of its own**.
That family is contested (`DB00741` vs `DB14540`), so the stem stays in force — the must-not-collapse
rule firing live on a patient, not only in a fixture.

## Build

Baseline measured on `main` itself at `078a3d5`, clean worktree: **938 api + 61 omod = 999**,
0 failures, 34 skipped.
This branch: **947 api + 61 omod = 1008**, 0 failures, 34 skipped. +9, all new; no existing test
changed.

querystore jar resolved: `querystore-api-1.0.0-20260806.153951-82.jar`, md5
`38205608891f10b68929c35fb3eace7e`, identical before and after every build here.

GitHub Actions ran and passed on this PR — Java 11, 17 and 21, plus the eval-harness selftests
(run 31134668592). The hosted-runner outage that left recent PRs with no CI result appears to have
cleared.

## Limitations, honestly

- **Two of the 12 new merges are defensible rather than obviously right**:
  `Fluoroestradiol f-18` with `Estradiol`, and `Silver (topical)` with the two `Silver nitrate` rows.
  In both the KB asserts one `rxcui` and one `rxnorm_name` and offers no registry distinction, so
  the criterion follows the data; the cost is one fewer advisory chip, never a stronger claim.
  Neither is reachable on the demo dictionary.
- **One rated interaction row is newly dropped beyond #164's own**: an influenza B strain pair, rated
  Minor. No Major or Moderate row is lost other than `Daxibotulinumtoxina × Botulinum toxin type A`,
  which is the defect.
- **`ContraindicationChips`' replace-an-incumbent branch is now unexercised by any test.** The route
  that reached it — an identity chip arriving after a class chip for the same key — is exactly what
  this change removes. What is left is a class chip replaced by a more specific class chip, which
  needs a group whose rows publish divergent ATC codes, and the shipped KB has none. The branch is
  kept and documented rather than deleted, because "most specific wins" is the arm's contract.
- **#185 is NOT fixed by this.** The duplicate-therapy skip compares the ORDER's ATC codes against
  the KB row's (`!Collections.disjoint(partner.codes, refCodes)`), and neither side is touched here;
  `partner.codes` holds only codes the concept dictionary supplied, so widening the substance key
  cannot add the missing one. Verified by reading `orderPartners`/`classRelationships`, not measured
  live — #185 records that it is unreachable on the demo dictionary.

## Two test COMMENTS this change falsifies — reported, not edited

No assertion, expected value or fixture datum of any existing test was touched, and all 999 existing
tests pass unchanged. But two explanatory comments in test files are now factually wrong, and I have
left them alone rather than decide unilaterally:

1. `SelfInteractionTest.aRowPairingADrugWithItselfIsNotLoaded` says the KB files the botulinum
   serotype mechanism "on genuine cross-row pairs of its own — type A against type B, and
   `Daxibotulinumtoxina` against each of them — **all of which the guard leaves loaded**". The guard
   now drops `Daxibotulinumtoxina × Botulinum toxin type A`. That fixture carries no
   `Daxibotulinumtoxina` row, so no assertion is affected.
2. `ContraindicationRouteVariantTest.theIdentityChipSurvivesWhenTheAllergenRowIsNotItsGroupsFirst`
   says "A first-wins ledger answers this case with `Tozinameran (12y+) … is in the same ATC class
   (J07BN) …`". It no longer would: with identity decided by substance, a first-wins ledger raises
   the identity chip too. The test's assertions are still correct and still pass; it just no longer
   discriminates first-wins from replace-in-place. Related, and stated in the limitations above: no
   test now reaches that branch.

Also stale by one figure: `SelfInteractionTest`'s class javadoc gives the self-pair population as
1 + 25. Both clauses remain true of the KB, but the total the guard drops is now 28.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
