### PR TITLE
fix(drug-safety): complete the one-substance-one-row sweep (#174 sites 2–4, #186, and a fifth site)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReference.java
@@ -325,6 +325,26 @@ public class DrugReference {
 		return candidate.namesNoRoute() && !incumbent.namesNoRoute() ? candidate : incumbent;
 	}
 
+	/**
+	 * @return {@link #canonicalRow(DrugReference, DrugReference)} folded over {@code rows} in
+	 *         iteration order — the row that represents the substance for a caller that already holds
+	 *         the whole group rather than accumulating it as it scans. {@code null} for an empty
+	 *         {@code rows}, which is the only way this can answer nothing.
+	 *
+	 *         <p>Shared rather than written out at each site for the reason the pairwise form exists
+	 *         at all: four surfaces now choose a substance's representative row — the interaction
+	 *         chip's subject (issue #162), the injected record (#163), the class chip's partner
+	 *         (#174 site 1) and the dose warning's subject (#174 site 4) — and a fold written four
+	 *         times is four chances for one of them to iterate in an order the others do not.
+	 */
+	static DrugReference canonicalRow(Iterable<DrugReference> rows) {
+		DrugReference canonical = null;
+		for (DrugReference row : rows) {
+			canonical = canonicalRow(canonical, row);
+		}
+		return canonical;
+	}
+
 	/** @return {@code name} with any trailing parenthesized qualifier(s) removed, normalized by
 	 *          {@link #normalizeName} — the empty string when the name is blank or is nothing but a
 	 *          qualifier, which keeps the key total. */

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -616,9 +616,19 @@ public class DrugReferenceInjector {
 	 * while the prose named ivosidenib: the two disagreed by construction.
 	 *
 	 * <p>Relevance uses {@link PatientClinicalContext#hasActiveDrug} — deliberately the same
-	 * predicate {@link DrugSafetyValidator} uses to decide an interaction concerns this patient, so
-	 * a partner that raises a chip is exactly a partner promoted here, and the rendered text cannot
-	 * drift from the chip.
+	 * predicate {@link DrugSafetyValidator} uses to decide an interaction concerns this patient (see
+	 * {@link #promotable}, which is that predicate and the severity floor together, applied both here
+	 * and inside the collapse below) — so a partner that raises a DRUG-IN-PLAY chip is exactly a
+	 * partner promoted here, and the rendered text cannot drift from that chip.
+	 *
+	 * <p>Scoped to that arm deliberately, and the scope is the correction
+	 * {@link DrugSafetyValidator#addQuestionPairInteractions} asks for: across the whole chip set the
+	 * correspondence does not hold, because a question-PAIR chip names two drugs the question named
+	 * and neither need be an active order, so its partner is promoted nowhere. That does not reopen
+	 * the chip-versus-prose split this ordering exists to close — since issue #110 every chip is also
+	 * injected verbatim as its own numbered, citable record ({@code preAnswerFindings} →
+	 * {@link #renderFinding}), so a pair finding is grounded by that record rather than by these
+	 * notes, and the promoted-note budget is untouched by it.
 	 *
 	 * <p>That correspondence is per PARTNER, and since issue #174 site 2 this method renders one note
 	 * per partner rather than one per ROW — the same collapse
@@ -629,8 +639,9 @@ public class DrugReferenceInjector {
 	 * note). Before it, a patient on one dexamethasone order got one Major chip beside a record reading
 	 * "dexamethasone (Major …); dexamethasone (Moderate …); dexamethasone (Moderate …)" — a model
 	 * answering from the record could name a severity the chip deliberately discarded, and from the
-	 * more quotable half, since in that measured case the discarded Moderate note is 649 characters
-	 * against the surviving Major row's 319.
+	 * more quotable half, since in that measured case the discarded Moderate note is 659 characters
+	 * against the surviving Major row's 326 (re-measured 2026-08-07 through the real parser over both
+	 * the fixture slice and the shipped KB, which agree).
 	 *
 	 * <p>Measured over the shipped 19 MB KB (2026-08-07; re-measure before relying on the figures):
 	 * 1876 of its 2283 entries carried at least one repeated partner and 19,316 of the 590,312

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -623,9 +623,10 @@ public class DrugReferenceInjector {
 	 * <p>That correspondence is per PARTNER, and since issue #174 site 2 this method renders one note
 	 * per partner rather than one per ROW — the same collapse
 	 * {@link DrugSafetyValidator#bestRulePerPartner} has made for the chips since issue #115, keyed
-	 * the same way ({@link DrugSafetyValidator#partnerLabel}, case-folded) and decided by the same
-	 * survivor rule ({@link DrugSafetyValidator#outranksOnRule}: most severe, then the longer note).
-	 * Before it, a patient on one dexamethasone order got one Major chip beside a record reading
+	 * on {@link DrugSafetyValidator#partnerLabel} case-folded — that method's own fallback key, for
+	 * the reasons {@link #onePerPartner} sets out — and reaching the same survivor: the row the
+	 * patient is on, then {@link DrugSafetyValidator#outranksOnRule} (most severe, then the longer
+	 * note). Before it, a patient on one dexamethasone order got one Major chip beside a record reading
 	 * "dexamethasone (Major …); dexamethasone (Moderate …); dexamethasone (Moderate …)" — a model
 	 * answering from the record could name a severity the chip deliberately discarded, and from the
 	 * more quotable half, since in that measured case the discarded Moderate note is 649 characters
@@ -675,7 +676,7 @@ public class DrugReferenceInjector {
 		// safety decision the chip path enforces. A sub-floor rule is not promoted; it keeps its
 		// dataset position, exactly as before promotion existed.
 		int floor = DrugSafetyValidator.configuredSeverityFloor();
-		for (DrugReference.Interaction i : onePerPartner(ref)) {
+		for (DrugReference.Interaction i : onePerPartner(ref, context, floor)) {
 			String label = DrugSafetyValidator.partnerLabel(i);
 			String note = ChartSearchAiUtils.firstNonBlank(i.getNote());
 			// Kept identical to the previous rendering: a labelless rule still contributes its bare
@@ -710,9 +711,8 @@ public class DrugReferenceInjector {
 			if (compact.length() >= rendered.length()) {
 				compact = rendered;
 			}
-			boolean promote = context != null && context.hasActiveDrug(i.getToken(), i.getAtc())
-					&& DrugSafetyValidator.clearsSeverityFloor(i, floor);
-			(promote ? promoted : rest).add(new InteractionNote(rendered, compact, i.getSeverity()));
+			(promotable(i, context, floor) ? promoted : rest)
+					.add(new InteractionNote(rendered, compact, i.getSeverity()));
 		}
 		// Within the promoted segment, severity — not dataset position — decides who keeps their
 		// mechanism prose when the budget can only afford one full note (see render). Measured on the
@@ -744,30 +744,106 @@ public class DrugReferenceInjector {
 	 *         {@link DrugReference.Interaction} defines no {@code equals} and can never equal a
 	 *         {@link String}.
 	 *
+	 *         <p><b>The label rather than the resolved ENTRY, and why that is not the text-keying
+	 *         issue #173 ruled out.</b> Every chip-side ledger keys on identity because a key made of
+	 *         rendered text rots when the rendering changes, so this looks like the exception and is
+	 *         worth settling once rather than re-litigating. Three things settle it.
+	 *         <ul>
+	 *           <li>There is usually no identity to be had. The chip's key
+	 *               ({@code DrugSafetyValidator.SubjectRule.partnerKey()}) is two-tier — the ENTRY
+	 *               where {@code activeOrderEntryFor} resolves the rule against one of the patient's
+	 *               ACTIVE ORDERS, else this same case-folded label. Every partner in the dataset
+	 *               tail, which is where nearly all the surplus above lives, resolves to nothing, so
+	 *               for them the chip's own key IS the label. Keying the tail on an entry would mean
+	 *               resolving each partner token across the whole dataset, which is a THIRD
+	 *               resolution rather than a port of the chip's.</li>
+	 *           <li>It would not be safer, it would be less safe. {@code identifies} resolves through
+	 *               an entry's alias list and its ATC codes, and the shipped KB shares both across
+	 *               entities the dataset itself files as separate drugs. Measured 2026-08-07 over the
+	 *               19 MB KB by calling that predicate: on 397 of 2283 entries, 487 notes, two rules
+	 *               with DIFFERENT labels resolve to ONE entry — {@code trastuzumab} with
+	 *               {@code trastuzumab deruxtecan}, {@code isosorbide} with
+	 *               {@code isosorbide mononitrate}, {@code moderna covid-19 vaccine} with
+	 *               {@code sars-cov-2 (covid-19) vaccine, mrna spike protein}. In a CHIP that
+	 *               over-merge costs one duplicate and the survivor is still the most severe rule; in
+	 *               a RECORD it costs a partner its name, and this record is the only place the tail
+	 *               is named at all. Dropping a partner is the direction this module does not take.</li>
+	 *           <li>What #173 ruled out was keying on an ASSEMBLED SENTENCE — the screening arm's
+	 *               {@code (type, drug, detail)} triple, which stopped recognising a repeat the moment
+	 *               either arm reworded its chip (see {@code DrugSafetyValidator.InteractionPairs}). A
+	 *               partner's own coalesced, trimmed name is not that: it is the atomic unit of the
+	 *               grouping, and issue #121's invariant — the key IS what the chip says — is
+	 *               deliberate rather than incidental.</li>
+	 *         </ul>
+	 *         The residue is real and is issue #190 item 2: two rules naming ONE partner under two
+	 *         different spellings stay two notes beside one chip. Note that closing it by grouping on
+	 *         the entry, which that issue proposes, buys the 397-entry over-merge above.
+	 *
 	 *         <p>Applied BEFORE the severity floor rather than after, deliberately: the floor decides
 	 *         which rules are worth PROMOTING, while a sub-floor row keeps its dataset position in
 	 *         the tail (see the caller), so collapsing only the promoted half would leave a sub-floor
 	 *         row of a partner in the tail beside that partner's promoted row — the same partner
-	 *         twice, which is what this removes. The survivor rule orders by the same severity
-	 *         ranking the floor reads, so a partner carrying any above-floor row keeps that row
-	 *         rather than a sub-floor sibling; a partner whose rows are ALL sub-floor keeps one of
-	 *         them, in the tail, exactly as before.
+	 *         twice, which is what this removes.
+	 *
+	 *         <p><b>Which row wins, and why promotability is asked FIRST.</b> Running before the floor
+	 *         means the survivor rule decides which row's {@code (token, ATC)} pair the caller's
+	 *         promotion predicate is then asked about — so the survivor must be a row that predicate
+	 *         says yes to wherever the group has one, or the collapse can push a partner OUT of the
+	 *         segment that overrides {@link #MAX_INTERACTION_RENDER_CHARS} and, with another partner
+	 *         promoted and only one tail representative rendered, out of the record altogether. That
+	 *         is {@link DrugSafetyValidator#bestRulePerPartner}'s behaviour reproduced rather than a
+	 *         rule of its own: it never sees a non-matching row at all, having filtered on
+	 *         {@code hasActiveDrug} before it groups. Within each half the order is
+	 *         {@link DrugSafetyValidator#outranksOnRule}, so the promoted note is the row the chip
+	 *         quotes, and a partner with no promotable row keeps its most severe one in the tail.
+	 *         The floor half of {@link #promotable} cannot change a winner on its own — a group's
+	 *         most severe row clears the floor whenever any of its rows does, since
+	 *         {@code severityPriority} ranks unrated highest and is otherwise monotone in the rank the
+	 *         floor compares — so only the {@code hasActiveDrug} half is doing work here. No shipped
+	 *         dataset can make it: {@code ddinter} writes every rule's ATC from its partner row, and
+	 *         measured 2026-08-07 through the real parser, 0 of the 19 MB KB's label groups hold rows
+	 *         differing on either field. A hand-authored file reaches it immediately, which is the
+	 *         same latency issue #174 site 4 is guarded at.
 	 *
 	 *         <p>A {@link LinkedHashMap}, so replacing a group's winner does not move the partner's
 	 *         position — the tail's dataset order is what the caller's javadoc guarantees.
 	 */
-	private static Collection<DrugReference.Interaction> onePerPartner(DrugReference ref) {
+	private static Collection<DrugReference.Interaction> onePerPartner(DrugReference ref,
+			PatientClinicalContext context, int floor) {
 		Map<Object, DrugReference.Interaction> best =
 				new LinkedHashMap<Object, DrugReference.Interaction>();
 		for (DrugReference.Interaction i : ref.getInteractions()) {
 			String label = DrugSafetyValidator.partnerLabel(i);
 			Object key = label != null ? (Object) label.toLowerCase(Locale.ROOT) : i;
 			DrugReference.Interaction incumbent = best.get(key);
-			if (incumbent == null || DrugSafetyValidator.outranksOnRule(i, incumbent)) {
+			if (incumbent == null || outranksForRendering(i, incumbent, context, floor)) {
 				best.put(key, i);
 			}
 		}
 		return best.values();
+	}
+
+	/** @return true when {@code candidate} is the row this record should show for a partner
+	 *          {@code incumbent} already covers: the row the patient is on before one they are not,
+	 *          then {@link DrugSafetyValidator#outranksOnRule}. See {@link #onePerPartner}. */
+	private static boolean outranksForRendering(DrugReference.Interaction candidate,
+			DrugReference.Interaction incumbent, PatientClinicalContext context, int floor) {
+		boolean candidatePromotable = promotable(candidate, context, floor);
+		if (candidatePromotable != promotable(incumbent, context, floor)) {
+			return candidatePromotable;
+		}
+		return DrugSafetyValidator.outranksOnRule(candidate, incumbent);
+	}
+
+	/** @return whether {@code i} names a drug this patient is on by a rule the severity floor admits
+	 *          — the promotion predicate of {@link #orderedInteractionNotes}, shared with
+	 *          {@link #onePerPartner} so the collapse cannot discard the very row that would have been
+	 *          promoted. Both arms are the ones {@link DrugSafetyValidator#bestRulePerPartner} applies
+	 *          before it groups. */
+	private static boolean promotable(DrugReference.Interaction i, PatientClinicalContext context,
+			int floor) {
+		return context != null && context.hasActiveDrug(i.getToken(), i.getAtc())
+				&& DrugSafetyValidator.clearsSeverityFloor(i, floor);
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -790,11 +790,12 @@ public class DrugReferenceInjector {
 	 *         different spellings stay two notes beside one chip. Note that closing it by grouping on
 	 *         the entry, which that issue proposes, buys the 397-entry over-merge above.
 	 *
-	 *         <p>Applied BEFORE the severity floor rather than after, deliberately: the floor decides
-	 *         which rules are worth PROMOTING, while a sub-floor row keeps its dataset position in
-	 *         the tail (see the caller), so collapsing only the promoted half would leave a sub-floor
-	 *         row of a partner in the tail beside that partner's promoted row — the same partner
-	 *         twice, which is what this removes.
+	 *         <p>Applied over EVERY rule rather than only over the promoted ones, deliberately: the
+	 *         floor decides which rules are worth PROMOTING, while a sub-floor row keeps its dataset
+	 *         position in the tail (see the caller), so collapsing only the promoted half would leave
+	 *         a sub-floor row of a partner in the tail beside that partner's promoted row — the same
+	 *         partner twice, which is what this removes. (The survivor rule below does READ the floor,
+	 *         through {@link #promotable}; what it does not do is filter the input by it.)
 	 *
 	 *         <p><b>Which row wins, and why promotability is asked FIRST.</b> Running before the floor
 	 *         means the survivor rule decides which row's {@code (token, ATC)} pair the caller's

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceInjector.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.chartsearchai.reference;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -545,7 +546,14 @@ public class DrugReferenceInjector {
 	 * sibling row is therefore prose this record no longer carries and no chip replaces. Narrower than
 	 * it sounds — it needs the question's drug to be ATC-related to one order and that order's substance
 	 * to be multi-row — but it is a real reduction in what the prompt carries, not a re-presentation of
-	 * it, and it is the same gap issue #174's {@code orderedInteractionNotes} sweep has to decide about.
+	 * it.
+	 *
+	 * <p>Issue #174's {@code orderedInteractionNotes} sweep did NOT close that residue and was never
+	 * going to: it collapses several rules of ONE entry that name one PARTNER, which is the other
+	 * axis. Widening this map to read every row of a substance is the change that would close it, and
+	 * it is a different one — the surviving entry's id is this record's citation id, so a record
+	 * assembled from several rows would have to choose one and then cite prose the chosen row does not
+	 * carry.
 	 */
 	private static void collect(Map<Object, DrugReference> bySubstance, DrugReference ref) {
 		Object substance = ref.substanceKey();
@@ -612,21 +620,28 @@ public class DrugReferenceInjector {
 	 * a partner that raises a chip is exactly a partner promoted here, and the rendered text cannot
 	 * drift from the chip.
 	 *
-	 * <p>That correspondence is per PARTNER, and since issue #115 it is no longer one note per chip:
-	 * {@link DrugSafetyValidator#bestRulePerPartner} collapses several rules naming one partner —
-	 * DDInter's route variants of a drug all publish the same match token — into a single
-	 * most-severe chip, while this method still promotes one entry per row. A patient on one
-	 * dexamethasone order therefore gets one Major chip beside a record reading "dexamethasone
-	 * (Major …); dexamethasone (Moderate …); dexamethasone (Moderate …)", so a model answering from
-	 * the record can still name a severity the chip deliberately discarded — and does so from the
-	 * more quotable half, because in that measured case the discarded Moderate note is 659 characters
-	 * against the surviving Major row's 326. Nothing goes missing: {@code render} emits every promoted
-	 * note, so a duplicated partner can only push another partner into its compact
-	 * {@code name (Severity)} form, never out. Collapsing here needs the same thing the chip cannot
-	 * decide either — which variant the order is — and so waits on the route vocabulary that is the
-	 * data-side half of #115. Until then the two paths agree on WHICH partners concern the patient,
-	 * which is what the ordering above exists to guarantee, but not on how many rows or which
-	 * severity.
+	 * <p>That correspondence is per PARTNER, and since issue #174 site 2 this method renders one note
+	 * per partner rather than one per ROW — the same collapse
+	 * {@link DrugSafetyValidator#bestRulePerPartner} has made for the chips since issue #115, keyed
+	 * the same way ({@link DrugSafetyValidator#partnerLabel}, case-folded) and decided by the same
+	 * survivor rule ({@link DrugSafetyValidator#outranksOnRule}: most severe, then the longer note).
+	 * Before it, a patient on one dexamethasone order got one Major chip beside a record reading
+	 * "dexamethasone (Major …); dexamethasone (Moderate …); dexamethasone (Moderate …)" — a model
+	 * answering from the record could name a severity the chip deliberately discarded, and from the
+	 * more quotable half, since in that measured case the discarded Moderate note is 649 characters
+	 * against the surviving Major row's 319.
+	 *
+	 * <p>Measured over the shipped 19 MB KB (2026-08-07; re-measure before relying on the figures):
+	 * 1876 of its 2283 entries carried at least one repeated partner and 19,316 of the 590,312
+	 * expanded rows were surplus, {@code Ozanimod} carrying the largest single surplus at 49. The cost
+	 * of carrying them was not only tidiness: segment 1 of {@code render} deliberately overrides
+	 * {@link #MAX_INTERACTION_RENDER_CHARS} so that a partner the patient is on is never invisible, so
+	 * a partner filed under three rows spent three notes of budget the budget could not claw back.
+	 *
+	 * <p>The route vocabulary that is the data-side half of #115 is still missing, and this collapse
+	 * does not need it: it decides which of several rows about ONE partner to SHOW, exactly as the
+	 * chip decides which to raise, and neither has to know which variant the order is. What still
+	 * waits on that vocabulary is stating a variant-specific severity at all.
 	 *
 	 * <p>Since issue #163 there is one more way they can differ, in the opposite direction, and it is
 	 * stated here rather than left to be discovered: {@link #matchingEntries} now injects ONE record per
@@ -660,8 +675,8 @@ public class DrugReferenceInjector {
 		// safety decision the chip path enforces. A sub-floor rule is not promoted; it keeps its
 		// dataset position, exactly as before promotion existed.
 		int floor = DrugSafetyValidator.configuredSeverityFloor();
-		for (DrugReference.Interaction i : ref.getInteractions()) {
-			String label = ChartSearchAiUtils.firstNonBlank(i.getToken(), i.getAtc());
+		for (DrugReference.Interaction i : onePerPartner(ref)) {
+			String label = DrugSafetyValidator.partnerLabel(i);
 			String note = ChartSearchAiUtils.firstNonBlank(i.getNote());
 			// Kept identical to the previous rendering: a labelless rule still contributes its bare
 			// note, and a null/blank pair contributes nothing (addIfPresent drops it) — the dataset
@@ -713,6 +728,46 @@ public class DrugReferenceInjector {
 		// segments distinguishable to render().
 		promoted.addAll(rest);
 		return new OrderedInteractions(promoted, promotedCount);
+	}
+
+	/**
+	 * @return {@code ref}'s interaction rules, at most ONE per partner, in the dataset order of each
+	 *         partner's first row — the rendering counterpart of
+	 *         {@link DrugSafetyValidator#bestRulePerPartner} (issue #174 site 2).
+	 *
+	 *         <p>The key is {@link DrugSafetyValidator#partnerLabel} case-folded, which is both the
+	 *         key that method falls back to and the very string this record prints, so the grouping
+	 *         and the rendering cannot come to disagree about what one partner is. A rule carrying
+	 *         NEITHER a token nor an ATC code keys on itself: it renders as a bare note with no name
+	 *         to group on, and merging two such rows would silently drop one operator-authored
+	 *         paragraph in favour of another. The two key spaces cannot collide — an
+	 *         {@link DrugReference.Interaction} defines no {@code equals} and can never equal a
+	 *         {@link String}.
+	 *
+	 *         <p>Applied BEFORE the severity floor rather than after, deliberately: the floor decides
+	 *         which rules are worth PROMOTING, while a sub-floor row keeps its dataset position in
+	 *         the tail (see the caller), so collapsing only the promoted half would leave a sub-floor
+	 *         row of a partner in the tail beside that partner's promoted row — the same partner
+	 *         twice, which is what this removes. The survivor rule orders by the same severity
+	 *         ranking the floor reads, so a partner carrying any above-floor row keeps that row
+	 *         rather than a sub-floor sibling; a partner whose rows are ALL sub-floor keeps one of
+	 *         them, in the tail, exactly as before.
+	 *
+	 *         <p>A {@link LinkedHashMap}, so replacing a group's winner does not move the partner's
+	 *         position — the tail's dataset order is what the caller's javadoc guarantees.
+	 */
+	private static Collection<DrugReference.Interaction> onePerPartner(DrugReference ref) {
+		Map<Object, DrugReference.Interaction> best =
+				new LinkedHashMap<Object, DrugReference.Interaction>();
+		for (DrugReference.Interaction i : ref.getInteractions()) {
+			String label = DrugSafetyValidator.partnerLabel(i);
+			Object key = label != null ? (Object) label.toLowerCase(Locale.ROOT) : i;
+			DrugReference.Interaction incumbent = best.get(key);
+			if (incumbent == null || DrugSafetyValidator.outranksOnRule(i, incumbent)) {
+				best.put(key, i);
+			}
+		}
+		return best.values();
 	}
 
 	/**
@@ -788,6 +843,12 @@ public class DrugReferenceInjector {
 
 		/** Interaction partners the text does not name — dropped by the budget or, more often, by
 		 *  segment 2 representing the dataset tail with one partner; 0 when it names them all.
+		 *
+		 *  <p>Partners, not rows, since issue #174 site 2: the entry's rules are collapsed to one per
+		 *  partner before anything is rendered, so this counts what the field has always claimed to
+		 *  count. It used to over-report by exactly the surplus — a record naming both of an entry's
+		 *  partners through 4 of its 7 rows declared 3 withheld, a citation claiming to be a strict
+		 *  subset of itself.
 		 *
 		 *  <p>Counted over the rendered ENTRY's own partners, which since issue #163 is one row of a
 		 *  substance rather than every row of it: a partner carried only by a sibling row is ABSENT from

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -1441,13 +1441,13 @@ public class DrugSafetyValidator {
 	 * (the one-directional case below), and that pair is this arm's to report, because the chart arm
 	 * raises nothing for it.
 	 *
-	 * <p>{@link DrugReferenceInjector#orderedInteractionNotes} is deliberately NOT extended to match,
-	 * and its "a partner that raises a chip is exactly a partner promoted here" should be read as scoped
-	 * to the arm it describes: across the whole chip set it no longer holds, since a pair chip's partner
-	 * is promoted nowhere. That sentence lives in a file this change does not touch — rewording it is
-	 * left to whichever PR owns that method next, so two PRs do not collide on it. What is NOT affected
-	 * is the invariant the sentence exists to protect, that a chip and the prose cannot describe the
-	 * same finding differently: since issue #110 the deterministic finding is itself injected as a
+	 * <p>{@link DrugReferenceInjector#orderedInteractionNotes} is deliberately NOT extended to match.
+	 * Its "a partner that raises a chip is exactly a partner promoted here" does not hold across the
+	 * whole chip set, since a pair chip's partner is promoted nowhere; that sentence now says so
+	 * itself, scoped to the drug-in-play arm, which is the rewording this paragraph used to defer to
+	 * whichever PR owned that method next (issue #174 site 2 was it). What is NOT affected is the
+	 * invariant the sentence exists to protect, that a chip and the prose cannot describe the same
+	 * finding differently: since issue #110 the deterministic finding is itself injected as a
 	 * numbered, citable record by {@code preAnswerFindings}, carrying this chip's string verbatim, so a
 	 * pair finding's grounding comes from that record rather than from the promoted notes, and the
 	 * promoted-note budget is untouched.

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -1459,6 +1459,9 @@ public class DrugSafetyValidator {
 		}
 		List<DrugReference> drugs = new ArrayList<DrugReference>(questionDrugs);
 		Map<DrugReference, String> names = pairKeyNames(drugs, severityFloor);
+		// And what the sentence CALLS each side: the substance's canonical row, never the row this
+		// walk reached (issue #174, the fifth site of the same shape — see canonicalSubjects).
+		Map<DrugReference, DrugReference> subjects = canonicalSubjects(drugs);
 		// Group first, decide second. Both the grouping and the chart-precedence verdict belong to the
 		// CLINICAL pair, and route variants make one clinical pair arrive as several entry pairs
 		// carrying different rule sets — the sub-floor sibling of an above-floor row loses that row, so
@@ -1476,7 +1479,7 @@ public class DrugSafetyValidator {
 		for (int i = 0; i < drugs.size() - 1; i++) {
 			for (int j = i + 1; j < drugs.size(); j++) {
 				collectQuestionPairInteraction(candidates, chartOwned, drugs.get(i), drugs.get(j), names,
-						context, severityFloor);
+						subjects, context, severityFloor);
 			}
 		}
 		List<PairFinding> found = new ArrayList<PairFinding>();
@@ -1539,7 +1542,8 @@ public class DrugSafetyValidator {
 	/** One question-named pair: at most one candidate chip, from whichever side carries the rule. */
 	private void collectQuestionPairInteraction(Map<List<String>, PairFinding> candidates,
 			Set<List<String>> chartOwned, DrugReference first, DrugReference second,
-			Map<DrugReference, String> names, PatientClinicalContext context, int severityFloor) {
+			Map<DrugReference, String> names, Map<DrugReference, DrugReference> subjects,
+			PatientClinicalContext context, int severityFloor) {
 		List<DrugReference.Interaction> forward = aboveFloorRulesAgainst(first, second, severityFloor);
 		List<DrugReference.Interaction> reverse = aboveFloorRulesAgainst(second, first, severityFloor);
 		if (forward.isEmpty() && reverse.isEmpty()) {
@@ -1570,8 +1574,14 @@ public class DrugSafetyValidator {
 		// the chip needs; a rule that followed the question's word order would need the drug's offset
 		// in the question, which findByQuery does not report.
 		boolean fromFirst = !forward.isEmpty();
-		DrugReference subject = fromFirst ? first : second;
-		DrugReference partner = fromFirst ? second : first;
+		// The ROW decides which side owns the sentence and which rule it carries; the SUBSTANCE
+		// decides what the sentence calls the two drugs (issue #174). Naming the row asserted a
+		// preparation the question never mentioned — "Lidocaine interacts with Chloroprocaine
+		// (ophthalmic), also named in the question" for a question that said "chloroprocaine" — the
+		// same defect issue #162 fixed on the drug-in-play arm, reached here through the dataset
+		// order the tie-break above deliberately settles on.
+		DrugReference subject = subjects.get(fromFirst ? first : second);
+		DrugReference partner = subjects.get(fromFirst ? second : first);
 		DrugReference.Interaction rule = fromFirst ? forward.get(0) : reverse.get(0);
 		// "named in the question" is what keeps this distinguishable from the active-order chip, and
 		// it is a claim about the QUESTION, so it stays true whatever the chart holds. Wording it as
@@ -1879,8 +1889,8 @@ public class DrugSafetyValidator {
 		// {@code rxnorm_name} and each variant would otherwise be its own subject keying its own pair.
 		Map<DrugReference, String> keyNames = pairKeyNames(orderDrugs, severityFloor);
 		// What each row's chip CALLS its subject: the substance's canonical row, never the row the
-		// loop happens to be on (issue #174 site 3). See screeningSubjects.
-		Map<DrugReference, DrugReference> subjects = screeningSubjects(orderDrugs);
+		// loop happens to be on (issue #174 site 3). See canonicalSubjects.
+		Map<DrugReference, DrugReference> subjects = canonicalSubjects(orderDrugs);
 		for (DrugReference ref : orderDrugs) {
 			// Resolved once per subject, not per rule: the reduction depends only on ref.
 			PatientClinicalContext others = activeOrdersOtherThan(ref, orderDrugs, context);
@@ -1956,33 +1966,41 @@ public class DrugSafetyValidator {
 	}
 
 	/**
-	 * @return for each of {@code orderDrugs}, the row that names the SUBSTANCE it is a row of —
-	 *         {@link #interactionSubject}'s choice over the whole group, so the screening arm calls a
+	 * @return for each of {@code rows}, the row that names the SUBSTANCE it is a row of —
+	 *         {@link #interactionSubject}'s choice over the whole group, so every arm calls a
 	 *         substance what the drug-in-play arm calls it.
 	 *
-	 *         <p><b>Issue #174 site 3.</b> This arm named its subject {@code ref.displayLabel()},
-	 *         i.e. whichever row {@link DrugReferenceService#findForActiveOrders} returned first,
-	 *         while the drug-in-play arm has named the canonical row since issue #162. For a family
-	 *         whose route-unspecified row is not its FIRST row — 7 of the shipped KB's multi-row
-	 *         families — the two arms therefore called one substance two things in one build, which
-	 *         was confirmed live: the same patient's chip read {@code Salicylic acid} for a question
-	 *         naming the drug and {@code Salicylic acid (sodium)} for a screening question.
+	 *         <p><b>Issue #174.</b> Two arms still named a drug by whichever ROW they reached, while
+	 *         the drug-in-play arm has named the canonical row since issue #162:
+	 *         <ul>
+	 *           <li><b>site 3</b>, the screening arm ({@link #addActiveOrderPairInteractions}), whose
+	 *               subject was whichever row {@link DrugReferenceService#findForActiveOrders}
+	 *               returned first. Confirmed live: one patient's chip read {@code Salicylic acid} for
+	 *               a question naming the drug and {@code Salicylic acid (sodium)} for a screening
+	 *               question — two names for one substance in one build;</li>
+	 *           <li>and the question-PAIR arm ({@link #addQuestionPairInteractions}), a FIFTH site the
+	 *               issue does not enumerate, whose two sides were both named by the row the walk
+	 *               reached — settled, as its own javadoc records, by "whichever entry the DATASET
+	 *               lists first".</li>
+	 *         </ul>
+	 *         Both are observable only for the 7 shipped families whose route-unspecified row is not
+	 *         their first, which is why they survived several passes.
 	 *
-	 *         <p>Label-only, and deliberately so. The arm's own unordered pair key already collapses
-	 *         the rows into one chip, and issue #173's {@link InteractionPairs} already suppresses a
-	 *         pair the other arm reported — that ledger is keyed on identity precisely so it did NOT
-	 *         depend on this label being fixed. What is left, and is not fixed here, is which ROW's
-	 *         rule survives for a partner both rows carry: this arm still takes the first row to
-	 *         reach the pair rather than the most severe rule, which is the analogue of issue #115 on
-	 *         this arm and a change to chip CONTENT rather than to a name.
+	 *         <p>Label-only, and deliberately so. Both arms already collapse the rows into one chip on
+	 *         their own unordered pair keys, and issue #173's {@link InteractionPairs} already
+	 *         suppresses a pair another arm reported — that ledger is keyed on identity precisely so
+	 *         it did NOT depend on these labels being fixed. What is left, and is not fixed here, is
+	 *         which ROW's rule survives for a partner several rows carry: both arms take the first row
+	 *         to reach the pair rather than the most severe rule, which is the analogue of issue #115
+	 *         on these arms and a change to chip CONTENT rather than to a name.
 	 *
 	 *         <p>A per-{@code validate} local map, never a field, for the reason issue #172 records:
 	 *         a memoised {@link DrugReference} outliving a {@code getAll()} hot-reload fails the
 	 *         reference comparisons the contraindication arms make against the same objects.
 	 */
-	private static Map<DrugReference, DrugReference> screeningSubjects(List<DrugReference> orderDrugs) {
+	private static Map<DrugReference, DrugReference> canonicalSubjects(List<DrugReference> rows) {
 		Map<DrugReference, DrugReference> out = new LinkedHashMap<DrugReference, DrugReference>();
-		for (Map.Entry<Object, List<DrugReference>> group : substanceRows(orderDrugs).entrySet()) {
+		for (Map.Entry<Object, List<DrugReference>> group : substanceRows(rows).entrySet()) {
 			DrugReference canonical = interactionSubject(group.getValue());
 			for (DrugReference row : group.getValue()) {
 				out.put(row, canonical);
@@ -2567,12 +2585,40 @@ public class DrugSafetyValidator {
 	 */
 	private static final class OrderPartner {
 
-		private final String label;
+		private String label;
+
+		/** Whether {@link #label} came from an ORDER rather than from the dataset — see
+		 *  {@link #nameByOrder}. */
+		private boolean namedByOrder;
 
 		private final Set<String> codes = new LinkedHashSet<String>();
 
-		private OrderPartner(String label) {
+		private OrderPartner(String label, boolean namedByOrder) {
 			this.label = label;
+			this.namedByOrder = namedByOrder;
+		}
+
+		/**
+		 * Re-name this partner after the ORDER, because one of the codes it holds is a code the
+		 * dataset cannot name (issue #186). Monotone — an entry name yields to an order name, never
+		 * the reverse, so the answer does not depend on which of the order's codes the context listed
+		 * first.
+		 *
+		 * <p>Why the order wins there. The dataset names the substance the COVERED codes identify;
+		 * it says nothing about the uncovered one, and the two need not be the same substance. The
+		 * 3.7.1 demo dictionary's {@code Isoniazid / Rifapentine} concept is exactly that: the loaded
+		 * KB covers {@code J04AB05} (rifapentine) and not {@code J04AC51}, and naming the merged
+		 * partner "Rifapentine" produces "…is in the same ATC class (J04AC) as active order
+		 * Rifapentine", a chip whose stated class does not classify the drug it names — the
+		 * right-finding-wrong-reason failure issue #161 fixed on the allergy arm. The order's own
+		 * display name is true of everything the order contains, which is what a partner holding an
+		 * unnameable code needs.
+		 */
+		private void nameByOrder(String orderLabel) {
+			if (!namedByOrder && !ChartSearchAiUtils.isBlank(orderLabel)) {
+				label = orderLabel;
+				namedByOrder = true;
+			}
 		}
 	}
 
@@ -2594,7 +2640,8 @@ public class DrugSafetyValidator {
 	 * different labels ("… as active order Metronidazole" beside "… as active order Metronidazole
 	 * 500mg"). An uncovered code now first asks whether the order carrying it resolves, as a whole,
 	 * to exactly ONE substance, and joins that substance's partner when it does
-	 * ({@link #soleSubstanceOf}).
+	 * ({@link #soleSubstanceOf}) — carrying the ORDER's name onto that partner as it goes, because
+	 * the dataset's name speaks only for the codes it covers (see {@link OrderPartner#nameByOrder}).
 	 *
 	 * <p>Grouping by the order OUTRIGHT would have been wrong in both directions, which is why the
 	 * order is consulted only for the codes the dataset cannot speak for. It would split a substance
@@ -2646,7 +2693,8 @@ public class DrugSafetyValidator {
 		for (String orderCode : context.getActiveDrugAtcCodes()) {
 			DrugReference entry = entryForAtcCode(orderCode, entryByCode);
 			PatientClinicalContext.ActiveDrugOrder order = null;
-			if (entry == null) {
+			boolean unnameableCode = entry == null;
+			if (unnameableCode) {
 				// The dataset cannot name this code. Before falling to the order itself, ask whether
 				// the ORDER carrying it names one substance between all its codes — issue #186.
 				order = orderCarrying(orderCode, context);
@@ -2656,18 +2704,26 @@ public class DrugSafetyValidator {
 			}
 			Object identity;
 			String label;
+			boolean namedByOrder;
 			if (entry != null) {
 				identity = entry.substanceGroupKey();
 				label = entry.displayLabel();
+				namedByOrder = false;
 			} else {
 				identity = order != null ? order : (Object) orderCode;
 				label = order != null
 						? ChartSearchAiUtils.firstNonBlank(order.getDisplay(), orderCode) : orderCode;
+				namedByOrder = order != null;
 			}
 			OrderPartner partner = byIdentity.get(identity);
 			if (partner == null) {
-				partner = new OrderPartner(label);
+				partner = new OrderPartner(label, namedByOrder);
 				byIdentity.put(identity, partner);
+			}
+			if (unnameableCode && order != null) {
+				// This partner holds a code the dataset cannot name, so the dataset's name for its
+				// other codes does not speak for the whole of it — see OrderPartner.nameByOrder.
+				partner.nameByOrder(ChartSearchAiUtils.firstNonBlank(order.getDisplay(), orderCode));
 			}
 			partner.codes.add(orderCode);
 		}

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -2945,7 +2945,7 @@ public class DrugSafetyValidator {
 	 * {@link DrugReference#getSubstanceName()} explicitly permits — reaches it immediately, so it is
 	 * guarded while the pattern is being swept rather than waited for.
 	 *
-	 * <p><b>Every row is still evaluated, and that is the point of the shape.</b> A collapse that
+	 * <p><b>Every row is still tried, and that is the point of the shape.</b> A collapse that
 	 * simply read the canonical row would DROP a warning whenever the band sits on a sibling — the
 	 * one direction a non-blocking advisory must never take. So the rows are tried in
 	 * canonical-first order and the first warning found is the one raised, which also keeps the

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -338,6 +338,14 @@ public class DrugSafetyValidator {
 		Map<Object, List<DrugReference>> interactionSubjects = warnInteractions
 				? substanceRows(inPlay) : Collections.<Object, List<DrugReference>> emptyMap();
 
+		// The same grouping for the DOSE arm (issue #174 site 4), which ran once per row and so
+		// produced one dose warning per row for one stated dose — see addOverdose. Its own map rather
+		// than the one above, because both are consumed by remove() as the loop reaches each group's
+		// first row and one map cannot be drained twice; and gated on its own toggle, so switching
+		// interactions off does not silently switch the dose grouping off with it.
+		Map<Object, List<DrugReference>> doseSubjects = warnDose
+				? substanceRows(inPlay) : Collections.<Object, List<DrugReference>> emptyMap();
+
 		// One ledger of the (substance, partner) pairs an interaction chip has been raised for, spanning
 		// the drug-in-play arm below and the screening arm at the end — see InteractionPairs. Like the
 		// contraindication ledger above it is a per-validate local, and for the same reason: it holds
@@ -362,7 +370,13 @@ public class DrugSafetyValidator {
 				}
 			}
 			if (warnDose) {
-				addOverdose(warnings, ref, context, lower, all);
+				// remove(), for the same reason as the interaction arm above: a substance's rows are
+				// handed to the arm ONCE, at the first of them, so its warning keeps the position that
+				// row's warning has always had and the map itself is the already-done ledger.
+				List<DrugReference> substance = doseSubjects.remove(ref.substanceGroupKey());
+				if (substance != null) {
+					addOverdose(warnings, substance, context, lower, all);
+				}
 			}
 		}
 		// The patient's own prescriptions against their own allergy and condition records — the one
@@ -973,13 +987,13 @@ public class DrugSafetyValidator {
 	 *         active order diclofenac} — asserting an ophthalmic preparation the clinician never named
 	 *         and the chart does not record. Nothing here can know the route (see
 	 *         {@link DrugReference#namesNoRoute()}), so the honest subject is the substance.
+	 *
+	 *         <p>Kept as a named method over the shared fold rather than inlined at its call sites,
+	 *         because "what a chip calls its subject" is the decision issue #162 made and #174 site 3
+	 *         extended to the screening arm — the name is where that decision is looked up.
 	 */
 	private static DrugReference interactionSubject(List<DrugReference> subjects) {
-		DrugReference canonical = null;
-		for (DrugReference subject : subjects) {
-			canonical = DrugReference.canonicalRow(canonical, subject);
-		}
-		return canonical;
+		return DrugReference.canonicalRow(subjects);
 	}
 
 	/**
@@ -1160,17 +1174,19 @@ public class DrugSafetyValidator {
 	 * over an operator-editable file and sanitizes neither case nor padding — nor does the ATC arm,
 	 * which is why the fold is applied to the coalesced value rather than to the token alone.
 	 *
-	 * <p>Not yet the only label site: {@link DrugReferenceInjector#orderedInteractionNotes} still
-	 * coalesces its own, untrimmed (it trims the assembled {@code label (note)} piece, not the label),
-	 * so a padded curated token reaches the citable record as {@code "warfarin   (Major. …)"} beside a
-	 * chip reading {@code "active order warfarin"}. Same partner, different spelling; giving the
-	 * injector this method is the follow-up.
+	 * <p>Shared with {@link DrugReferenceInjector#orderedInteractionNotes} since issue #174, which
+	 * coalesced its own copy untrimmed (it trimmed the assembled {@code label (note)} piece, not the
+	 * label), so a padded curated token reached the citable record as {@code "warfarin   (Major. …)"}
+	 * beside a chip reading {@code "active order warfarin"}. That method now groups its notes by
+	 * partner exactly as {@link #bestRulePerPartner} groups its chips, so the two must agree on what
+	 * the partner is CALLED as well as on which of them is which — one method rather than two
+	 * coalesces, for the same reason the grouping key and the rendered label have to be one string.
 	 *
 	 * @return the label, or null when the rule carries neither — which a rule that matched an active
 	 *         order cannot ({@code hasActiveDrug} needs a non-blank token or a non-blank ATC), so
 	 *         callers inside the matched loop never see it
 	 */
-	private static String partnerLabel(DrugReference.Interaction interaction) {
+	static String partnerLabel(DrugReference.Interaction interaction) {
 		String label = ChartSearchAiUtils.firstNonBlank(interaction.getToken(), interaction.getAtc());
 		return label == null ? null : label.trim();
 	}
@@ -1352,7 +1368,30 @@ public class DrugSafetyValidator {
 		if (candidate.subject.namesNoRoute() != incumbent.subject.namesNoRoute()) {
 			return candidate.subject.namesNoRoute();
 		}
-		return noteLength(candidate.rule) > noteLength(incumbent.rule);
+		// Severity is equal by here, so this falls through to the note-length step.
+		return outranksOnRule(candidate.rule, incumbent.rule);
+	}
+
+	/**
+	 * The rule-side half of {@link #outranks} — most severe, then the longer note — for a collapse
+	 * whose candidates all come from ONE subject row and so cannot differ on the route step between
+	 * them. That is {@link DrugReferenceInjector#orderedInteractionNotes} (issue #174 site 2), which
+	 * collapses one entry's several rows about a partner into the note it renders.
+	 *
+	 * <p>Shared rather than re-derived there, because the record and the chip describe the same pair
+	 * to the same clinician: with two definitions, a record could name the Moderate mechanism beside
+	 * a chip reporting Major — a severity the deterministic layer deliberately discarded, arriving in
+	 * the prompt through the more quotable half. Both rationales for the two steps live on
+	 * {@link #bestRulePerPartner} and {@link #outranks}; nothing about them is restated here.
+	 */
+	static boolean outranksOnRule(DrugReference.Interaction candidate,
+			DrugReference.Interaction incumbent) {
+		int candidateSeverity = severityPriority(candidate.getSeverity());
+		int incumbentSeverity = severityPriority(incumbent.getSeverity());
+		if (candidateSeverity != incumbentSeverity) {
+			return candidateSeverity > incumbentSeverity;
+		}
+		return noteLength(candidate) > noteLength(incumbent);
 	}
 
 	/**
@@ -1839,6 +1878,9 @@ public class DrugSafetyValidator {
 		// in the pair arm, because one order name resolves every route variant sharing an
 		// {@code rxnorm_name} and each variant would otherwise be its own subject keying its own pair.
 		Map<DrugReference, String> keyNames = pairKeyNames(orderDrugs, severityFloor);
+		// What each row's chip CALLS its subject: the substance's canonical row, never the row the
+		// loop happens to be on (issue #174 site 3). See screeningSubjects.
+		Map<DrugReference, DrugReference> subjects = screeningSubjects(orderDrugs);
 		for (DrugReference ref : orderDrugs) {
 			// Resolved once per subject, not per rule: the reduction depends only on ref.
 			PatientClinicalContext others = activeOrdersOtherThan(ref, orderDrugs, context);
@@ -1873,10 +1915,18 @@ public class DrugSafetyValidator {
 				if (reportedPairs.alreadyReported(ref, matched.partnerKey())) {
 					continue;
 				}
-				pairs.add(new ScreenedPair(interactionWarning(ref, i), severityPriority(i.getSeverity()),
-						ref.displayLabel() + " x "
-								+ (partner != null ? partner.displayLabel() : partnerLabel(i)) + " ("
-								+ ChartSearchAiUtils.firstNonBlank(i.getSeverity(), "unrated") + ")"));
+				// The SUBSTANCE, not the row this iteration is on — and the same substance the log
+				// label below names, so a withheld pair is recoverable under the name the chip would
+				// have carried.
+				DrugReference subject = subjects.get(ref);
+				DrugReference partnerSubject = partner != null ? subjects.get(partner) : null;
+				pairs.add(new ScreenedPair(interactionWarning(subject, i),
+						severityPriority(i.getSeverity()),
+						subject.displayLabel() + " x "
+								+ (partnerSubject != null ? partnerSubject.displayLabel()
+										: partnerLabel(i))
+								+ " (" + ChartSearchAiUtils.firstNonBlank(i.getSeverity(), "unrated")
+								+ ")"));
 			}
 		}
 		if (pairs.isEmpty()) {
@@ -1903,6 +1953,42 @@ public class DrugSafetyValidator {
 		for (int n = 0; n < reported; n++) {
 			warnings.add(pairs.get(n).warning);
 		}
+	}
+
+	/**
+	 * @return for each of {@code orderDrugs}, the row that names the SUBSTANCE it is a row of —
+	 *         {@link #interactionSubject}'s choice over the whole group, so the screening arm calls a
+	 *         substance what the drug-in-play arm calls it.
+	 *
+	 *         <p><b>Issue #174 site 3.</b> This arm named its subject {@code ref.displayLabel()},
+	 *         i.e. whichever row {@link DrugReferenceService#findForActiveOrders} returned first,
+	 *         while the drug-in-play arm has named the canonical row since issue #162. For a family
+	 *         whose route-unspecified row is not its FIRST row — 7 of the shipped KB's multi-row
+	 *         families — the two arms therefore called one substance two things in one build, which
+	 *         was confirmed live: the same patient's chip read {@code Salicylic acid} for a question
+	 *         naming the drug and {@code Salicylic acid (sodium)} for a screening question.
+	 *
+	 *         <p>Label-only, and deliberately so. The arm's own unordered pair key already collapses
+	 *         the rows into one chip, and issue #173's {@link InteractionPairs} already suppresses a
+	 *         pair the other arm reported — that ledger is keyed on identity precisely so it did NOT
+	 *         depend on this label being fixed. What is left, and is not fixed here, is which ROW's
+	 *         rule survives for a partner both rows carry: this arm still takes the first row to
+	 *         reach the pair rather than the most severe rule, which is the analogue of issue #115 on
+	 *         this arm and a change to chip CONTENT rather than to a name.
+	 *
+	 *         <p>A per-{@code validate} local map, never a field, for the reason issue #172 records:
+	 *         a memoised {@link DrugReference} outliving a {@code getAll()} hot-reload fails the
+	 *         reference comparisons the contraindication arms make against the same objects.
+	 */
+	private static Map<DrugReference, DrugReference> screeningSubjects(List<DrugReference> orderDrugs) {
+		Map<DrugReference, DrugReference> out = new LinkedHashMap<DrugReference, DrugReference>();
+		for (Map.Entry<Object, List<DrugReference>> group : substanceRows(orderDrugs).entrySet()) {
+			DrugReference canonical = interactionSubject(group.getValue());
+			for (DrugReference row : group.getValue()) {
+				out.put(row, canonical);
+			}
+		}
+		return out;
 	}
 
 	/**
@@ -2501,15 +2587,33 @@ public class DrugSafetyValidator {
 	 * partner rather than one per code; else the code itself, which is all a context carrying only the
 	 * flattened set (issue #118's fallback) offers.
 	 *
-	 * <p><b>Where the ladder does not hold its promise</b>, stated rather than left to be rediscovered:
-	 * "one partner rather than one per code" holds for an order the dataset covers wholly or not at all.
-	 * An order it covers only PARTLY climbs two different rungs — the covered codes key on the entry,
-	 * the uncovered ones on the order — and becomes two partners, which is one chip too many. Whether
-	 * any deployment's concept dictionary and loaded dataset actually disagree that way is not measured;
-	 * closing it means grouping by ORDER first and resolving the entry from the group, which is a
-	 * behaviour change with its own measurement, not a comment. Same root for the builder's KNOWN GAP: a
-	 * nameless order reaches {@link PatientClinicalContext#getActiveDrugAtcCodes()} without reaching
-	 * {@code getActiveDrugOrders()}, so every rung fails and each of its codes is its own partner.
+	 * <p><b>The rung issue #186 added, and why it is not simply "group by order".</b> The ladder used
+	 * to be applied per code with nothing consulting the ORDER until the entry rung had already
+	 * failed, so an order the dataset covers only PARTLY climbed two different rungs — the covered
+	 * codes onto the entry, the uncovered ones onto the order — and became two partners under two
+	 * different labels ("… as active order Metronidazole" beside "… as active order Metronidazole
+	 * 500mg"). An uncovered code now first asks whether the order carrying it resolves, as a whole,
+	 * to exactly ONE substance, and joins that substance's partner when it does
+	 * ({@link #soleSubstanceOf}).
+	 *
+	 * <p>Grouping by the order OUTRIGHT would have been wrong in both directions, which is why the
+	 * order is consulted only for the codes the dataset cannot speak for. It would split a substance
+	 * the patient holds TWO orders of into two partners, which this ladder deliberately merges; and
+	 * it would merge a fixed-dose COMBINATION — one order whose concept maps to the codes of two
+	 * different substances — into one, dropping a real duplicate-therapy chip. A combination is
+	 * exactly the case {@link #soleSubstanceOf} answers null for, so its uncovered codes stay on the
+	 * order rung: with two substances in one tablet there is no evidence which of them an uncovered
+	 * code belongs to, and the order is the honest answer.
+	 *
+	 * <p><b>Where the ladder still does not hold its promise.</b> The builder's KNOWN GAP: a nameless
+	 * order reaches {@link PatientClinicalContext#getActiveDrugAtcCodes()} without reaching
+	 * {@code getActiveDrugOrders()}, so {@link #orderCarrying} finds nothing, the new rung cannot
+	 * fire either, and each of its uncovered codes is its own partner. Nothing here can close that —
+	 * with no order identity there is nothing to group BY, and grouping every unclaimed code together
+	 * would merge two genuinely different orders (and, on the flattened fallback of issue #118, merge
+	 * the whole medication list into one partner). Closing it means giving such an order a fallback
+	 * display in {@link PatientClinicalContextBuilder} so it reaches the list at all, which is that
+	 * gap's own fix and has its own consequences for the injected record.
 	 *
 	 * <p><b>The label follows the same ladder</b> (issue #155). It used to be the entry's label or,
 	 * failing that, the bare CODE — so on the default {@code sourceFormat=json}, whose four-entry
@@ -2531,15 +2635,31 @@ public class DrugSafetyValidator {
 	 */
 	private List<OrderPartner> orderPartners(PatientClinicalContext context) {
 		Map<Object, OrderPartner> byIdentity = new LinkedHashMap<Object, OrderPartner>();
+		// Per-CALL memos, never fields: entryForAtcCode is a full scan of getAll() and the rung added
+		// by issue #186 asks it once per code of an order as well as once per code of the context, so
+		// without them a partly-covered order rescans the dataset for every code it carries. A field
+		// would be issue #172's trap — a memoised DrugReference outliving a getAll() hot-reload fails
+		// the reference comparisons the contraindication arms make, silently re-opening issue #145.
+		Map<String, DrugReference> entryByCode = new LinkedHashMap<String, DrugReference>();
+		Map<PatientClinicalContext.ActiveDrugOrder, DrugReference> substanceByOrder =
+				new LinkedHashMap<PatientClinicalContext.ActiveDrugOrder, DrugReference>();
 		for (String orderCode : context.getActiveDrugAtcCodes()) {
-			DrugReference entry = entryForAtcCode(orderCode);
+			DrugReference entry = entryForAtcCode(orderCode, entryByCode);
+			PatientClinicalContext.ActiveDrugOrder order = null;
+			if (entry == null) {
+				// The dataset cannot name this code. Before falling to the order itself, ask whether
+				// the ORDER carrying it names one substance between all its codes — issue #186.
+				order = orderCarrying(orderCode, context);
+				if (order != null) {
+					entry = soleSubstanceOf(order, entryByCode, substanceByOrder);
+				}
+			}
 			Object identity;
 			String label;
 			if (entry != null) {
 				identity = entry.substanceGroupKey();
 				label = entry.displayLabel();
 			} else {
-				PatientClinicalContext.ActiveDrugOrder order = orderCarrying(orderCode, context);
 				identity = order != null ? order : (Object) orderCode;
 				label = order != null
 						? ChartSearchAiUtils.firstNonBlank(order.getDisplay(), orderCode) : orderCode;
@@ -2552,6 +2672,61 @@ public class DrugSafetyValidator {
 			partner.codes.add(orderCode);
 		}
 		return new ArrayList<OrderPartner>(byIdentity.values());
+	}
+
+	/**
+	 * @return the one substance {@code order}'s ATC codes resolve to between them, as the row that
+	 *         names it ({@link DrugReference#canonicalRow}), or null when they resolve to none or to
+	 *         MORE than one.
+	 *
+	 *         <p>Null for a combination is the load-bearing half (issue #186): one order mapped to
+	 *         two substances' codes is two co-medications, and answering with either of them would
+	 *         attach an uncovered code to a substance nothing says it belongs to — and, worse, could
+	 *         merge the two into one partner and drop a duplicate-therapy chip. Null for "resolves to
+	 *         none" leaves the ladder exactly where it was: the order itself is the identity.
+	 *
+	 *         <p>Memoised per {@code validate} pass through {@code cache}, because
+	 *         {@link #classRelationships} calls {@link #orderPartners} once per in-play substance and
+	 *         this walks every code of an order — see there for why the memo may not be a field.
+	 */
+	private DrugReference soleSubstanceOf(PatientClinicalContext.ActiveDrugOrder order,
+			Map<String, DrugReference> entryByCode,
+			Map<PatientClinicalContext.ActiveDrugOrder, DrugReference> cache) {
+		if (cache.containsKey(order)) {
+			return cache.get(order);
+		}
+		Object substance = null;
+		DrugReference canonical = null;
+		for (String code : order.getAtcCodes()) {
+			DrugReference entry = entryForAtcCode(code, entryByCode);
+			if (entry == null) {
+				continue;
+			}
+			Object key = entry.substanceGroupKey();
+			if (substance != null && !substance.equals(key)) {
+				// A second substance: this order is a combination, and no uncovered code of it can be
+				// attributed to either half.
+				canonical = null;
+				break;
+			}
+			substance = key;
+			canonical = DrugReference.canonicalRow(canonical, entry);
+		}
+		cache.put(order, canonical);
+		return canonical;
+	}
+
+	/** {@link #entryForAtcCode} memoised for one {@code orderPartners} call. {@code null} is a real
+	 *  answer ("the dataset does not cover this code") and is cached as one, so an uncovered code
+	 *  does not rescan the dataset on every visit — hence {@code containsKey} rather than a null
+	 *  check. */
+	private DrugReference entryForAtcCode(String upperCode, Map<String, DrugReference> cache) {
+		if (cache.containsKey(upperCode)) {
+			return cache.get(upperCode);
+		}
+		DrugReference entry = entryForAtcCode(upperCode);
+		cache.put(upperCode, entry);
+		return entry;
 	}
 
 	/**
@@ -2699,48 +2874,97 @@ public class DrugSafetyValidator {
 		return canonical;
 	}
 
-	private void addOverdose(List<SafetyWarning> warnings, DrugReference ref,
+	/**
+	 * At most ONE dose warning for the substance {@code subjects} are the reference rows of, named
+	 * after the row that names the substance.
+	 *
+	 * <p><b>Issue #174 site 4 — the fourth per-row site, and the one that was latent.</b> This ran
+	 * once per row of {@code inPlay}, so a substance filed as several rows produced one dose warning
+	 * per row for a single stated dose, each named after its own row — and, since issue #110, one
+	 * near-identical citable safety-finding record per warning in the prompt as well. No bundled
+	 * dataset can reach it: a warning needs {@code ageBands}, which only the curated {@code json}
+	 * schema carries, and the grouping needs a {@code substanceName}, which the shipped curated seed
+	 * does not set. An operator authoring a file with both — which
+	 * {@link DrugReference#getSubstanceName()} explicitly permits — reaches it immediately, so it is
+	 * guarded while the pattern is being swept rather than waited for.
+	 *
+	 * <p><b>Every row is still evaluated, and that is the point of the shape.</b> A collapse that
+	 * simply read the canonical row would DROP a warning whenever the band sits on a sibling — the
+	 * one direction a non-blocking advisory must never take. So the rows are tried in
+	 * canonical-first order and the first warning found is the one raised, which also keeps the
+	 * quoted band the substance's own wherever it publishes one. What the collapse gives up is the
+	 * ability to report two different published ceilings for one substance, which is not a thing a
+	 * clinician can act on: nothing here knows which formulation is in play (see
+	 * {@link DrugReference#namesNoRoute()}), so a second ceiling is a second guess, not a second
+	 * fact.
+	 */
+	private void addOverdose(List<SafetyWarning> warnings, List<DrugReference> subjects,
+			PatientClinicalContext context, String lowerAnswer, List<DrugReference> allEntries) {
+		DrugReference subject = interactionSubject(subjects);
+		if (addOverdose(warnings, subject, subject, context, lowerAnswer, allEntries)) {
+			return;
+		}
+		for (DrugReference row : subjects) {
+			if (row != subject && addOverdose(warnings, subject, row, context, lowerAnswer, allEntries)) {
+				return;
+			}
+		}
+	}
+
+	/**
+	 * The dose check for ONE reference row, reported under {@code subject}'s name.
+	 *
+	 * @param subject the row the warning NAMES — the substance's canonical row, so a chip never
+	 *        asserts a formulation the chart does not record (the same judgement
+	 *        {@link #interactionSubject} makes for the interaction chips)
+	 * @param ref the row whose published {@code ageBands} and aliases the check READS
+	 * @return whether a warning was raised, so the caller can stop at the first row that trips
+	 */
+	private boolean addOverdose(List<SafetyWarning> warnings, DrugReference subject, DrugReference ref,
 			PatientClinicalContext context, String lowerAnswer, List<DrugReference> allEntries) {
 		Integer age = context != null ? context.getAgeYears() : null;
 		DrugReference.AgeBand band = ref.bandForAge(age);
 		if (band == null) {
-			return;
+			return false;
 		}
 		Double weightKg = context != null ? context.getWeightKg() : null;
 		boolean dailyArm = band.getMaxDailyDoseMg() > 0;
 		boolean weightArm = weightKg != null && weightKg > 0 && band.getMgPerKgMax() > 0;
 		if (!dailyArm && !weightArm) {
-			return;
+			return false;
 		}
 		// One attribution walk feeds whichever arms apply.
 		List<AttributedDose> doses = attributedDoses(lowerAnswer, ref, allEntries);
+		String label = subject.displayLabel();
 		if (dailyArm) {
 			Double dailyMg = parseDailyDoseMg(doses);
 			if (dailyMg != null && dailyMg > band.getMaxDailyDoseMg()) {
-				warnings.add(new SafetyWarning(SafetyWarning.TYPE_OVERDOSE, ref.displayLabel(),
-						"The stated " + ref.displayLabel() + " dose ~" + DrugReference.formatNumber(dailyMg)
+				warnings.add(new SafetyWarning(SafetyWarning.TYPE_OVERDOSE, label,
+						"The stated " + label + " dose ~" + DrugReference.formatNumber(dailyMg)
 								+ " mg/day exceeds the "
 								+ DrugReference.formatNumber(band.getMaxDailyDoseMg()) + " mg/day maximum for ages "
 								+ band.getMinYears() + "-" + band.getMaxYears()));
 				// One warning per drug: the published daily ceiling is the stronger statement,
 				// so the per-dose arm below is not stacked on top of it.
-				return;
+				return true;
 			}
 		}
 		if (!weightArm) {
-			return;
+			return false;
 		}
 		Double perDoseMg = parseMaxPerDoseMg(doses);
 		double perDoseLimitMg = band.getMgPerKgMax() * weightKg;
 		if (perDoseMg != null && perDoseMg > perDoseLimitMg) {
-			warnings.add(new SafetyWarning(SafetyWarning.TYPE_OVERDOSE, ref.displayLabel(),
-					"The stated " + ref.displayLabel() + " dose ~" + DrugReference.formatNumber(perDoseMg)
+			warnings.add(new SafetyWarning(SafetyWarning.TYPE_OVERDOSE, label,
+					"The stated " + label + " dose ~" + DrugReference.formatNumber(perDoseMg)
 							+ " mg exceeds the "
 							+ DrugReference.formatNumber(band.getMgPerKgMax()) + " mg/kg per-dose maximum (~"
 							+ DrugReference.formatNumber(perDoseLimitMg) + " mg) for the patient's weight "
 							+ DrugReference.formatNumber(weightKg) + " kg (ages " + band.getMinYears() + "-"
 							+ band.getMaxYears() + ")"));
+			return true;
 		}
+		return false;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -2675,10 +2675,11 @@ public class DrugSafetyValidator {
 	 * substance and calls this each time, and {@link #ruleAbout} re-runs {@link #entryForAtcCode}
 	 * itself rather than reading the resolution carried here. They agree because that scan is a
 	 * function of {@code getAll()} alone, which is loaded once — a property of the service, not
-	 * something this method enforces. A per-{@code validate} memo would make it enforced and would cut
-	 * the repeated full scans, but it must then be a local threaded through the pass and NEVER a field:
-	 * a memoised {@link DrugReference} outliving a {@code getAll()} reload fails the reference
-	 * comparisons the contraindication arms make (issue #172), which silently re-opens issue #145.
+	 * something this method enforces. The memo below is per CALL and does not change that; widening it
+	 * to the whole {@code validate} pass would, and would cut the repeated full scans, but it must
+	 * then be a local threaded through the pass and NEVER a field: a memoised {@link DrugReference}
+	 * outliving a {@code getAll()} reload fails the reference comparisons the contraindication arms
+	 * make (issue #172), which silently re-opens issue #145.
 	 */
 	private List<OrderPartner> orderPartners(PatientClinicalContext context) {
 		Map<Object, OrderPartner> byIdentity = new LinkedHashMap<Object, OrderPartner>();
@@ -2741,9 +2742,9 @@ public class DrugSafetyValidator {
 	 *         merge the two into one partner and drop a duplicate-therapy chip. Null for "resolves to
 	 *         none" leaves the ladder exactly where it was: the order itself is the identity.
 	 *
-	 *         <p>Memoised per {@code validate} pass through {@code cache}, because
-	 *         {@link #classRelationships} calls {@link #orderPartners} once per in-play substance and
-	 *         this walks every code of an order — see there for why the memo may not be a field.
+	 *         <p>Memoised through {@code cache} for the duration of one {@link #orderPartners} call,
+	 *         because this walks every code of an order and every code of that order asks it — see
+	 *         there for why the memo may not be a field.
 	 */
 	private DrugReference soleSubstanceOf(PatientClinicalContext.ActiveDrugOrder order,
 			Map<String, DrugReference> entryByCode,

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
@@ -197,6 +197,57 @@ public class InjectedInteractionNoteCollapseTest {
 						+ record.getText());
 	}
 
+	/**
+	 * The operator-editable curated source, which is the only one that can pose the label questions:
+	 * plain Jackson over a hand-authored file, so a rule token keeps whatever case and padding it was
+	 * written with. Shared with {@code InteractionPartnerGroupingTest}, which asks the same questions
+	 * of the CHIPS.
+	 */
+	private static final String CURATED_FIXTURE =
+			"chartsearchai-test/drug-reference-partner-label-variants.json";
+
+	private static RecordMapping curatedRecord(String question, PatientClinicalContext context)
+			throws Exception {
+		PatientChart chart = DrugReferenceTestSupport
+				.injector(DrugReferenceTestSupport
+						.serviceWith(DrugReferenceTestSupport.fixtureEntries(CURATED_FIXTURE)))
+				.injectRecords(DrugReferenceTestSupport.oneRecordChart(), context, question);
+		return DrugReferenceTestSupport.injectedReferences(chart).get(0);
+	}
+
+	@Test
+	public void twoCuratedRowsForOnePartnerRenderOnce() throws Exception {
+		// The chip side of this has been one chip since issue #115 — hasActiveDrug folds case and
+		// padding, so "Warfarin" and "  warfarin  " are one partner to the only predicate that decides
+		// an interaction concerns this patient. The record listed both, at two severities, and printed
+		// the padding: "warfarin   (Major. …)" beside a chip reading "active order warfarin".
+		RecordMapping record = curatedRecord("is it safe to give fluconazole?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Warfarin 5mg"), null, null, null));
+		String interactions = interactionsOf(record);
+
+		assertEquals(1, notesHeadedBy(interactions, "warfarin"),
+				"one partner is one note however the operator spelled the token: " + interactions);
+		assertTrue(interactions.contains("warfarin (major."),
+				"the label must be trimmed and the surviving row the Major one — the same row the chip "
+						+ "reports: " + interactions);
+	}
+
+	@Test
+	public void twoCuratedRowsIdentifyingOnePartnerByAtcAlsoRenderOnce() throws Exception {
+		// The other half of the label, which no shipped dataset exercises: a rule carrying an ATC code
+		// and no token at all. The fixture writes the same code as " b01aa03 " and "B01AA03".
+		RecordMapping record = curatedRecord("is it safe to give rivaroxaban?",
+				DrugReferenceTestSupport.ctx(60, null, null, null, null, null));
+		String interactions = interactionsOf(record);
+
+		assertEquals(1, notesHeadedBy(interactions, "b01aa03"),
+				"one ATC-identified partner is one note whatever case and padding it carries: "
+						+ interactions);
+		assertTrue(interactions.contains("b01aa03 (major."),
+				"and the surviving row is the Major one: " + interactions);
+	}
+
 	@Test
 	public void aSinglePartnerRecordIsUnchanged() throws Exception {
 		// The control. Nothing may move for an entry whose partners are each filed once: the

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
@@ -1,0 +1,232 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.PatientChart;
+import org.openmrs.module.chartsearchai.serializer.PatientChartSerializer.RecordMapping;
+
+/**
+ * Issue #174 site 2 — {@code DrugReferenceInjector.orderedInteractionNotes} emitted one note per
+ * partner ROW, so one injected record named the same partner several times.
+ *
+ * <p><b>The measurement.</b> Over the shipped 19 MB KB (2283 entries, 590,312 expanded interaction
+ * rows after the issue #152 self-pair guard drops 28): 1876 entries carry at least one repeated
+ * partner and 19,316 rows are surplus, {@code Ozanimod} carrying the largest single surplus at 49
+ * (measured 2026-08-07 against the standalone's {@code ddi_knowledge_base.json}; re-measure before
+ * relying on the figures). It is invisible from the REST response, which returns only CITED
+ * references — the same reason issue #163's equivalent had to be measured off the injected slice
+ * rather than off the wire.
+ *
+ * <p><b>Why it is not merely untidy.</b> Segment 1 of {@code render} deliberately overrides the
+ * character budget so a partner the patient is actually on is never invisible, so a partner filed
+ * under three rows spends three notes of budget that the budget cannot claw back — near-duplicate
+ * text crowding out the chart records the answer needs (issues #95, #99), and several
+ * differently-worded copies of one fact handed to a model that miscopies them (#142). It also put a
+ * severity in the prompt that the chip deliberately discarded: {@code DrugSafetyValidator}'s
+ * {@code bestRulePerPartner} has collapsed several rules naming one partner into a single
+ * most-severe chip since issue #115, while this path still listed all of them.
+ *
+ * <p>Every scenario runs the REAL production path: verbatim DDInter KB slices parsed by the real
+ * {@link DdiDrugReferenceSource}, the real {@code injectRecords} entry point, GP reads on their
+ * no-context defaults (severity floor {@code minor}).
+ */
+public class InjectedInteractionNoteCollapseTest {
+
+	/**
+	 * The verbatim KB slice whose Voxelotor entry carries SEVEN interaction rows naming FOUR
+	 * partners: three rows against the dexamethasone family (Major, Moderate, Moderate — the
+	 * measured case {@code orderedInteractionNotes} names in its own javadoc), two against the
+	 * sirolimus family (Major, Moderate), one lapatinib and one phenytoin. Both multi-row families
+	 * publish one {@code rxnorm_name} across their rows, which is the match token a rule carries and
+	 * the label a note prints, so the rows are indistinguishable in the rendered record.
+	 */
+	private static final String FIXTURE = DrugReferenceTestSupport.DDI_ROUTE_VARIANTS;
+
+	private static DrugReferenceInjector injector() throws Exception {
+		return DrugReferenceTestSupport.injector(DrugReferenceTestSupport.ddiFixtureService(FIXTURE));
+	}
+
+	/** The record the real injector emits for the drug the question names. */
+	private static RecordMapping injectedRecord(String question, PatientClinicalContext context)
+			throws Exception {
+		PatientChart chart = injector().injectRecords(DrugReferenceTestSupport.oneRecordChart(),
+				context, question);
+		List<RecordMapping> references = DrugReferenceTestSupport.injectedReferences(chart);
+		assertEquals(1, references.size(),
+				"precondition: exactly one reference record must be injected, was: " + chart.getText());
+		return references.get(0);
+	}
+
+	/** The lowercased {@code Interactions:} section of a rendered record. */
+	private static String interactionsOf(RecordMapping record) {
+		String text = record.getText();
+		int start = text.indexOf("Interactions:");
+		assertTrue(start >= 0, "precondition: the record must render an Interactions section: " + text);
+		return text.substring(start).toLowerCase(Locale.ROOT);
+	}
+
+	/**
+	 * How many NOTES in {@code section} are headed by {@code partner} — occurrences of the label
+	 * followed by the rendering's own {@code " ("}, not of the bare name, because a mechanism
+	 * paragraph legitimately mentions the drugs it is about ("…exposure to sirolimus, which is
+	 * primarily metabolized…") and counting those would make this assert something else.
+	 */
+	private static int notesHeadedBy(String section, String partner) {
+		String needle = partner + " (";
+		int count = 0;
+		for (int at = section.indexOf(needle); at >= 0; at = section.indexOf(needle, at + 1)) {
+			count++;
+		}
+		return count;
+	}
+
+	@Test
+	public void aPartnerFiledAsSeveralRowsIsNamedOnceInTheInjectedRecord() throws Exception {
+		// The patient is on dexamethasone, so all three of Voxelotor's dexamethasone rows are promoted
+		// into segment 1 — the segment that overrides the character budget. Before this fix the record
+		// read "dexamethasone (Major. …); dexamethasone (Moderate. …); dexamethasone (Moderate. …)"
+		// beside a single Major chip.
+		RecordMapping record = injectedRecord("is it safe to give voxelotor?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Dexamethasone 4mg"), null, null, null));
+		String interactions = interactionsOf(record);
+
+		assertEquals(1, notesHeadedBy(interactions, "dexamethasone"),
+				"one substance is one partner, however many rows the KB files it as: " + interactions);
+	}
+
+	@Test
+	public void theSurvivingNoteIsTheOneTheChipReports() throws Exception {
+		// Which row survives is not a free choice: the chip for this pair is the MAJOR one
+		// (DrugSafetyValidator.bestRulePerPartner, most severe wins), so a record naming the Moderate
+		// mechanism beside it would put a severity in the prompt that the deterministic layer
+		// deliberately discarded — the chip-versus-prose divergence this module keeps removing.
+		//
+		// The two mechanism texts are distinguishable: the Major row (mechanism group 3595) opens
+		// "Coadministration with potent or moderate inducers of CYP450 3A4", the two Moderate rows
+		// (group 3270) open "Coadministration with inhibitors of CYP450 3A4".
+		RecordMapping record = injectedRecord("is it safe to give voxelotor?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Dexamethasone 4mg"), null, null, null));
+		String interactions = interactionsOf(record);
+
+		assertTrue(interactions.contains("dexamethasone (major."),
+				"the promoted note must carry the severity the chip reports: " + interactions);
+		assertFalse(interactions.contains("dexamethasone (moderate"),
+				"and must not also carry the severity the chip discarded: " + interactions);
+	}
+
+	@Test
+	public void theDatasetTailNamesEachPartnerOnceToo() throws Exception {
+		// The same collapse with NOTHING promoted — the common shape, since most patients are on none
+		// of an entry's partners. Segment 2 then spends the whole budget on full notes in dataset
+		// order, so a repeated partner is a repeated paragraph: Voxelotor's two sirolimus rows
+		// (Major and Moderate) are two separate mechanism paragraphs about one co-medication.
+		RecordMapping record = injectedRecord("is it safe to give voxelotor?",
+				DrugReferenceTestSupport.ctx(60, null, null, null, null, null));
+		String interactions = interactionsOf(record);
+
+		assertEquals(1, notesHeadedBy(interactions, "sirolimus"),
+				"the dataset tail must name each partner once as well: " + interactions);
+		assertEquals(1, notesHeadedBy(interactions, "dexamethasone"),
+				"including the family the patient is not on: " + interactions);
+	}
+
+	@Test
+	public void theWithheldCountIsPartnersNotRows() throws Exception {
+		// RenderedReference.withheldInteractions is documented as "interaction partners the text does
+		// not name", and a client renders it beside the citation chip as honest truncation. Counted
+		// over ROWS it did not describe that: Voxelotor's 7 rows name 4 partners, and with
+		// dexamethasone promoted the record named 2 of them (dexamethasone and the tail
+		// representative lapatinib) while declaring 3 withheld — one more than the 2 partners
+		// (phenytoin, sirolimus) it actually leaves out.
+		//
+		// Asserted against the section itself rather than against a literal, so the invariant is
+		// "the count equals what is missing" rather than a number that has to be re-derived whenever
+		// the budget or the fixture moves.
+		RecordMapping record = injectedRecord("is it safe to give voxelotor?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Dexamethasone 4mg"), null, null, null));
+		String interactions = interactionsOf(record);
+
+		int unnamed = 0;
+		for (String partner : new String[] { "dexamethasone", "lapatinib", "phenytoin", "sirolimus" }) {
+			if (notesHeadedBy(interactions, partner) == 0) {
+				unnamed++;
+			}
+		}
+		assertEquals(2, unnamed,
+				"precondition: this record must leave exactly two of the four partners unnamed: "
+						+ interactions);
+		assertEquals(unnamed, record.getWithheldInteractions(),
+				"the withheld count must be the partners the text does not name, not the rows: "
+						+ interactions);
+	}
+
+	@Test
+	public void collapsingTheRowsShortensTheRecordTheModelReads() throws Exception {
+		// The prompt-budget claim, measured on this slice rather than asserted in prose. Segment 1
+		// overrides MAX_INTERACTION_RENDER_CHARS for every promoted partner, so the two surplus
+		// dexamethasone rows were 703 characters of near-duplicate text that the budget could not
+		// claw back — a 649-character Moderate mechanism paragraph plus a compact repeat. Measured
+		// 2026-08-07 through this test: the record was 1124 characters and is now 421.
+		//
+		// Pinned as an exact length rather than an inequality because the number IS the finding — an
+		// inequality would still pass if the collapse kept one of the two surplus rows.
+		RecordMapping record = injectedRecord("is it safe to give voxelotor?",
+				DrugReferenceTestSupport.ctx(60, null,
+						DrugReferenceTestSupport.set("Dexamethasone 4mg"), null, null, null));
+
+		assertEquals(421, record.getText().length(),
+				"the injected record's character cost must fall to the collapsed rendering: "
+						+ record.getText());
+	}
+
+	@Test
+	public void aSinglePartnerRecordIsUnchanged() throws Exception {
+		// The control. Nothing may move for an entry whose partners are each filed once: the
+		// bundled DDInter sample's Lisinopril carries 15 partners and no repeats, so its record must
+		// render byte-for-byte as it did before the collapse. Pinned as the exact string rather than
+		// a length, because a collapse keyed wrongly (on the note, say, or on the severity) would
+		// change WHICH partner survives while leaving the length alone.
+		PatientChart chart = DrugReferenceTestSupport.injector(DrugReferenceTestSupport.ddinterService())
+				.injectRecords(DrugReferenceTestSupport.oneRecordChart(),
+						DrugReferenceTestSupport.ctx(60, null,
+								DrugReferenceTestSupport.set("ibuprofen"), null, null, null),
+						"is it safe to give lisinopril?");
+		RecordMapping record = DrugReferenceTestSupport.injectedReferences(chart).get(0);
+
+		assertEquals("Drug reference — Lisinopril (ATC C09AA03). Interactions: ibuprofen (Moderate. "
+				+ "Nonsteroidal anti-inflammatory drugs (NSAIDs) may attenuate the antihypertensive "
+				+ "effects of ACE inhibitors. The proposed mechanism is NSAID-induced inhibition of "
+				+ "renal prostaglandin synthesis, which results in unopposed pressor activity "
+				+ "producing hypertension. In addition, NSAIDs can cause fluid retention, which also "
+				+ "affects blood pressure. Concomitant use of NSAIDs and ACE inhibitors may also "
+				+ "cause deterioration in renal function, particularly in patients who are elderly "
+				+ "or volume-depleted (including those on diuretic therapy) or have compromised "
+				+ "renal function. Acute renal failure may occur, although effects are usually "
+				+ "reversible. Chronic use of NSAIDs alone may be associated with renal toxicities, "
+				+ "including elevations in serum creatinine and BUN, tubular necrosis, glomerulitis, "
+				+ "renal papillary necrosis, acute interstitial nephritis, nephrotic syndrome, and "
+				+ "renal failure.); metformin (Moderate).",
+				record.getText(),
+				"a single-partner entry's record must be byte-identical: " + record.getText());
+		assertEquals(13, record.getWithheldInteractions(),
+				"and its withheld count must not move either: " + record.getText());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
@@ -183,7 +183,7 @@ public class InjectedInteractionNoteCollapseTest {
 		// The prompt-budget claim, measured on this slice rather than asserted in prose. Segment 1
 		// overrides MAX_INTERACTION_RENDER_CHARS for every promoted partner, so the two surplus
 		// dexamethasone rows were 703 characters of near-duplicate text that the budget could not
-		// claw back — a 649-character Moderate mechanism paragraph plus a compact repeat. Measured
+		// claw back — a 659-character Moderate mechanism paragraph plus a compact repeat. Measured
 		// 2026-08-07 through this test: the record was 1124 characters and is now 421.
 		//
 		// Pinned as an exact length rather than an inequality because the number IS the finding — an

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/InjectedInteractionNoteCollapseTest.java
@@ -248,6 +248,61 @@ public class InjectedInteractionNoteCollapseTest {
 				"and the surviving row is the Major one: " + interactions);
 	}
 
+	/**
+	 * A curated entry filing ONE partner as two rows carrying the same token and DIFFERENT ATC codes
+	 * — the only shape in which two rows of one partner group answer
+	 * {@link PatientClinicalContext#hasActiveDrug} differently. See the fixture's own description.
+	 */
+	private static final String ATC_SPLIT_FIXTURE =
+			"chartsearchai-test/drug-reference-partner-atc-split-rows.json";
+
+	/** On acenocoumarol ({@code B01AA07}) by ATC alone, so the rules' TOKEN arm matches neither row
+	 *  and only the {@code B01AA07} row is the patient's. */
+	private static PatientClinicalContext onAcenocoumarolByAtc() {
+		return DrugReferenceTestSupport.ctx(60, null, null, DrugReferenceTestSupport.set("B01AA07"),
+				null, null);
+	}
+
+	@Test
+	public void thePartnerTheChipWarnsAboutSurvivesTheCollapse() throws Exception {
+		// The collapse runs BEFORE the promotion predicate, so the survivor rule decides which row's
+		// (token, ATC) pair that predicate is then asked about. Where two rows of one partner carry
+		// DIFFERENT ATC codes those answers differ, and the most severe row can be the one the
+		// patient does not match — so the partner loses its place in segment 1, which is the segment
+		// that overrides MAX_INTERACTION_RENDER_CHARS. With another partner promoted, segment 2
+		// renders exactly ONE representative, so the de-promoted partner does not merely change
+		// wording: it leaves the record while the chip still warns about it.
+		//
+		// bestRulePerPartner cannot reach this shape because it filters on hasActiveDrug BEFORE
+		// grouping, so only rows the patient matches are ever candidates. This asserts the collapse
+		// makes the same choice.
+		List<DrugReference> entries = DrugReferenceTestSupport.fixtureEntries(ATC_SPLIT_FIXTURE);
+		PatientClinicalContext context = onAcenocoumarolByAtc();
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport
+				.validator(DrugReferenceTestSupport.serviceWith(entries))
+				.validate("", "is it safe to give voriconazole?", context);
+		assertEquals(1, warnings.size(),
+				"precondition: exactly one chip, for the partner the patient IS on, was: " + warnings);
+		assertTrue(warnings.get(0).getDetail().contains("active order warfarin — Moderate."),
+				"precondition: the chip must quote the row whose ATC the patient matches, was: "
+						+ warnings.get(0).getDetail());
+
+		PatientChart chart = DrugReferenceTestSupport
+				.injector(DrugReferenceTestSupport.serviceWith(entries))
+				.injectRecords(DrugReferenceTestSupport.oneRecordChart(), context,
+						"is it safe to give voriconazole?");
+		String interactions =
+				interactionsOf(DrugReferenceTestSupport.injectedReferences(chart).get(0));
+
+		assertEquals(1, notesHeadedBy(interactions, "warfarin"),
+				"the partner the chip warns about must be named exactly once in the record: "
+						+ interactions);
+		assertTrue(interactions.contains("warfarin (moderate."),
+				"and under the rule the chip quotes, not the more severe row the patient does not "
+						+ "match: " + interactions);
+	}
+
 	@Test
 	public void aSinglePartnerRecordIsUnchanged() throws Exception {
 		// The control. Nothing may move for an entry whose partners are each filed once: the

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/OverdoseSubstanceCollapseTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/OverdoseSubstanceCollapseTest.java
@@ -1,0 +1,108 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #174 site 4 — {@code DrugSafetyValidator.addOverdose} ran once per reference ROW, so a
+ * substance the data files as several rows produced one dose warning per row, each named after its
+ * own row.
+ *
+ * <p><b>Latent on shipped data, and that is the whole reason it is swept here rather than waited
+ * for.</b> An overdose warning needs {@code ageBands}, which only the curated {@code json} schema
+ * carries, and the grouping needs a {@code substanceName}, which no bundled dataset sets on a
+ * curated entry — the {@code ddinter} source publishes substance names but no dosing, and the
+ * shipped curated seed publishes dosing but no substance names. It becomes reachable the moment an
+ * operator authors a file that does both, which the curated schema explicitly permits (see
+ * {@link DrugReference#getSubstanceName()}: "a hand-authored file that sets this field opts into
+ * the grouping"). The fixture here is that file.
+ *
+ * <p>Every scenario runs the REAL production path: the fixture parsed by the real
+ * {@link JsonDrugReferenceSource}, the real {@code validate} entry point, GP reads on their
+ * no-context defaults.
+ */
+public class OverdoseSubstanceCollapseTest {
+
+	/**
+	 * A curated file filing two substances as two rows each. {@code Amoxicillin} publishes the same
+	 * band on BOTH its rows and lists the ROUTE-QUALIFIED one first, so the row count and the label
+	 * are both observable; {@code Cefalexin} publishes a band on its qualified row ONLY, which is the
+	 * case a collapse must not turn into a lost warning.
+	 */
+	private static final String FIXTURE = "chartsearchai-test/drug-reference-substance-dosing-rows.json";
+
+	private static DrugSafetyValidator validator() throws Exception {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport
+				.serviceWith(DrugReferenceTestSupport.fixtureEntries(FIXTURE)));
+	}
+
+	@Test
+	public void oneSubstanceRaisesOneDoseWarningHoweverManyRowsItIsFiledAs() throws Exception {
+		// 2000 mg twice daily is 4000 mg/day against a published 3000 mg/day ceiling, so both
+		// amoxicillin rows trip. Before this fix that was two chips for one dose — and, since issue
+		// #110, two near-identical citable safety-finding records in the prompt as well.
+		List<SafetyWarning> warnings = validator().validate(
+				"Give amoxicillin 2000 mg twice daily.", "what dose of amoxicillin?",
+				DrugReferenceTestSupport.ctx(30, 70.0, null, null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"one substance and one stated dose is one warning, was: " + warnings);
+		assertEquals(SafetyWarning.TYPE_OVERDOSE, warnings.get(0).getType(),
+				"precondition: the warning must be the dose-excess one, was: " + warnings);
+	}
+
+	@Test
+	public void theDoseWarningNamesTheSubstanceNotTheRowTheFileListedFirst() throws Exception {
+		// The label half, which the collapse alone would not settle: the fixture lists
+		// "Amoxicillin (suspension)" first, so a first-row survivor names a formulation nobody asked
+		// about. Nothing here can know the formulation — the same reason issue #162 gave for the
+		// interaction subject — so the honest subject is the substance.
+		List<SafetyWarning> warnings = validator().validate(
+				"Give amoxicillin 2000 mg twice daily.", "what dose of amoxicillin?",
+				DrugReferenceTestSupport.ctx(30, 70.0, null, null, null, null));
+
+		assertEquals("Amoxicillin", warnings.get(0).getDrug(),
+				"the dose warning must name the substance, was: " + warnings);
+		assertFalse(warnings.get(0).getDetail().contains("(suspension)"),
+				"and its detail must not assert a formulation either, was: "
+						+ warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void aBandOnlyASiblingRowPublishesStillWarns() throws Exception {
+		// The direction a collapse must not take. Cefalexin's route-unspecified row — the one the
+		// substance is named after — publishes NO age band at all; only its paediatric row does. A
+		// collapse that simply evaluated the canonical row would drop a real overdose warning, which
+		// is the one direction this module never takes. Every row is still evaluated; only the number
+		// of chips and the name on them changed.
+		//
+		// 800 mg twice daily is 1600 mg/day against the paediatric row's 1000 mg/day ceiling for a
+		// 6-year-old.
+		List<SafetyWarning> warnings = validator().validate(
+				"Give cefalexin 800 mg twice daily.", "what dose of cefalexin?",
+				DrugReferenceTestSupport.ctx(6, 20.0, null, null, null, null));
+
+		assertEquals(1, warnings.size(),
+				"the warning must survive a collapse whose canonical row publishes no band, was: "
+						+ warnings);
+		assertEquals("Cefalexin", warnings.get(0).getDrug(),
+				"and it must still be named after the substance, was: " + warnings);
+		assertTrue(warnings.get(0).getDetail().contains("1000 mg/day maximum for ages 0-11"),
+				"and it must quote the band that actually applies, was: "
+						+ warnings.get(0).getDetail());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/PartialOrderCoveragePartnerTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/PartialOrderCoveragePartnerTest.java
@@ -1,0 +1,150 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #186 — {@code DrugSafetyValidator.orderPartners} keyed the class arm's co-medications by
+ * ATC CODE, so an order the loaded dataset covers only PARTLY climbed two different rungs of its
+ * identity ladder (the covered codes onto the dataset entry, the uncovered ones onto the order) and
+ * became two partners. One co-medication, two chips, under two different labels.
+ *
+ * <p>Documented by issue #182's hardening and reported rather than fixed there, because regrouping
+ * is a behaviour change and #182 was carrying a measured impact partition a regrouping would
+ * invalidate. It is the partner-side member of the one-substance-one-row family: #171 removed the
+ * per-CODE chip on the same arm, and this removes the per-code PARTNER underneath it.
+ *
+ * <p>The two shapes the fix must not break are pinned here beside the defect, because both are
+ * things the per-code ladder gets right and an order-first regrouping could plausibly lose: two
+ * orders of one substance staying ONE partner, and a combination order covering two substances
+ * staying TWO.
+ *
+ * <p>Every scenario runs the REAL production path: a curated fixture parsed by the real
+ * {@link JsonDrugReferenceSource}, the real {@code validate} entry point, GP reads on their
+ * no-context defaults.
+ */
+public class PartialOrderCoveragePartnerTest {
+
+	/**
+	 * Three nitroimidazoles. {@code Tinidazole} — the drug the questions ask about — is filed under
+	 * {@code P01AB02} and {@code J01XD02}, so it shares a level-4 subgroup with a partner reached
+	 * through EITHER family; the dataset carries {@code P01AB01}/{@code P01AB09}
+	 * ({@code Metronidazole}) and {@code P01AB07} ({@code Secnidazole}) and no {@code J01XD} code at
+	 * all, which is what makes an order mapped to {@code J01XD01} partly-covered.
+	 */
+	private static final String FIXTURE = "chartsearchai-test/drug-reference-partial-order-coverage.json";
+
+	private static final String QUESTION = "Is it safe to give tinidazole?";
+
+	private static DrugSafetyValidator validator() throws Exception {
+		return DrugReferenceTestSupport.validator(DrugReferenceTestSupport
+				.serviceWith(DrugReferenceTestSupport.fixtureEntries(FIXTURE)));
+	}
+
+	/** The details of the class-relationship chips, which is all this arm can raise over a rule-less
+	 *  dataset — so a count here is a count of co-medications the arm decided about. */
+	private static List<String> classChipDetails(List<SafetyWarning> warnings) {
+		return warnings.stream().filter(w -> SafetyWarning.TYPE_INTERACTION.equals(w.getType()))
+				.map(SafetyWarning::getDetail).collect(java.util.stream.Collectors.toList());
+	}
+
+	@Test
+	public void anOrderTheDatasetCoversOnlyPartlyIsOneCoMedication() throws Exception {
+		// ONE order, whose concept maps to two ATC codes: P01AB01 (the dataset carries it) and
+		// J01XD01 (it does not). Tinidazole shares a subgroup with each, so before this fix the
+		// patient was told twice about one co-medication — once as "active order Metronidazole"
+		// through the dataset entry and once as "active order Metronidazole 500mg" through the order
+		// itself.
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Metronidazole 500mg"),
+				DrugReferenceTestSupport.set("P01AB01", "J01XD01"), null, null,
+				Arrays.asList(DrugReferenceTestSupport.activeOrder("order-1", "Metronidazole 500mg",
+						DrugReferenceTestSupport.set("Metronidazole 500mg"),
+						DrugReferenceTestSupport.set("P01AB01", "J01XD01"))));
+
+		List<String> chips = classChipDetails(validator().validate("", QUESTION, context));
+
+		assertEquals(1, chips.size(),
+				"one order is one co-medication however many of its codes the dataset covers, was: "
+						+ chips);
+		assertTrue(chips.get(0).contains("as active order Metronidazole —"),
+				"and it is named by the dataset's own name for the substance, was: " + chips);
+	}
+
+	@Test
+	public void twoOrdersOfOneSubstanceAreStillOneCoMedication() throws Exception {
+		// The promise the per-code ladder already kept and an order-first regrouping could lose: two
+		// separate orders that the dataset resolves to ONE substance must not become two partners.
+		// Each order carries a different code of the same Metronidazole entry.
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Metronidazole 500mg", "Metronidazole gel"),
+				DrugReferenceTestSupport.set("P01AB01", "P01AB09"), null, null,
+				Arrays.asList(
+						DrugReferenceTestSupport.activeOrder("order-1", "Metronidazole 500mg",
+								DrugReferenceTestSupport.set("Metronidazole 500mg"),
+								DrugReferenceTestSupport.set("P01AB01")),
+						DrugReferenceTestSupport.activeOrder("order-2", "Metronidazole gel",
+								DrugReferenceTestSupport.set("Metronidazole gel"),
+								DrugReferenceTestSupport.set("P01AB09"))));
+
+		List<String> chips = classChipDetails(validator().validate("", QUESTION, context));
+
+		assertEquals(1, chips.size(),
+				"two orders of one substance are one co-medication, was: " + chips);
+	}
+
+	@Test
+	public void aCombinationOrderCoveringTwoSubstancesIsStillTwoCoMedications() throws Exception {
+		// The other direction, and the reason the fix cannot simply be "group by order". One order
+		// whose concept maps to the codes of TWO different substances the dataset carries really is
+		// two co-medications in one tablet, and collapsing it would drop a duplicate-therapy chip.
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Metronidazole and secnidazole"),
+				DrugReferenceTestSupport.set("P01AB01", "P01AB07"), null, null,
+				Arrays.asList(DrugReferenceTestSupport.activeOrder("order-1",
+						"Metronidazole and secnidazole",
+						DrugReferenceTestSupport.set("Metronidazole and secnidazole"),
+						DrugReferenceTestSupport.set("P01AB01", "P01AB07"))));
+
+		List<String> chips = classChipDetails(validator().validate("", QUESTION, context));
+
+		assertEquals(2, chips.size(),
+				"a combination order covering two substances stays two co-medications, was: " + chips);
+		assertTrue(chips.toString().contains("active order Metronidazole")
+				&& chips.toString().contains("active order Secnidazole"),
+				"and each is named by its own substance, was: " + chips);
+	}
+
+	@Test
+	public void anOrderTheDatasetDoesNotCoverAtAllIsStillOneCoMedication() throws Exception {
+		// The rung below, unchanged: with no entry for either code the order itself is the identity,
+		// so its codes are one partner named by the order's display name (issue #155).
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Ornidazole 500mg"),
+				DrugReferenceTestSupport.set("J01XD03", "P01AB03"), null, null,
+				Arrays.asList(DrugReferenceTestSupport.activeOrder("order-1", "Ornidazole 500mg",
+						DrugReferenceTestSupport.set("Ornidazole 500mg"),
+						DrugReferenceTestSupport.set("J01XD03", "P01AB03"))));
+
+		List<String> chips = classChipDetails(validator().validate("", QUESTION, context));
+
+		assertEquals(1, chips.size(),
+				"an uncovered order is one co-medication, was: " + chips);
+		assertTrue(chips.get(0).contains("as active order Ornidazole 500mg —"),
+				"named by the order's own display name, was: " + chips);
+	}
+}

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/PartialOrderCoveragePartnerTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/PartialOrderCoveragePartnerTest.java
@@ -81,8 +81,36 @@ public class PartialOrderCoveragePartnerTest {
 		assertEquals(1, chips.size(),
 				"one order is one co-medication however many of its codes the dataset covers, was: "
 						+ chips);
-		assertTrue(chips.get(0).contains("as active order Metronidazole —"),
-				"and it is named by the dataset's own name for the substance, was: " + chips);
+		assertTrue(chips.get(0).contains("as active order Metronidazole 500mg —"),
+				"and it is named by the ORDER, not by the dataset's name for the codes it happens to "
+						+ "cover — that name does not speak for the code it does not, was: " + chips);
+	}
+
+	@Test
+	public void theMergedPartnerIsNotNamedAfterHalfOfACombination() throws Exception {
+		// Why the merged partner takes the ORDER's name, on the real shape that makes it matter. The
+		// 3.7.1 demo dictionary's "Isoniazid / Rifapentine" concept maps to J04AB05 and J04AC51, and
+		// the loaded 19 MB KB carries the first and not the second — so the covered half names
+		// rifapentine while the class the chip states (J04AC) is the isoniazid half's. Naming the
+		// partner "Rifapentine" would publish "…is in the same ATC class (J04AC) as active order
+		// Rifapentine", whose stated class does not classify the drug it names.
+		//
+		// Reproduced here over the fixture's own codes rather than over J04*, so the assertion does
+		// not depend on the demo dictionary: Secnidazole is covered, J01XD01 is not, and the question
+		// drug relates through J01XD.
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Secnidazole and ornidazole"),
+				DrugReferenceTestSupport.set("P01AB07", "J01XD01"), null, null,
+				Arrays.asList(DrugReferenceTestSupport.activeOrder("order-1",
+						"Secnidazole and ornidazole",
+						DrugReferenceTestSupport.set("Secnidazole and ornidazole"),
+						DrugReferenceTestSupport.set("P01AB07", "J01XD01"))));
+
+		List<String> chips = classChipDetails(validator().validate("", QUESTION, context));
+
+		assertEquals(1, chips.size(), "one order is one co-medication, was: " + chips);
+		assertTrue(chips.get(0).contains("as active order Secnidazole and ornidazole —"),
+				"the chip must name the order, was: " + chips);
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ScreeningSubjectLabelTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ScreeningSubjectLabelTest.java
@@ -90,6 +90,33 @@ public class ScreeningSubjectLabelTest {
 	}
 
 	@Test
+	public void theQuestionPairArmNamesTheSubstanceToo() throws Exception {
+		// A FIFTH site of the same shape, found while sweeping the four issue #174 enumerates and not
+		// listed there: the question-PAIR arm (issue #114) names both sides of its sentence by
+		// whichever entry row it reached, and its own javadoc records that the tie "goes to whichever
+		// entry the DATASET lists first". For Chloroprocaine that is the ophthalmic row, so a question
+		// naming two drugs asserted a preparation the clinician never named — the same defect issue
+		// #162 fixed on the drug-in-play arm and #174 site 3 on the screening arm.
+		//
+		// No active orders, so this arm is the only one that can chip: the drug-in-play arm needs
+		// hasActiveDrug and the screening arm needs a question naming no drug.
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null, null, null, null, null);
+
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(service)
+				.validate("", "Does chloroprocaine interact with lidocaine?", context);
+
+		assertEquals(1, warnings.size(),
+				"precondition: the question pair must chip exactly once, was: " + warnings);
+		assertTrue(warnings.get(0).getDetail().contains("interacts with Chloroprocaine,"),
+				"the pair sentence must name the SUBSTANCE, not the row the dataset listed first, "
+						+ "was: " + warnings.get(0).getDetail());
+		assertFalse(warnings.get(0).getDetail().contains("(ophthalmic)")
+				|| warnings.get(0).getDrug().contains("(ophthalmic)"),
+				"and must assert no preparation the question did not name, was: " + warnings);
+	}
+
+	@Test
 	public void bothArmsCallOneSubstanceTheSameThingInOneBuild() throws Exception {
 		// The live-confirmed shape, in process: one patient, one substance, two questions. A question
 		// NAMING the drug reaches the drug-in-play arm, which has named the substance's canonical row

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/ScreeningSubjectLabelTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/ScreeningSubjectLabelTest.java
@@ -1,0 +1,116 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #174 site 3 — the interaction SCREENING arm
+ * ({@code DrugSafetyValidator.addActiveOrderPairInteractions}, issue #113) named its subject after
+ * whichever row {@link DrugReferenceService#findForActiveOrders} returned first, so a substance the
+ * KB files as several rows was named by a route-qualified row for a systemic order.
+ *
+ * <p>Label-only: the arm's own unordered pair key already collapses the duplicate chips, and issue
+ * #173's identity ledger already stops the drug-in-play arm and this one both reporting one pair.
+ * What was left is that the two arms could still CALL one substance two different things in one
+ * build — live-confirmed on a deployment where the same patient's chip read {@code Salicylic acid}
+ * for a question naming the drug and {@code Salicylic acid (sodium)} for a screening question.
+ *
+ * <p>Seven of the shipped KB's multi-row families name their route-unspecified row somewhere other
+ * than first, which is what makes the choice observable at all; {@code Chloroprocaine} is one of
+ * them, and the fixture below is a verbatim slice of it.
+ *
+ * <p>Every scenario runs the REAL production path: a verbatim DDInter KB slice parsed by the real
+ * {@link DdiDrugReferenceSource}, the real {@code validate} entry point, real question strings, GP
+ * reads on their no-context defaults.
+ */
+public class ScreeningSubjectLabelTest {
+
+	/** The canonical screening question, verbatim from issue #113. */
+	private static final String SCREENING_QUESTION =
+			"Are there any drug interactions with her current medications?";
+
+	/**
+	 * The verbatim slice whose {@code Chloroprocaine} family lists its OPHTHALMIC row first and
+	 * carries lidocaine's rule on that row alone — so a first-row subject and a canonical-row
+	 * subject are two different strings. Shared with
+	 * {@code DrugSafetyInteractionScreeningTest}'s cross-arm cases, which assert the ledger this one
+	 * does not exercise.
+	 */
+	private static final String FIXTURE = "chartsearchai-test/ddi-crossarm-canonical-duplicate.json";
+
+	private static PatientClinicalContext bothOrders() {
+		return DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Chloroprocaine 20mg/mL", "Lidocaine 2%"), null, null, null);
+	}
+
+	@Test
+	public void theScreenNamesTheSubstanceNotWhicheverRowResolvedFirst() throws Exception {
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+		PatientClinicalContext context = bothOrders();
+
+		// Preconditions through the production resolvers: the screening gate needs a question naming
+		// no drug, and the defect needs the QUALIFIED row to resolve first.
+		assertTrue(service.findByQuery(SCREENING_QUESTION).isEmpty(),
+				"precondition: the screening question must name no drug, or the screen never runs");
+		assertEquals(Arrays.asList("Chloroprocaine (ophthalmic)", "Chloroprocaine", "Lidocaine"),
+				DrugReferenceTestSupport.names(service.findForActiveOrders(context)),
+				"precondition: the ROUTE-QUALIFIED row must resolve first — that is what the subject "
+						+ "label used to be taken from");
+
+		// The EMPTY answer is the pre-answer production shape (DrugReferenceInjector.preAnswerFindings
+		// calls validate exactly this way), so nothing is in play and the screening arm is the only
+		// arm that can raise this chip. That isolation is the point: the cross-arm ledger cannot mask
+		// the label here, because there is no other arm.
+		List<SafetyWarning> warnings = DrugReferenceTestSupport.validator(service)
+				.validate("", SCREENING_QUESTION, context);
+
+		assertEquals(1, warnings.size(),
+				"precondition: the screen must reach the one pair among these orders, was: " + warnings);
+		assertEquals("Chloroprocaine", warnings.get(0).getDrug(),
+				"the screening chip must name the SUBSTANCE, not the row the dataset listed first, "
+						+ "was: " + warnings);
+		assertFalse(warnings.get(0).getDetail().contains("(ophthalmic)"),
+				"and its detail must not assert an ophthalmic preparation the chart does not record, "
+						+ "was: " + warnings.get(0).getDetail());
+	}
+
+	@Test
+	public void bothArmsCallOneSubstanceTheSameThingInOneBuild() throws Exception {
+		// The live-confirmed shape, in process: one patient, one substance, two questions. A question
+		// NAMING the drug reaches the drug-in-play arm, which has named the substance's canonical row
+		// since issue #162; a SCREENING question reaches the arm above. Two labels for one substance
+		// in one build is what a clinician reads as the module contradicting itself, and the identity
+		// ledger of issue #173 deliberately does not fix it — it stopped depending on the label
+		// instead.
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+		DrugSafetyValidator validator = DrugReferenceTestSupport.validator(service);
+		PatientClinicalContext context = bothOrders();
+
+		List<SafetyWarning> screened = validator.validate("", SCREENING_QUESTION, context);
+		List<SafetyWarning> named = validator.validate("", "Is it safe to give her chloroprocaine?",
+				context);
+
+		assertEquals(1, screened.size(), "precondition: the screen must chip, was: " + screened);
+		assertEquals(1, named.size(),
+				"precondition: the drug-named question must chip the same pair, was: " + named);
+		assertEquals(named.get(0).getDrug(), screened.get(0).getDrug(),
+				"one substance must have one name across the two arms — was '" + named.get(0).getDrug()
+						+ "' when the question named it and '" + screened.get(0).getDrug()
+						+ "' when it was screened for");
+	}
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-partial-order-coverage.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-partial-order-coverage.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.0",
+  "source": "test fixture — issue #186: the class arm's co-medication grouping, over a dataset that covers one of an order's ATC codes and not the other",
+  "entries": [
+    {
+      "id": "metronidazole",
+      "name": "Metronidazole",
+      "aliases": [
+        "metronidazole"
+      ],
+      "atcCodes": [
+        "P01AB01",
+        "P01AB09"
+      ],
+      "source": "test fixture"
+    },
+    {
+      "id": "secnidazole",
+      "name": "Secnidazole",
+      "aliases": [
+        "secnidazole"
+      ],
+      "atcCodes": [
+        "P01AB07"
+      ],
+      "source": "test fixture"
+    },
+    {
+      "id": "tinidazole",
+      "name": "Tinidazole",
+      "aliases": [
+        "tinidazole"
+      ],
+      "atcCodes": [
+        "P01AB02",
+        "J01XD02"
+      ],
+      "source": "test fixture"
+    }
+  ]
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-partner-atc-split-rows.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-partner-atc-split-rows.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "description": "Test fixture (issue #174 site 2, hardening): a curated entry filing ONE partner as two rows that carry the SAME match token and DIFFERENT ATC codes. That is the only shape in which the two halves of PatientClinicalContext.hasActiveDrug disagree between two rows of one partner group — the token arm answers the same for both, the ATC arm does not — so the row that wins DrugSafetyValidator.outranksOnRule on severity can be a row the patient does not match while a discarded sibling is the row that raises the chip. The curated source is the only one that can pose it: DdiDrugReferenceSource writes each rule's ATC from its partner row, so every rule of one partner in the shipped 19 MB KB carries an identical (token, atc) pair (measured 2026-08-07 through the real parser: 0 label groups whose rules differ on either field). The two filler partners ahead of warfarin are long on purpose — together they exceed DrugReferenceInjector.MAX_INTERACTION_RENDER_CHARS, so a warfarin note that is not PROMOTED is pushed out of the record entirely rather than merely reworded, which is the damage this shape does. Parsed by the real JsonDrugReferenceSource parser.",
+  "entries": [
+    {
+      "id": "voriconazole-curated",
+      "name": "Voriconazole",
+      "drugClass": "Triazole antifungal",
+      "aliases": [
+        "voriconazole"
+      ],
+      "atcCodes": [
+        "J02AC03"
+      ],
+      "interactions": [
+        {
+          "token": "rifabutin",
+          "severity": "Major",
+          "note": "Major. Rifabutin induces CYP450 3A4 and CYP2C19 and markedly reduces voriconazole plasma concentrations, while voriconazole inhibits rifabutin metabolism and raises rifabutin exposure enough to precipitate uveitis, leukopenia and arthralgia. Concomitant use is generally avoided. Where the combination cannot be avoided the voriconazole maintenance dose is doubled and the patient is monitored with full blood counts and for rifabutin toxicity throughout, with slit-lamp examination if visual symptoms appear. The interaction is bidirectional, so neither dose adjustment on its own restores both exposures, and the effect persists for a period after rifabutin is withdrawn because enzyme induction resolves only as the induced protein turns over. Therapeutic drug monitoring of voriconazole trough concentrations is recommended wherever it is available."
+        },
+        {
+          "token": "carbamazepine",
+          "severity": "Major",
+          "note": "Major. Carbamazepine is a potent inducer of CYP450 3A4 and substantially lowers voriconazole plasma concentrations, to a degree that has produced breakthrough invasive fungal infection during treatment. The reduction is not reliably overcome by increasing the voriconazole dose, because the extent of induction varies between patients and cannot be predicted from the carbamazepine dose alone. Coadministration is contraindicated in most labelling. Where antifungal therapy is required in a patient established on carbamazepine, an agent that is not a CYP450 3A4 substrate should be selected instead, and where carbamazepine is being started in a patient on voriconazole the antifungal regimen should be reviewed before the inducer is introduced rather than after breakthrough infection is observed."
+        },
+        {
+          "token": "warfarin",
+          "atc": "B01AA03",
+          "severity": "Major",
+          "note": "Major. This row identifies its partner by the ATC code of racemic warfarin, which THIS patient is not on. It is the more severe of the two rows, so it wins the survivor rule on severity alone."
+        },
+        {
+          "token": "warfarin",
+          "atc": "B01AA07",
+          "severity": "Moderate",
+          "note": "Moderate. This row identifies its partner by the ATC code of acenocoumarol, which the patient IS on, so it is the row that raises the chip and the row the record must quote."
+        }
+      ],
+      "source": "Test fixture"
+    }
+  ]
+}

--- a/api/src/test/resources/chartsearchai-test/drug-reference-substance-dosing-rows.json
+++ b/api/src/test/resources/chartsearchai-test/drug-reference-substance-dosing-rows.json
@@ -1,0 +1,81 @@
+{
+  "version": "1.0",
+  "source": "test fixture — issue #174 site 4: a curated file that files one substance as several rows AND publishes age bands on them, the shape no bundled source can produce",
+  "entries": [
+    {
+      "id": "amoxicillin-suspension",
+      "name": "Amoxicillin (suspension)",
+      "substanceName": "amoxicillin",
+      "aliases": [
+        "amoxicillin"
+      ],
+      "atcCodes": [
+        "J01CA04"
+      ],
+      "ageBands": [
+        {
+          "minYears": 0,
+          "maxYears": 120,
+          "mgPerKgMin": 15,
+          "mgPerKgMax": 30,
+          "maxDailyDoseMg": 3000
+        }
+      ],
+      "source": "test fixture"
+    },
+    {
+      "id": "amoxicillin",
+      "name": "Amoxicillin",
+      "substanceName": "amoxicillin",
+      "aliases": [
+        "amoxicillin"
+      ],
+      "atcCodes": [
+        "J01CA04"
+      ],
+      "ageBands": [
+        {
+          "minYears": 0,
+          "maxYears": 120,
+          "mgPerKgMin": 15,
+          "mgPerKgMax": 30,
+          "maxDailyDoseMg": 3000
+        }
+      ],
+      "source": "test fixture"
+    },
+    {
+      "id": "cefalexin",
+      "name": "Cefalexin",
+      "substanceName": "cefalexin",
+      "aliases": [
+        "cefalexin"
+      ],
+      "atcCodes": [
+        "J01DB01"
+      ],
+      "source": "test fixture"
+    },
+    {
+      "id": "cefalexin-paediatric",
+      "name": "Cefalexin (paediatric)",
+      "substanceName": "cefalexin",
+      "aliases": [
+        "cefalexin"
+      ],
+      "atcCodes": [
+        "J01DB01"
+      ],
+      "ageBands": [
+        {
+          "minYears": 0,
+          "maxYears": 11,
+          "mgPerKgMin": 12.5,
+          "mgPerKgMax": 25,
+          "maxDailyDoseMg": 1000
+        }
+      ],
+      "source": "test fixture"
+    }
+  ]
+}


### PR DESCRIPTION
# Complete the one-substance-one-row sweep

Closes #174
Closes #186

## The shared root

Five places still turned one clinical fact into N of something, because they enumerated the
reference data's ROWS (or an order's ATC CODES) rather than the substance or the order those rows
stand for. #145/#160 fixed the contraindication chips, #173 the interaction subject and the injected
records, #182 the class chip's partner label (#174 site 1), #187 substance identity. This is the
remainder: #174 sites 2, 3 and 4, #186, and one further site of the same shape that #174 does not
enumerate.

Nothing new was invented. `DrugReference.substanceKey()` / `substanceGroupKey()` / `canonicalRow()`
/ `namesNoRoute()` and the two identity ledgers (`ContraindicationChips`, `InteractionPairs`)
already existed; this reuses them, adds no third dedup mechanism, and keys nothing on rendered text.
The only addition is a fold — `DrugReference.canonicalRow(Iterable)` — for the four surfaces that
now make the same choice.

## What changed, per site

### #174 site 2 — `DrugReferenceInjector.orderedInteractionNotes`: one note per partner ROW

The largest measured surplus in the cluster, and invisible from the REST response, which returns
only *cited* references.

Re-measured over the shipped 19 MB KB (2026-08-07, `appdata/chartsearchai/ddi_knowledge_base.json`,
2283 entries, 590,312 expanded rows after #152's self-pair guard drops 28): **1876 entries carry at
least one repeated partner and 19,316 rows are surplus**. `Ozanimod` carries 49 and its
COVID-vaccine token appears 6×. (#174 records 1872 / 19,228 from an earlier count; these are my own
figures and I have not reconciled the small delta.)

`orderedInteractionNotes` now collapses to one note per partner before anything is rendered:

* keyed on `DrugSafetyValidator.partnerLabel` case-folded — the key `bestRulePerPartner` already
  falls back to, and the very string the note prints, so the grouping and the rendering cannot
  disagree about what one partner is. That method is now **shared** rather than coalesced a second
  time, which also closes the untrimmed-label divergence its own javadoc named as the follow-up
  (`"warfarin   (Major. …)"` beside a chip reading `active order warfarin`);
* decided by `DrugSafetyValidator.outranksOnRule`, the rule-side half of the chip's own survivor
  rule (most severe, then the longer note), extracted so the record and the chip cannot rank one
  pair's rows oppositely. `outranks`' middle step is subject-side and cannot apply here, where every
  candidate comes from one row;
* applied before the severity floor, so a partner's sub-floor row cannot survive in the tail beside
  its above-floor row;
* a rule carrying neither token nor ATC code keys on itself — it has no name to group on, and
  merging two such rows would silently drop an operator-authored paragraph.

`withheldInteractions` now counts partners, which is what its javadoc has always claimed.

Note on the blocker the old javadoc named: the route vocabulary (#115's data-side half) is still
missing and this collapse does not need it. It decides which of several rows about ONE partner to
show, exactly as the chip decides which to raise; neither has to know which variant the order is.

### #174 site 3 — `addActiveOrderPairInteractions`: wrong subject label

Label-only, as the issue says: the arm's unordered pair key already collapses the chips and #173's
identity ledger already suppresses a pair the drug-in-play arm reported. The subject is now the
substance's canonical row rather than whichever row `findForActiveOrders` returned first.

### A fifth site — `addQuestionPairInteractions`: both labels

Found while sweeping the four, not enumerated in #174. It names both sides of its sentence by the
row the walk reached — settled, as its own javadoc records, by "whichever entry the DATASET lists
first". Same fix, same shared map (`canonicalSubjects`).

### #174 site 4 — `addOverdose`: latent

Ran once per row of `inPlay`, so a substance filed as several rows produced one dose warning per row
for a single stated dose — and, since #110, one near-identical citable finding per warning.
Unreachable on shipped data (a warning needs `ageBands`, which only the curated schema carries; the
grouping needs a `substanceName`, which no bundled curated file sets) and guarded now rather than
waited for. One warning per substance, named by the canonical row — **with every row still
evaluated**, so a band only a sibling publishes still warns. Dropping a warning is the one direction
this module does not take.

### #186 — `orderPartners` splits one order into two partners

An uncovered ATC code now asks whether the ORDER carrying it resolves, as a whole, to exactly one
substance, and joins that substance's partner when it does. Grouping by the order outright would
have been wrong in both directions and is not what this does: two orders of one substance stay one
partner, and a fixed-dose combination resolving to two substances stays two.

The merged partner takes the **ORDER's** name, not the dataset's name for the codes it happens to
cover. Not cosmetic: the demo dictionary's `Isoniazid / Rifapentine` maps to `J04AB05` (the KB covers
it) and `J04AC51` (it does not), so naming the merged partner "Rifapentine" publishes *"…is in the
same ATC class (J04AC) as active order Rifapentine"* — a chip whose stated class does not classify
the drug it names.

The builder's nameless-order gap is **not** closed and cannot be closed in this method: such an
order never reaches `getActiveDrugOrders()`, so there is nothing to group by. See below.

## Measured injected-slice reduction

Measured two independent ways that agree byte-for-byte: the standalone's DEBUG line for the injected
slice, and a throwaway harness running the real `injectRecords` over the same 19 MB KB file
(discarded; not in the diff).

| case | before | after |
|---|---|---|
| `Ozanimod`, patient on a phenylephrine-bearing order | 1 record, **1479 chars**, withheld 873 | 1 record, **939 chars**, withheld 827 |
| `Ozanimod`, no promoted partner | 1 record, 1155 chars, withheld 876 | 1 record, 1155 chars, withheld **827** |
| `Carbidopa` (3 partners, no repeats) — control | 1 record, 1196 chars, withheld 0 | **byte-identical** |

**−540 characters (−36%) on the promoted case**, and the record says *more*: the freed budget bought
`diphenhydramine` its full mechanism note, which was compact before.

Before (verbatim, truncated at the repeats):

> Drug reference — Ozanimod (ATC L04AE02). Interactions: phenylephrine (Major. Indirect- or
> mixed-acting sympathomimetic amines may precipitate severe hypertensive reactions … );
> **phenylephrine (Moderate. By inhibiting the breakdown of catecholamines, monoamine oxidase
> inhibitors (MAOIs) may theoretically potentiate the cardiovascular effects of systemically absorbed
> sympathomimetic agents following topical administration (e.g., nasal decongestants, ophthalmic
> vasoconstrictors).); phenylephrine (Moderate. … same paragraph again …); phenylephrine (Moderate. …
> same paragraph a third time …);** diphenhydramine (Moderate); ivosidenib (Major).

After:

> Drug reference — Ozanimod (ATC L04AE02). Interactions: phenylephrine (Major. Indirect- or
> mixed-acting sympathomimetic amines may precipitate severe hypertensive reactions and hyperpyrexia
> in patients treated with monoamine oxidase inhibitors (MAOIs). Death has occurred in some reported
> cases. …); **diphenhydramine (Moderate. Coadministration of monoamine oxidase inhibitors (MAOIs)
> and antihistamines may result in additive central nervous system depressant effects. …)**;
> ivosidenib (Major).

The tail-only case is honest about what it did and did not buy: the character total is unchanged
because the budget was already binding and the first three tail notes happen to name three different
partners. What changed there is the withheld count, from a row count wrong in both directions (876)
to the partner count (827).

## Live verification

Deployed to the 3.7.1 standalone via `standalone-verify.sh` (full JVM restart, retrieval gate, warm
control). Loaded source confirmed through `GET /chartsearchai/drugreferencestatus`:
`sourceFormat=ddinter`, `entryCount=2283`, `origin=appdata:chartsearchai/ddi_knowledge_base.json`.
Every patient resolved by name lookup against the live database. Order lists were read from the
database, not from `GET /order?v=custom:(…)`, which errors out on a null-route DrugOrder.

The "before" build is the deployed head of #187's branch, whose production code is byte-identical to
`main` at 682c307 (`git diff` shows only two test files).

### Fixtures created (kept — demo data is disposable)

Tagged `order_number LIKE 'I174-%'`, uuid prefix `a1740000-`:

* **Kenneth Hernandez** — `Salicylic acid` (concept 34) + `Enalapril Co 10mg`. Salicylic acid is one
  of the 7 shipped families whose route-unspecified row is not the family's first (KB order:
  `(sodium)`, `(topical)`, unqualified), and enalapril is a Moderate partner of it.
* **Steven White** — `Isoniazid / Rifapentine` (concept 143), a partly-covered order.
* **Karen Sanchez** — `Metronidazole` (concept 56), to which the fixture adds one WHOATC map the KB
  does not carry (`J01XD09`, reference term uuid `a1740000-…-c1`). This is the only schema change.
* **Karen Thompson** — `Eucalyptus & Diphenhydramine & Phenylephrine` (concept 3897), so all four of
  Ozanimod's phenylephrine rows are promoted into segment 1.

## Live verification, before → after

### Injected-slice size, every probe, before → after (the DEBUG line, verbatim numbers)

| probe | before | after |
|---|---|---|
| Mary Smith + clarithromycin | 1 ref, 331 chars | 1 ref, 331 chars |
| Agnes Adams + warfarin | 1 ref, 456 chars | 1 ref, 456 chars |
| Joshua Johnson + ibuprofen | 1 ref, 1025 chars | 1 ref, 1025 chars |
| Betty Williams + bupivacaine | 1 ref, 1344 chars | 1 ref, **362 chars** |
| George Anderson + esomeprazole | 2 refs, 3088 chars | 2 refs, 3088 chars |
| Sarah Taylor + hydrocortisone | 2 refs, 2509 chars | 2 refs, 2509 chars |
| Karen Thompson + ozanimod (promoted) | 1 ref, 1479 chars | 1 ref, **939 chars** |
| Mary Smith + ozanimod (tail only) | 1 ref, 1155 chars | 1 ref, 1155 chars |
| Mary Smith + carbidopa (control) | 1 ref, 1196 chars | 1 ref, 1196 chars |
| Kenneth Hernandez + salicylic acid | 1 ref, 535 chars | 1 ref, 535 chars |
| Steven White + isoniazid | 1 ref, 1447 chars | 1 ref, 1446 chars |
| Karen Sanchez + tinidazole | 2 refs, 3101 chars, **2 findings** | 2 refs, 3043 chars, **1 finding** |

Betty Williams is the incidental one worth pointing at: a stock control patient, one chip either
way, and her injected reference slice fell from 1344 to 362 characters because the bupivacaine entry
files lidocaine under several rows.

### Chips, before → after

**#174 site 3 — Kenneth Hernandez** (`Salicylic acid` + `Enalapril Co 10mg`), two questions, one
patient, one build. Before:

```
screening    Salicylic acid (sodium) interacts with active order enalapril — Moderate. Nonsteroidal
             anti-inflammatory drugs (NSAIDs) may attenuate the antihypertensive effects of ACE
             inhibitors. …
drug-named   Salicylic acid interacts with active order enalapril — Moderate. Nonsteroidal
             anti-inflammatory drugs (NSAIDs) may attenuate the antihypertensive effects of ACE
             inhibitors.  The proposed mechanism … Some NSAIDs may also alter the pharmacokinetics
             of certain ACE inhibitors.
```

After:

```
screening    Salicylic acid interacts with active order enalapril — Moderate. …
drug-named   Salicylic acid interacts with active order enalapril — Moderate. …
```

*Counterfactual:* had the fix not landed, the screening chip would still read
`Salicylic acid (sodium)` — that is the live-confirmed shape #174's comment describes, reproduced
here. Note the two chips still quote DIFFERENT mechanism paragraphs; that residue is item 1 of
"found but not fixed".

**#186 — Karen Sanchez** (`Metronidazole`, one of whose six ATC maps the KB does not carry), asked
about tinidazole. Before, two chips:

```
Tinidazole is in the same ATC class (J01XD) as active order Metronidazole — possible duplicate therapy
Tinidazole is in the same ATC class (J01XD) as active order Metronidazole — possible duplicate therapy
```

Byte-identical, because the order's display name and the dataset's name for it happen to be the same
string — one co-medication reported twice, and (since #110) injected as two citable findings.

*Counterfactual:* had the fix not landed, the DEBUG line would still read `2 safety-finding
record(s)`; it now reads `1`.

**#186 non-regression — Steven White** (`Isoniazid / Rifapentine`, `J04AB05` covered, `J04AC51` not),
asked about isoniazid: one chip before and after, both reading `… as active order Isoniazid /
Rifapentine`. *Counterfactual:* had the merged partner taken the dataset's name for its covered half,
this would now read `… as active order Rifapentine`, whose stated class (J04AC) does not classify
rifapentine.

**A fifth site — Mary Smith**, asked `Does chloroprocaine interact with lidocaine?` (no patient
context needed; the question-pair arm is the only one that can fire). Before:

```
Lidocaine interacts with Chloroprocaine (ophthalmic), also named in the question — Moderate. …
```

After:

```
Lidocaine interacts with Chloroprocaine, also named in the question — Moderate. …
```

*Counterfactual:* had the fix not landed, this would still assert an ophthalmic preparation for a
question that said "chloroprocaine". Its injected slice grew, 2529 → 2696 characters — the collapse
is a de-duplication, not a truncation, so freed budget can buy a fuller note for a DIFFERENT
partner. Same effect as `diphenhydramine` gaining its full note in the Ozanimod case.

**#186 label — Steven White**, asked about rifampicin, which relates to the COVERED half. Before:

```
Rifampicin (rifampin) is in the same ATC class (J04AB) as active order Rifapentine — possible duplicate therapy
```

After:

```
Rifampicin (rifampin) is in the same ATC class (J04AB) as active order Isoniazid / Rifapentine — possible duplicate therapy
```

The chart records one order called `Isoniazid / Rifapentine`; the chip now calls it that.

### The four regression controls plus three more, all after the fix

| patient | question | expected | got |
|---|---|---|---|
| Mary Smith | clarithromycin | 1 Major ×simvastatin | 1 Major ×simvastatin |
| Agnes Adams | warfarin | 1 Major ×aspirin | 1 Major ×aspirin |
| Joshua Johnson | ibuprofen | 2 | 2 (NSAID cross-reactivity + lisinopril Moderate) |
| Mary Smith | paracetamol | 0 | 0 |
| Betty Williams | bupivacaine | exactly 1 | 1 (Major ×lidocaine) |
| George Anderson | esomeprazole | 2, both PPIs | 2 (Omeprazole + Esomeprazole) |
| Sarah Taylor | hydrocortisone | 9, of which 4 named `Hydrocortisone` | 9, of which 4 |

Every one is byte-identical to the same probe on the before build, including the injected-slice
character totals — which is what makes them discriminating here: a `canonicalSubjects` that renamed
a single-row substance, or an `orderPartners` that over-merged, would move one of these.
`standalone-verify.sh` exited 0 (retrieval gate `hits=75`, warm control chip present).

## Build numbers

| | api | omod |
|---|---|---|
| baseline, `main` at `682c307` measured in a clean worktree | 947 | 61 |
| this branch | 966 | 61 |

0 failures, 34 skipped, both. +19 tests, all in four new files; **no pre-existing test file is
modified** (`git diff --name-status 682c307 HEAD` shows no `M` under `src/test`).

Resolved querystore jar: `querystore-api-1.0.0-20260806.153951-82.jar`, md5
`38205608891f10b68929c35fb3eace7e` — identical before and after every build here.

## Limitations, honestly

* The tail-only injected record is **not** shorter. The budget was already binding; what changed is
  which partners the same characters name, and the withheld count. The character win is concentrated
  where a duplicated partner is PROMOTED, because segment 1 deliberately overrides the budget.
* Site 4 is unreachable on any bundled dataset and is verified by unit test over an authored curated
  fixture only. It cannot be probed live without shipping such a file.
* The two pair arms now agree on what a substance is CALLED. They still do not agree on which ROW's
  rule they quote — see below.
* `orderedInteractionNotes` groups partners by LABEL, not by resolved entry, because it has no
  `orderEntries` to resolve against. Two rules naming one partner under two different tokens (#136's
  `warfarin`/`coumadin` shape) therefore stay two notes while `bestRulePerPartner` makes them one
  chip. Reasoned from the code; the shipped KB derives one token per partner row from
  `rxnorm_name`, so it needs an operator-authored file.
* Answer prose is not reproducible on this box (`cache_prompt` KV reuse), so nothing here asserts on
  wording — only on chips, records and the injected-slice totals.

## Is the pattern exhausted?

Close, but not quite, and the honest answer has two halves.

**One-substance-one-CHIP / one-RECORD is now exhausted** as far as I can find. I swept every
consumer that enumerates reference rows or an order's codes: `getInteractions()` (4 call sites),
`getContraindications()` (2), `getActiveDrugAtcCodes()` (3), and every caller of `findByQuery` /
`findByDrugName` / `findByActiveOrders` / `findForActiveOrders`. Every one of them now either goes
through an identity ledger (`ContraindicationChips`, `InteractionPairs`), through `substanceRows` +
`canonicalRow`, or through the per-partner collapse this PR adds. The one exception is listed below.

**One-substance-one-NAME is exhausted; one-substance-one-RULE is not.** Both pair arms now call a
substance what the drug-in-play arm calls it, but they still choose WHICH ROW's rule they quote by
dataset order rather than by severity. That is a change to chip content, not to a name, and it wants
its own measurement — see the first item below.

## Found but not fixed

1. **The two pair arms pick a pair's surviving rule by dataset order, not by severity.**
   `DrugSafetyValidator.addActiveOrderPairInteractions` and `addQuestionPairInteractions` iterate
   reference ROWS and let the first row to reach a pair own the chip, where
   `addInteractionWarnings` has used `bestRulePerPartner`/`outranks` since #115/#162.
   **Measured live, 2026-08-07**, on Kenneth Hernandez (fixture above), after this PR: the screening
   question and the drug-named question now agree that the substance is `Salicylic acid`, but the
   screening chip quotes the `(sodium)` row's mechanism note and the drug-named chip quotes the
   unqualified row's — two different paragraphs for one pair in one build. The analogue of #115 on
   these arms. Fix: hand the substance's whole row group to the existing multi-subject
   `bestRulePerPartner` overload rather than one row at a time; `activeOrdersOtherThan` must then
   reduce by the group rather than by the row, which is the part that needs care.

2. **`PatientClinicalContextBuilder`'s nameless-order gap keeps #186's second symptom open.** An
   order whose names all read blank is skipped from `getActiveDrugOrders()` while its ATC codes
   still reach `getActiveDrugAtcCodes()`, so `orderPartners` has no order to group its codes by and
   emits one partner per uncovered code. Not fixable inside `orderPartners`. The builder's own
   KNOWN-GAP comment names the fix (a fallback display), but that also changes what
   `unrepresentedActiveOrders` injects in front of a clinician, so it is its own change. Reasoned
   from code and from that comment; **not reproduced live** (I did not construct a nameless order).

3. **`DrugReferenceInjector`'s `Contraindicated with:` section is a candidate sixth site.** It
   renders one clause per contraindication ROW, while `ContraindicationChips` collapses per
   `(substance, type, token)` — so a curated file with two rows for one token yields two clauses
   beside one chip. Unreachable on shipped data (only the curated `json` source publishes
   contraindications at all, and the bundled seed's four entries carry no duplicate tokens), so it
   is the same latency as #174 site 4. **Not obviously the same fix**: the two notes carry different
   text ("documented ibuprofen allergy" / "avoid all NSAIDs" in
   `drug-reference-duplicate-rule-tokens.json`), so joining them may be right where dropping one is
   not. Measured over the bundled seed; the operator-file case is reasoned.

4. **`orderedInteractionNotes` groups partners by LABEL, not by resolved entry.** Two rules naming
   one partner under two different tokens stay two notes while `bestRulePerPartner` makes them one
   chip, because the injector has no `orderEntries` to resolve against. #136 records that shape
   (`warfarin` / `coumadin` on one entry). Reasoned from code; needs an operator-authored file or an
   alias-carrying entry, since `ddinter` derives one token per partner row from `rxnorm_name`.

5. **`orderPartners` takes the merged partner's name from whichever contributing order carries an
   unnameable code.** A patient holding a fully-covered order and a partly-covered order of ONE
   substance gets a partner named after the partly-covered one. Reasoned, not measured; low impact,
   and the alternative (prefer the dataset name) is the case item 3 of #186 above rules against.

6. **CLAUDE.md's API-surface list does not name `DrugReference.canonicalRow`** (now the single
   choice for four surfaces) **or `DrugSafetyValidator.partnerLabel`** (now shared with the
   injector). `foldDiacritics` is likewise absent — reported by an earlier pass. Stale
   documentation, not a defect; not edited here.

7. **#174's counts and mine differ slightly.** The issue records 1872 entries / 19,228 surplus rows;
   measuring through the real parser and the real `partnerLabel` I get **1876 / 19,316** (and
   `Ozanimod` 49, the COVID-vaccine token 6×, both exact matches). I did not reconcile the delta.
   Worth noting that my first attempt at this measurement was a Python reimplementation of
   `substanceKey`, and it disagreed with production on the family counts (126/116/6 against the true
   129/119/7) — which is why every figure quoted here was re-derived by calling the production code.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4f3XXyMCyJqZTPjXoRctu
