### PR TITLE
fix(validity): report the substance merge the alias rule cannot see (#196 item 4)

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSource.java
@@ -361,6 +361,16 @@ public class DdiDrugReferenceSource implements DrugReferenceSource {
 	 * that is what merges {@code Thallous Chloride}/{@code Thallous chloride tl-201} and
 	 * {@code Typhoid vaccine (live)}/{@code Typhoid vaccine live}.
 	 *
+	 * <p><b>The first case also merges one pair it should not, and the loader says so.</b> A row
+	 * carrying no id takes the family's whichever it is, so a DERIVATIVE filed under its parent's
+	 * {@code rxnorm_name} is merged into the parent on the strength of a claim nothing checked:
+	 * {@code Fluoroestradiol f-18} publishes {@code rxnorm_name: estradiol} and no id, so a PET imaging
+	 * tracer takes {@code DB00783}. Nothing here can tell that from the two shapes above — a second
+	 * NAME for one substance and a derivative of it are the same row to this method — so it is not
+	 * repaired here; {@link DrugReferenceValidity#DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE} reports
+	 * it at load instead, keyed on the relationship the display name states. Issue #196 item 4, and the
+	 * one row in the shipped KB it fires on.
+	 *
 	 * <p>Measured over the shipped 19 MB KB (2283 rows; re-measure before relying on the figures): 142
 	 * substance names are shared by more than one row, 19 of them naming two or more DrugBank
 	 * substances and 123 naming at most one. No group the resulting key produces holds two DrugBank

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidity.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidity.java
@@ -615,32 +615,29 @@ public final class DrugReferenceValidity {
 	 *       shape issue #196 records as undetectable from inside the file, and a derivative the module
 	 *       has correctly kept APART from its parent that has route variants of its OWN;</li>
 	 *   <li>the name must carry the substance's own name as a bounded WORD to be excluded, so every
-	 *       presentation, salt and ester stays silent — and so does every second NAME for one
-	 *       substance, which carries it neither as a word nor as a substring. That exclusion is the
-	 *       load-bearing half: measured over the shipped KB, <b>12</b> rows are silent only because of
-	 *       it, every one inspected an ester, a salt or a preparation
+	 *       presentation, salt and ester is read as what it is rather than as a derivative. That is not
+	 *       a rare shape: 12 rows of the shipped KB carry their substance's name as a bounded word
 	 *       ({@code Beclomethasone dipropionate} under {@code beclomethasone},
 	 *       {@code Estrone sulfate} under {@code estrone}, the four
-	 *       {@code Human immunoglobulin G} routes under {@code immunoglobulin g}), so without it this
-	 *       rule would report 13 rows of which 12 are correct data.</li>
+	 *       {@code Human immunoglobulin G} routes under {@code immunoglobulin g}), measured through
+	 *       {@link DrugReference#displayStem}/{@link DrugReference#containsWord} over the file.</li>
 	 * </ul>
 	 * Folded through {@link DrugReference#foldDiacritics} before the substring half so that half and
 	 * {@link DrugReference#containsWord} read the same alphabet; unfolded, a localized dataset would be
 	 * quieter about a real merge than an ASCII one. No shipped row can witness that — measured
 	 * 2026-08-13, none of the 2283 carries a non-ASCII character in {@code name} or {@code rxnorm_name}
-	 * — so {@code ddi-derivative-localized-name.json} is hand-authored and says so.
+	 * — so {@code ddi-derivative-rule-edges.json} is hand-authored and says so.
 	 *
-	 * <p><b>Which datasets this can fire on at all.</b> It needs a family of more than one row to hold a
-	 * derivative, so it needs {@link DrugReference#substanceKey()} to be non-null and shared, and what
-	 * supplies that differs per format. The {@code atc} adapter publishes no substance name, so every
-	 * row is its own family and the rule is vacuous there. The {@code ddinter} adapter publishes the
-	 * registry that keys a derivative WITH ITS PARENT, which is the shipped case. A curated
-	 * {@code json} file falls back to the display STEM — so it cannot key a derivative with its parent,
-	 * whose stem differs by construction, but it can key one with its own qualifier variant
-	 * ({@code Fluoroestradiol f-18} and {@code Fluoroestradiol f-18 (suspension)} both declaring
-	 * {@code substanceName: estradiol}), which is the shape {@code drug-reference-charted-substance-row}
-	 * already ships for {@code Amoxicillin}. So the rule is not {@code ddinter}-only; what is
-	 * {@code ddinter}-only is the derivative-and-parent merge it was written for.
+	 * <p><b>Which datasets this can fire on at all, and why it is one.</b> Reporting needs a family
+	 * holding both a derivative row and a row that is not one, so it needs
+	 * {@link DrugReference#substanceKey()} to be shared by rows whose display STEMS differ. Only a
+	 * resolved substance registry id can do that: where the key falls back to the stem — the curated
+	 * {@code json} schema, which publishes no registry — every row of a family has the same stem AND
+	 * the same substance name, so {@link #derivesFromItsOwnSubstance} is constant across it and the
+	 * family is either wholly derivative (no parent, skipped) or wholly not (nothing to report). The
+	 * {@code atc} adapter publishes no substance name at all, so every row is its own family. Today
+	 * that leaves the {@code ddinter} adapter, and this is a derivation from the two gates rather than
+	 * a list of formats to maintain.
 	 *
 	 * <p><b>REPORTED.</b> Splitting the rows would be inventing the fact the data is missing — the
 	 * loader cannot tell a derivative that is a different substance from one the registry would confirm
@@ -724,28 +721,6 @@ public final class DrugReferenceValidity {
 	}
 
 	/**
-	 * @return whether this row's display stem names a DERIVATIVE of the substance the data filed it
-	 *         under: it carries that substance's name, and not as a bounded word. Two conditions
-	 *         because there are three answers, and {@link DrugReference#containsWord} rules out two of
-	 *         them at once — the stem that IS the substance name (a row of it, {@code Estradiol}) and
-	 *         the stem that carries it as a WORD (a presentation, salt or ester of it,
-	 *         {@code Beclomethasone dipropionate} under {@code beclomethasone}). What the substring test
-	 *         then rules out is the third: a stem not carrying the name at all is a second NAME for the
-	 *         substance, which issue #164 measured as one substance ({@code Daxibotulinumtoxina}). It is
-	 *         also what keeps the total key {@link DrugReference#displayStem} is documented to return
-	 *         silent — the empty stem carries nothing — which the first test would not, since
-	 *         {@link DrugReference#containsWord} is false there and false is this predicate's REPORTING
-	 *         direction. Only what survives both is a derivative.
-	 *
-	 *         <p>Gated on the substance name being a name at all, through this class's own
-	 *         {@link #namesAnything}: a token of nothing but combining marks is non-blank to
-	 *         {@link DrugReference#normalizeName} and folds to EMPTY, and the two tests then disagree
-	 *         about it — {@code containsWord} refuses an empty token while {@code contains("")} accepts
-	 *         every stem — so every row of such a family would be reported. That is the one way these
-	 *         two halves can read different alphabets, and it fails OPEN, which is the direction this
-	 *         class does not accept.
-	 */
-	/**
 	 * @return whether {@code rows} holds a row the derivatives among them could have been merged WITH:
 	 *         one that is not itself a derivative of the substance they all claim. This is the family
 	 *         gate, and a size check is not it — a derivative the module has correctly kept APART from
@@ -756,6 +731,10 @@ public final class DrugReferenceValidity {
 	 *         family with no parent in it, and without this gate both are reported, each naming the
 	 *         other. Measured through this rule on {@code ddi-derivative-rule-edges.json}: 3
 	 *         occurrences without the gate, 1 with it.
+	 *
+	 *         <p>Strictly narrower than the size check it replaced, which is why it can only remove
+	 *         findings: a reported row derives, this needs one that does not, and the two cannot be the
+	 *         same row.
 	 */
 	private static boolean holdsAParent(List<DrugReference> rows) {
 		for (DrugReference row : rows) {
@@ -766,6 +745,28 @@ public final class DrugReferenceValidity {
 		return false;
 	}
 
+	/**
+	 * @return whether this row's display stem names a DERIVATIVE of the substance the data filed it
+	 *         under: it carries that substance's name, and not as a bounded word. Two conditions
+	 *         because there are three answers, and {@link DrugReference#containsWord} rules out two of
+	 *         them at once — the stem that IS the substance name (a row of it, {@code Estradiol}) and
+	 *         the stem that carries it as a WORD (a presentation, salt or ester of it,
+	 *         {@code Beclomethasone dipropionate} under {@code beclomethasone}). What the substring test
+	 *         then rules out is the third: a stem not carrying the name at all is a second NAME for the
+	 *         substance, which issue #164 measured as one substance ({@code Daxibotulinumtoxina}). Only
+	 *         what survives both is a derivative.
+	 *
+	 *         <p>Gated on the substance name being a name at all, through this class's own
+	 *         {@link #namesAnything}, because that is where the two tests can disagree: a token with no
+	 *         letter or digit is non-blank to {@link DrugReference#normalizeName}, and
+	 *         {@code containsWord} refuses it while {@code String.contains} finds it in whichever stems
+	 *         happen to carry the character. An {@code rxnorm_name} of {@code "-"} shared by
+	 *         {@code Bupivacaine hcl-2} and {@code Marcaine} therefore reports the first as deriving
+	 *         from {@code "-"} — it fails OPEN, which is the direction this class does not accept.
+	 *         A token of nothing but combining marks is NOT that witness, though it looks like one: it
+	 *         folds to empty, {@code contains("")} is true of every stem, so every row of the family
+	 *         derives and {@link #holdsAParent} silences it before this gate is reached.
+	 */
 	private static boolean derivesFromItsOwnSubstance(DrugReference row) {
 		String substance = DrugReference.normalizeName(row.getSubstanceName());
 		if (substance == null || !namesAnything(substance)) {

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidity.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidity.java
@@ -592,11 +592,10 @@ public final class DrugReferenceValidity {
 	 * <p><b>The criterion, and why it is not "one substance, unlike names".</b> That broader predicate was
 	 * measured first — {@link DrugReference#substanceGroupKey()} over the shipped KB, then
 	 * {@link DrugReference#displayStem}/{@link DrugReference#containsWord} between each family's rows —
-	 * and it fires on 15 rows across 8 families, most of them merges issue #164 measured as CORRECT:
-	 * {@code Daxibotulinumtoxina} with {@code Botulinum toxin type A}, {@code Pfizer-BioNTech Covid-19
-	 * Vaccine} with {@code Tozinameran}, {@code Ga 68 psma-11} with {@code Gallium Ga-68 gozetotide}. A
-	 * rule reporting those would tell an operator that this module's own correct behaviour is a data
-	 * defect. So the criterion is the relationship the row's own NAME states rather than the absence of
+	 * and it fires on 15 rows across 8 families — a set that includes BOTH merges issue #164 measured as
+	 * CORRECT, {@code Daxibotulinumtoxina} with {@code Botulinum toxin type A} and
+	 * {@code Pfizer-BioNTech Covid-19 Vaccine} with {@code Tozinameran}. A rule reporting those would
+	 * tell an operator that this module's own correct behaviour is a data defect. So the criterion is the relationship the row's own NAME states rather than the absence of
 	 * one: a name that carries the substance's name WITHOUT a word boundary is a derivative — fluoro-,
 	 * levo-, dex-, es-, nor- — and this module already reads it that way everywhere else.
 	 * {@link DrugReference#containsWord} is exactly what separates {@code Levoketoconazole} from
@@ -610,9 +609,11 @@ public final class DrugReferenceValidity {
 	 * <p><b>Both conditions exclude a shape that is CORRECT</b>, which is what keeps this off the list of
 	 * channels operators filter:
 	 * <ul>
-	 *   <li>the family must hold more than one row — a lone row claiming a substance name confuses
-	 *       nothing, and its wrong {@code rxnorm_name} is the shape issue #196 records as undetectable
-	 *       from inside the file;</li>
+	 *   <li>the family must hold a row the derivative could have been merged WITH — one that is not
+	 *       itself a derivative of the same claim ({@link #holdsAParent}). That excludes both a lone row
+	 *       claiming a substance name, which confuses nothing and whose wrong {@code rxnorm_name} is the
+	 *       shape issue #196 records as undetectable from inside the file, and a derivative the module
+	 *       has correctly kept APART from its parent that has route variants of its OWN;</li>
 	 *   <li>the name must carry the substance's own name as a bounded WORD to be excluded, so every
 	 *       presentation, salt and ester stays silent — and so does every second NAME for one
 	 *       substance, which carries it neither as a word nor as a substring. That exclusion is the
@@ -624,8 +625,22 @@ public final class DrugReferenceValidity {
 	 *       rule would report 13 rows of which 12 are correct data.</li>
 	 * </ul>
 	 * Folded through {@link DrugReference#foldDiacritics} before the substring half so that half and
-	 * {@link DrugReference#containsWord} read the same alphabet; a fold on one side only would let a
-	 * diacritic decide which of the two answers a row gets.
+	 * {@link DrugReference#containsWord} read the same alphabet; unfolded, a localized dataset would be
+	 * quieter about a real merge than an ASCII one. No shipped row can witness that — measured
+	 * 2026-08-13, none of the 2283 carries a non-ASCII character in {@code name} or {@code rxnorm_name}
+	 * — so {@code ddi-derivative-localized-name.json} is hand-authored and says so.
+	 *
+	 * <p><b>Which datasets this can fire on at all.</b> It needs a family of more than one row to hold a
+	 * derivative, so it needs {@link DrugReference#substanceKey()} to be non-null and shared, and what
+	 * supplies that differs per format. The {@code atc} adapter publishes no substance name, so every
+	 * row is its own family and the rule is vacuous there. The {@code ddinter} adapter publishes the
+	 * registry that keys a derivative WITH ITS PARENT, which is the shipped case. A curated
+	 * {@code json} file falls back to the display STEM — so it cannot key a derivative with its parent,
+	 * whose stem differs by construction, but it can key one with its own qualifier variant
+	 * ({@code Fluoroestradiol f-18} and {@code Fluoroestradiol f-18 (suspension)} both declaring
+	 * {@code substanceName: estradiol}), which is the shape {@code drug-reference-charted-substance-row}
+	 * already ships for {@code Amoxicillin}. So the rule is not {@code ddinter}-only; what is
+	 * {@code ddinter}-only is the derivative-and-parent merge it was written for.
 	 *
 	 * <p><b>REPORTED.</b> Splitting the rows would be inventing the fact the data is missing — the
 	 * loader cannot tell a derivative that is a different substance from one the registry would confirm
@@ -652,7 +667,7 @@ public final class DrugReferenceValidity {
 		int merged = 0;
 		Set<String> details = new LinkedHashSet<String>();
 		for (List<DrugReference> rows : bySubstance.values()) {
-			if (rows.size() < 2) {
+			if (!holdsAParent(rows)) {
 				continue;
 			}
 			for (DrugReference row : rows) {
@@ -661,7 +676,7 @@ public final class DrugReferenceValidity {
 				}
 				merged++;
 				details.add(row.getName() + " is filed as '" + row.getSubstanceName() + "' beside "
-						+ namesOfOthers(rows, row));
+						+ sample(namesOfOthers(rows, row)));
 			}
 		}
 		if (merged > 0) {
@@ -669,9 +684,11 @@ public final class DrugReferenceValidity {
 					merged + " row(s) are keyed as ONE substance with rows their own name says they only "
 							+ "DERIVE from, so a chip, a record or a citation about the substance can be "
 							+ "named after the derivative and carry its rules. The data is left as loaded "
-							+ "— the fix is in the dataset, which has to give the derivative row its own "
-							+ "substance registry id (the rows this module already keeps apart are kept "
-							+ "apart by exactly that). " + sample(details));
+							+ "— the fix is in the dataset, which has to stop filing the derivative under "
+							+ "the parent's substance: in a DDInter-shaped file by giving it its own "
+							+ "drugbank_id, which is what keeps every derivative this module already "
+							+ "separates apart, and in a curated file by giving it its own substanceName. "
+							+ sample(details));
 		}
 	}
 
@@ -712,16 +729,46 @@ public final class DrugReferenceValidity {
 	 *         because there are three answers, and {@link DrugReference#containsWord} rules out two of
 	 *         them at once — the stem that IS the substance name (a row of it, {@code Estradiol}) and
 	 *         the stem that carries it as a WORD (a presentation, salt or ester of it,
-	 *         {@code Beclomethasone dipropionate} under {@code beclomethasone}); it is false for the
-	 *         empty stem too, so the total key
-	 *         {@link DrugReference#displayStem} is documented to return needs no guard of its own. What
-	 *         the substring test then rules out is the third: a stem not carrying the name at all is a
-	 *         second NAME for the substance, which issue #164 measured as one substance
-	 *         ({@code Daxibotulinumtoxina}). Only what survives both is a derivative.
+	 *         {@code Beclomethasone dipropionate} under {@code beclomethasone}). What the substring test
+	 *         then rules out is the third: a stem not carrying the name at all is a second NAME for the
+	 *         substance, which issue #164 measured as one substance ({@code Daxibotulinumtoxina}). It is
+	 *         also what keeps the total key {@link DrugReference#displayStem} is documented to return
+	 *         silent — the empty stem carries nothing — which the first test would not, since
+	 *         {@link DrugReference#containsWord} is false there and false is this predicate's REPORTING
+	 *         direction. Only what survives both is a derivative.
+	 *
+	 *         <p>Gated on the substance name being a name at all, through this class's own
+	 *         {@link #namesAnything}: a token of nothing but combining marks is non-blank to
+	 *         {@link DrugReference#normalizeName} and folds to EMPTY, and the two tests then disagree
+	 *         about it — {@code containsWord} refuses an empty token while {@code contains("")} accepts
+	 *         every stem — so every row of such a family would be reported. That is the one way these
+	 *         two halves can read different alphabets, and it fails OPEN, which is the direction this
+	 *         class does not accept.
 	 */
+	/**
+	 * @return whether {@code rows} holds a row the derivatives among them could have been merged WITH:
+	 *         one that is not itself a derivative of the substance they all claim. This is the family
+	 *         gate, and a size check is not it — a derivative the module has correctly kept APART from
+	 *         its parent still forms a family with its OWN route variants, and reporting those states a
+	 *         merge that never happened. {@code Levoketoconazole} carries its own DrugBank id against
+	 *         {@code Ketoconazole}'s, so the family's id is withheld and the keys fall to the display
+	 *         stem — which puts {@code Levoketoconazole} and a {@code (oral)} variant of it in one
+	 *         family with no parent in it, and without this gate both are reported, each naming the
+	 *         other. Measured through this rule on {@code ddi-derivative-rule-edges.json}: 3
+	 *         occurrences without the gate, 1 with it.
+	 */
+	private static boolean holdsAParent(List<DrugReference> rows) {
+		for (DrugReference row : rows) {
+			if (!derivesFromItsOwnSubstance(row)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private static boolean derivesFromItsOwnSubstance(DrugReference row) {
 		String substance = DrugReference.normalizeName(row.getSubstanceName());
-		if (substance == null) {
+		if (substance == null || !namesAnything(substance)) {
 			return false;
 		}
 		String stem = DrugReference.displayStem(row.getName());
@@ -730,15 +777,20 @@ public final class DrugReferenceValidity {
 	}
 
 	/** @return the display names of the other rows of one substance, for a finding that has to say what
-	 *          a row was merged WITH. */
-	private static String namesOfOthers(List<DrugReference> rows, DrugReference row) {
-		List<String> others = new ArrayList<String>(rows.size() - 1);
+	 *          a row was merged WITH. Handed to {@link #sample} by the caller rather than joined here,
+	 *          so one report's bound covers the occurrences AND the names inside each of them: a
+	 *          mis-keyed family can be as large as the dataset, and an unbounded list nested inside a
+	 *          bounded one is the same log line {@link #DETAIL_SAMPLE} exists to prevent. The whole set
+	 *          is still built — the bound is on what is EMITTED, not on what is collected, because
+	 *          {@link #sample}'s "and N more" has to count the ones it does not name. */
+	private static Set<String> namesOfOthers(List<DrugReference> rows, DrugReference row) {
+		Set<String> others = new LinkedHashSet<String>();
 		for (DrugReference other : rows) {
 			if (other != row) {
 				others.add(other.getName());
 			}
 		}
-		return others.toString();
+		return others;
 	}
 
 	/** @return whether either entry's display stem carries the other's as a word — the relationship a

--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidity.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidity.java
@@ -33,8 +33,8 @@ import org.slf4j.Logger;
  * line that may belong to a previous load. Those covered the COUNT. Every rule below is that same
  * principle applied one layer deeper, to the CONTENT: a dataset can load a plausible number of entries
  * and still violate an assumption that silently changes every safety decision taken from it (#150), drop
- * every rule-bearing row of a substance (#211), be a different dataset than the one configured (#156), or
- * publish one substance's name on another (#196).
+ * every rule-bearing row of a substance (#211), be a different dataset than the one configured (#156),
+ * publish one substance's name on another, or key two substances as one (#196).
  *
  * <p><b>Why the remedies differ per rule, deliberately.</b> Making them uniform would be a decision taken
  * by default. Each rule below records which of the three it takes and why:
@@ -89,6 +89,11 @@ public final class DrugReferenceValidity {
 
 	/** An entry publishing, among its own names, a name a different substance is called — issue #196. */
 	public static final String ALIAS_NAMES_ANOTHER_SUBSTANCE = "alias-names-another-substance";
+
+	/** A row the data merged into a substance its OWN name says it is only a derivative of — issue
+	 *  #196 item 4. */
+	public static final String DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE =
+			"derivative-merged-with-its-parent-substance";
 
 	/** An explicitly configured dataset file that could not be read, so a different dataset is in
 	 *  force — issue #156, case 1. */
@@ -290,6 +295,7 @@ public final class DrugReferenceValidity {
 		sanitizeAliases(entries);
 		reportRulesWithoutASubstanceIdentity(entries);
 		reportAliasesNamingAnotherSubstance(entries);
+		reportDerivativesMergedWithTheirParent(entries);
 	}
 
 	/**
@@ -568,6 +574,107 @@ public final class DrugReferenceValidity {
 		}
 	}
 
+	/**
+	 * The check for issue #196 item 4: a row the dataset merged into a substance its OWN name says it
+	 * is only a DERIVATIVE of.
+	 *
+	 * <p><b>Why the rule above cannot see this, structurally.</b>
+	 * {@link #reportAliasesNamingAnotherSubstance} reports a published name denoting a DIFFERENT
+	 * substance, and its first exclusion is that the two entries key alike — so where the merge itself
+	 * is the defect there is no different substance left for it to find. The shipped case:
+	 * {@code Fluoroestradiol f-18} publishes {@code rxnorm_name: estradiol} and carries no
+	 * {@code drugbank_id}, so {@link DdiDrugReferenceSource}'s per-family resolution hands it
+	 * {@code Estradiol}'s {@code DB00783} and a PET imaging tracer and a therapeutic oestrogen become one
+	 * substance to {@link DrugReference#substanceKey()}. Measured over the shipped 19 MB KB 2026-08-13 by
+	 * driving {@link DrugReferenceService#getLoadStatus()} over it: that rule fires 18 times and this row
+	 * is in none of them.
+	 *
+	 * <p><b>The criterion, and why it is not "one substance, unlike names".</b> That broader predicate was
+	 * measured first — {@link DrugReference#substanceGroupKey()} over the shipped KB, then
+	 * {@link DrugReference#displayStem}/{@link DrugReference#containsWord} between each family's rows —
+	 * and it fires on 15 rows across 8 families, most of them merges issue #164 measured as CORRECT:
+	 * {@code Daxibotulinumtoxina} with {@code Botulinum toxin type A}, {@code Pfizer-BioNTech Covid-19
+	 * Vaccine} with {@code Tozinameran}, {@code Ga 68 psma-11} with {@code Gallium Ga-68 gozetotide}. A
+	 * rule reporting those would tell an operator that this module's own correct behaviour is a data
+	 * defect. So the criterion is the relationship the row's own NAME states rather than the absence of
+	 * one: a name that carries the substance's name WITHOUT a word boundary is a derivative — fluoro-,
+	 * levo-, dex-, es-, nor- — and this module already reads it that way everywhere else.
+	 * {@link DrugReference#containsWord} is exactly what separates {@code Levoketoconazole} from
+	 * {@code Ketoconazole} and {@code Esomeprazole} from {@code Omeprazole} in every matcher here. So the
+	 * dataset's registry is contradicting the module's own name rule, and it is the registry's silence
+	 * that let it: those two pairs are kept apart only because each derivative carries its OWN DrugBank
+	 * id, which withholds the family's id and drops the verdict to the display stem (issue #164). This
+	 * rule is the residue of that mechanism — the merges that survived because the derivative row named
+	 * no substance at all.
+	 *
+	 * <p><b>Both conditions exclude a shape that is CORRECT</b>, which is what keeps this off the list of
+	 * channels operators filter:
+	 * <ul>
+	 *   <li>the family must hold more than one row — a lone row claiming a substance name confuses
+	 *       nothing, and its wrong {@code rxnorm_name} is the shape issue #196 records as undetectable
+	 *       from inside the file;</li>
+	 *   <li>the name must carry the substance's own name as a bounded WORD to be excluded, so every
+	 *       presentation, salt and ester stays silent — and so does every second NAME for one
+	 *       substance, which carries it neither as a word nor as a substring. That exclusion is the
+	 *       load-bearing half: measured over the shipped KB, <b>12</b> rows are silent only because of
+	 *       it, every one inspected an ester, a salt or a preparation
+	 *       ({@code Beclomethasone dipropionate} under {@code beclomethasone},
+	 *       {@code Estrone sulfate} under {@code estrone}, the four
+	 *       {@code Human immunoglobulin G} routes under {@code immunoglobulin g}), so without it this
+	 *       rule would report 13 rows of which 12 are correct data.</li>
+	 * </ul>
+	 * Folded through {@link DrugReference#foldDiacritics} before the substring half so that half and
+	 * {@link DrugReference#containsWord} read the same alphabet; a fold on one side only would let a
+	 * diacritic decide which of the two answers a row gets.
+	 *
+	 * <p><b>REPORTED.</b> Splitting the rows would be inventing the fact the data is missing — the
+	 * loader cannot tell a derivative that is a different substance from one the registry would confirm
+	 * is the same, which is the judgement issues #164 and #192 measured this module must not make — and
+	 * dropping the row would lose real interaction rules (the tracer carries four of its own). Both fail
+	 * closed, silently, to fix a fail-loud. The fix is a substance registry id on the derivative row, and
+	 * this is the check that finds the rows to hand upstream.
+	 *
+	 * <p>Measured over the shipped 19 MB KB 2026-08-13, by this method through
+	 * {@link DrugReferenceService#getLoadStatus()}: <b>one</b> row, {@code Fluoroestradiol f-18}.
+	 * Re-measure before relying on the figure.
+	 */
+	private void reportDerivativesMergedWithTheirParent(List<DrugReference> entries) {
+		Map<Object, List<DrugReference>> bySubstance = new LinkedHashMap<Object, List<DrugReference>>();
+		for (DrugReference entry : entries) {
+			Object key = entry.substanceGroupKey();
+			List<DrugReference> rows = bySubstance.get(key);
+			if (rows == null) {
+				rows = new ArrayList<DrugReference>(2);
+				bySubstance.put(key, rows);
+			}
+			rows.add(entry);
+		}
+		int merged = 0;
+		Set<String> details = new LinkedHashSet<String>();
+		for (List<DrugReference> rows : bySubstance.values()) {
+			if (rows.size() < 2) {
+				continue;
+			}
+			for (DrugReference row : rows) {
+				if (!derivesFromItsOwnSubstance(row)) {
+					continue;
+				}
+				merged++;
+				details.add(row.getName() + " is filed as '" + row.getSubstanceName() + "' beside "
+						+ namesOfOthers(rows, row));
+			}
+		}
+		if (merged > 0) {
+			report(DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE, Remedy.REPORTED, merged,
+					merged + " row(s) are keyed as ONE substance with rows their own name says they only "
+							+ "DERIVE from, so a chip, a record or a citation about the substance can be "
+							+ "named after the derivative and carry its rules. The data is left as loaded "
+							+ "— the fix is in the dataset, which has to give the derivative row its own "
+							+ "substance registry id (the rows this module already keeps apart are kept "
+							+ "apart by exactly that). " + sample(details));
+		}
+	}
+
 	// ------------------------------------------------------------------
 	// Predicates
 	// ------------------------------------------------------------------
@@ -597,6 +704,41 @@ public final class DrugReferenceValidity {
 	private static boolean carriesRules(DrugReference entry) {
 		return !entry.getInteractions().isEmpty() || !entry.getContraindications().isEmpty()
 				|| !entry.getAgeBands().isEmpty();
+	}
+
+	/**
+	 * @return whether this row's display stem names a DERIVATIVE of the substance the data filed it
+	 *         under: it carries that substance's name, and not as a bounded word. Two conditions
+	 *         because there are three answers, and {@link DrugReference#containsWord} rules out two of
+	 *         them at once — the stem that IS the substance name (a row of it, {@code Estradiol}) and
+	 *         the stem that carries it as a WORD (a presentation, salt or ester of it,
+	 *         {@code Beclomethasone dipropionate} under {@code beclomethasone}); it is false for the
+	 *         empty stem too, so the total key
+	 *         {@link DrugReference#displayStem} is documented to return needs no guard of its own. What
+	 *         the substring test then rules out is the third: a stem not carrying the name at all is a
+	 *         second NAME for the substance, which issue #164 measured as one substance
+	 *         ({@code Daxibotulinumtoxina}). Only what survives both is a derivative.
+	 */
+	private static boolean derivesFromItsOwnSubstance(DrugReference row) {
+		String substance = DrugReference.normalizeName(row.getSubstanceName());
+		if (substance == null) {
+			return false;
+		}
+		String stem = DrugReference.displayStem(row.getName());
+		return !DrugReference.containsWord(stem, substance)
+				&& DrugReference.foldDiacritics(stem).contains(DrugReference.foldDiacritics(substance));
+	}
+
+	/** @return the display names of the other rows of one substance, for a finding that has to say what
+	 *          a row was merged WITH. */
+	private static String namesOfOthers(List<DrugReference> rows, DrugReference row) {
+		List<String> others = new ArrayList<String>(rows.size() - 1);
+		for (DrugReference other : rows) {
+			if (other != row) {
+				others.add(other.getName());
+			}
+		}
+		return others.toString();
 	}
 
 	/** @return whether either entry's display stem carries the other's as a word — the relationship a

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
@@ -60,6 +60,9 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 	private static final String ALIAS_NAMES_ANOTHER_SUBSTANCE_FIXTURE =
 			"chartsearchai-test/ddi-alias-names-another-substance.json";
 
+	private static final String DERIVATIVE_MERGED_FIXTURE =
+			"chartsearchai-test/ddi-derivative-merged-into-one-substance.json";
+
 	private final List<File> created = new ArrayList<File>();
 
 	@AfterEach
@@ -104,6 +107,19 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		}
 		throw new AssertionError("no finding for rule '" + rule + "' — findings were: "
 				+ status.getFindings());
+	}
+
+	/** @return the loaded row with exactly this display name — for a case that has to compare two named
+	 *          rows of one fixture, which no production accessor answers (they all resolve a string to a
+	 *          SET of rows, which is the question being asked ABOUT here). */
+	private static DrugReference rowNamed(DrugReferenceService service, String name) {
+		for (DrugReference entry : service.getAll()) {
+			if (name.equals(entry.getName())) {
+				return entry;
+			}
+		}
+		throw new AssertionError("no loaded row named '" + name + "' — loaded: "
+				+ DrugReferenceTestSupport.names(service.getAll()));
 	}
 
 	private static List<String> rulesOf(DrugReferenceLoad status) {
@@ -335,6 +351,84 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 						+ "which issue #164 decided is one substance. Detail was: " + found.getDetail());
 
 		assertEquals(9, service.getAll().size(), "every row is still loaded; nothing was dropped");
+	}
+
+	/**
+	 * Issue #196 item 4, over a verbatim slice of the shipped 19 MB knowledge base. The rule above
+	 * cannot see this one and never could: it reports a published name denoting a DIFFERENT substance,
+	 * and here the two rows are the SAME substance to {@link DrugReference#substanceGroupKey()}, so its
+	 * first exclusion removes the case by construction. Measured on the shipped file 2026-08-13 by
+	 * driving {@link DrugReferenceService#getLoadStatus()} over it: {@code alias-names-another-substance}
+	 * fires 18 times and {@code Fluoroestradiol f-18} is in none of them.
+	 *
+	 * <p>The five controls are the point of the case. A rule keyed on "one substance, unlike names"
+	 * would report {@code Daxibotulinumtoxina} — a merge issue #164 measured as CORRECT — so this one is
+	 * keyed on the derivative relationship the row's OWN name states, and
+	 * {@code Beclomethasone dipropionate (nasal)} is the control that separates the two: same inherited
+	 * identity as the tracer, name extending the substance's by a word rather than embedding it.
+	 *
+	 * <p>The loaded-row count is asserted rather than assumed: a {@code ddi} document that parses to
+	 * nothing does so in silence (issue #242), and a rule-count assertion over an empty load passes
+	 * vacuously.
+	 */
+	@Test
+	public void aDerivativeMergedIntoItsParentSubstanceIsReportedAndTheDataIsLeftAlone()
+			throws IOException {
+		DrugReferenceService service = loading(DERIVATIVE_MERGED_FIXTURE, "h196-item4-slice.json",
+				ChartSearchAiConstants.DRUG_REFERENCE_SOURCE_DDINTER);
+
+		DrugReferenceLoad status;
+		try (LogCapture capture = LogCapture.on(DrugReferenceTestSupport.REFERENCE_LOGGER)) {
+			status = service.getLoadStatus();
+			assertTrue(capture.hasEventAtOrAbove(Level.WARN),
+					"a PET tracer and a therapeutic oestrogen keyed as one substance is exactly the "
+							+ "content defect this check exists to be loud about. Captured: "
+							+ capture.describeAll());
+		}
+
+		DrugReferenceValidity.Finding found = finding(status,
+				DrugReferenceValidity.DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE);
+		assertEquals(DrugReferenceValidity.Remedy.REPORTED, found.getRemedy());
+		assertEquals(1, found.getOccurrences(),
+				"exactly the one merge in this slice, and not the five controls beside it. Detail was: "
+						+ found.getDetail());
+		assertTrue(found.getDetail().contains("Fluoroestradiol f-18")
+				&& found.getDetail().contains("estradiol"),
+				"item 4: the tracer, and the substance it was merged into. Detail was: "
+						+ found.getDetail());
+		assertFalse(found.getDetail().contains("Beclomethasone dipropionate (nasal) is filed as"),
+				"the closest control there is — a row with no drugbank_id of its own inheriting its "
+						+ "family's, exactly as the tracer does, but whose name extends the substance "
+						+ "name by a WORD. Only containsWord keeps it silent, and 12 rows of the shipped "
+						+ "KB are silent for that reason. Detail was: " + found.getDetail());
+		// Asked as "not the SUBJECT of an occurrence" rather than "absent", because this control is a row
+		// of the offending row's own family and the detail names those deliberately — an operator needs
+		// to know what the derivative was merged WITH. The three controls below are each their own
+		// single-row family, so they cannot appear in any position, and absence is the stricter claim.
+		assertFalse(found.getDetail().contains("Estradiol (topical) is filed as"),
+				"the control a route variant is: its stem IS the substance name, so it is a "
+						+ "presentation rather than a derivative. Detail was: " + found.getDetail());
+		assertFalse(found.getDetail().contains("Levoketoconazole"),
+				"the control the merge gate excludes — the identical prefix-derivative shape, but the "
+						+ "family names two DrugBank substances, so the id is withheld and the display "
+						+ "stem already separates them. Detail was: " + found.getDetail());
+		assertFalse(found.getDetail().contains("Daxibotulinumtoxina"),
+				"the control that makes this rule narrower than 'one substance, unlike names': issue "
+						+ "#164 measured that merge as correct. Detail was: " + found.getDetail());
+		assertFalse(found.getDetail().contains("Ospemifene"),
+				"an unrelated partner is not a derivative of anything here. Detail was: "
+						+ found.getDetail());
+
+		assertEquals(11, service.getAll().size(), "every row is still loaded; nothing was dropped");
+		assertEquals(rowNamed(service, "Estradiol").substanceGroupKey(),
+				rowNamed(service, "Fluoroestradiol f-18").substanceGroupKey(),
+				"and nothing was repaired: the two rows are still one substance, because deciding they "
+						+ "are two would be inventing a fact the data does not carry");
+
+		assertTrue(rulesOf(status).contains(DrugReferenceValidity.ALIAS_NAMES_ANOTHER_SUBSTANCE),
+				"the sibling rule still fires on this slice — Levoketoconazole publishes 'ketoconazole' "
+						+ "— which is what shows the two rules answer different questions about the same "
+						+ "row. Rules were: " + rulesOf(status));
 	}
 
 	// ------------------------------------------------------------------

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
@@ -399,8 +399,8 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 						+ "KB are silent for that reason. Detail was: " + found.getDetail());
 		// Asked as "not the SUBJECT of an occurrence" rather than "absent", because this control is a row
 		// of the offending row's own family and the detail names those deliberately — an operator needs
-		// to know what the derivative was merged WITH. The three controls below are each their own
-		// single-row family, so they cannot appear in any position, and absence is the stricter claim.
+		// to know what the derivative was merged WITH. Daxibotulinumtoxina is in a two-row family of its
+		// own and can appear the same way; Levoketoconazole and Ospemifene are singletons and cannot.
 		assertFalse(found.getDetail().contains("Estradiol (topical) is filed as"),
 				"the control a route variant is: its stem IS the substance name, so it is a "
 						+ "presentation rather than a derivative. Detail was: " + found.getDetail());
@@ -416,10 +416,23 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 						+ found.getDetail());
 
 		assertEquals(11, service.getAll().size(), "every row is still loaded; nothing was dropped");
-		assertEquals(DrugReferenceTestSupport.row(service.getAll(), "Estradiol").substanceGroupKey(),
-				DrugReferenceTestSupport.row(service.getAll(), "Fluoroestradiol f-18").substanceGroupKey(),
+		List<DrugReference> all = service.getAll();
+		assertEquals(DrugReferenceTestSupport.row(all, "Estradiol").substanceGroupKey(),
+				DrugReferenceTestSupport.row(all, "Fluoroestradiol f-18").substanceGroupKey(),
 				"and nothing was repaired: the two rows are still one substance, because deciding they "
 						+ "are two would be inventing a fact the data does not carry");
+		// The two controls that need an identity, asserted rather than narrated: an assertFalse on a
+		// detail string cannot tell a control that is present and correctly silent from one that was
+		// removed from the fixture.
+		assertEquals(DrugReferenceTestSupport.row(all, "Botulinum toxin type A").substanceGroupKey(),
+				DrugReferenceTestSupport.row(all, "Daxibotulinumtoxina").substanceGroupKey(),
+				"the #164 merge this rule must not report is only a control while it IS a merge");
+		assertEquals(
+				DrugReferenceTestSupport.row(all, "Beclomethasone dipropionate").substanceGroupKey(),
+				DrugReferenceTestSupport.row(all, "Beclomethasone dipropionate (nasal)")
+						.substanceGroupKey(),
+				"and the ester control only isolates containsWord while the two rows are one substance "
+						+ "— the (nasal) row carries no drugbank_id of its own and inherits DB00394");
 
 		assertTrue(rulesOf(status).contains(DrugReferenceValidity.ALIAS_NAMES_ANOTHER_SUBSTANCE),
 				"the sibling rule still fires on this slice — Levoketoconazole publishes 'ketoconazole' "
@@ -439,11 +452,13 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 	 *       one. Measured over the shipped 19 MB KB: none of its 2283 rows carries a non-ASCII
 	 *       character in {@code name} or {@code rxnorm_name}, so this decision has no verbatim witness
 	 *       and the file says it is hand-authored.</li>
-	 *   <li><b>The one input the two halves can disagree about.</b> A substance name of nothing but
-	 *       combining marks is non-blank to {@code normalizeName} and folds to EMPTY, which
-	 *       {@code containsWord} refuses and {@code contains} accepts from every stem — so both rows of
-	 *       that family would be reported. It fails OPEN, which is why the gate is a guard and not a
-	 *       nicety.</li>
+	 *   <li><b>The one input the two halves can disagree about.</b> A substance name with no letter or
+	 *       digit is non-blank to {@code normalizeName}, and {@code containsWord} refuses it while
+	 *       {@code String.contains} finds it in whichever stems carry the character — so an
+	 *       {@code rxnorm_name} of {@code "-"} makes {@code Bupivacaine hcl-2} a "derivative" of
+	 *       {@code "-"} beside {@code Marcaine}. It fails OPEN, which is why the gate is a guard and
+	 *       not a nicety. A marks-only token is not this witness: it folds to empty, every row of the
+	 *       family then derives, and the parent gate silences it first.</li>
 	 *   <li><b>What "merged" means.</b> A derivative that the module has correctly kept APART from its
 	 *       parent, but which has a route variant of its own, is a family of two derivatives with no
 	 *       parent in it. Reporting those states a merge that never happened — so the rule requires a
@@ -467,13 +482,13 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 
 		DrugReferenceValidity.Finding found = finding(status,
 				DrugReferenceValidity.DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE);
-		assertEquals(1, found.getOccurrences(), "the localized derivative, and only it — not the two "
-				+ "rows whose substance name folds to nothing, and not the two route variants of a "
-				+ "derivative that has no parent in its family. Detail was: " + found.getDetail());
-		assertTrue(found.getDetail().contains("Fluoroestradiól f-18 is filed as"),
+		assertEquals(1, found.getOccurrences(), "the localized derivative, and only it — not the row "
+				+ "whose substance name names nothing, and not the two route variants of a derivative "
+				+ "that has no parent in its family. Detail was: " + found.getDetail());
+		assertTrue(found.getDetail().contains("Fluoroestradiól f-18 is filed as '"),
 				"the accented display name is the row reported. Detail was: " + found.getDetail());
-		assertFalse(found.getDetail().contains("Marcaine") || found.getDetail().contains("Sensorcaine"),
-				"a substance name that folds to nothing names nothing, so no row derives from it. "
+		assertFalse(found.getDetail().contains("Bupivacaine hcl-2"),
+				"a substance name with no letter or digit names nothing, so no row derives from it. "
 						+ "Detail was: " + found.getDetail());
 		assertFalse(found.getDetail().contains("Levoketoconazole"),
 				"the module kept this derivative apart from Ketoconazole exactly as designed; its two "

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
@@ -63,6 +63,9 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 	private static final String DERIVATIVE_MERGED_FIXTURE =
 			"chartsearchai-test/ddi-derivative-merged-into-one-substance.json";
 
+	private static final String DERIVATIVE_RULE_EDGES_FIXTURE =
+			"chartsearchai-test/ddi-derivative-rule-edges.json";
+
 	private final List<File> created = new ArrayList<File>();
 
 	@AfterEach
@@ -107,19 +110,6 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		}
 		throw new AssertionError("no finding for rule '" + rule + "' — findings were: "
 				+ status.getFindings());
-	}
-
-	/** @return the loaded row with exactly this display name — for a case that has to compare two named
-	 *          rows of one fixture, which no production accessor answers (they all resolve a string to a
-	 *          SET of rows, which is the question being asked ABOUT here). */
-	private static DrugReference rowNamed(DrugReferenceService service, String name) {
-		for (DrugReference entry : service.getAll()) {
-			if (name.equals(entry.getName())) {
-				return entry;
-			}
-		}
-		throw new AssertionError("no loaded row named '" + name + "' — loaded: "
-				+ DrugReferenceTestSupport.names(service.getAll()));
 	}
 
 	private static List<String> rulesOf(DrugReferenceLoad status) {
@@ -380,7 +370,11 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		DrugReferenceLoad status;
 		try (LogCapture capture = LogCapture.on(DrugReferenceTestSupport.REFERENCE_LOGGER)) {
 			status = service.getLoadStatus();
-			assertTrue(capture.hasEventAtOrAbove(Level.WARN),
+			// Asked of THIS rule's line, not of any WARN: the slice deliberately fires the sibling rule
+			// too (asserted below), and logTo logs every finding, so hasEventAtOrAbove(WARN) is
+			// satisfied by that line alone and stays green with this rule deleted outright.
+			assertTrue(capture.messagesAt(Level.WARN).stream().anyMatch(
+					m -> m.contains(DrugReferenceValidity.DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE)),
 					"a PET tracer and a therapeutic oestrogen keyed as one substance is exactly the "
 							+ "content defect this check exists to be loud about. Captured: "
 							+ capture.describeAll());
@@ -392,10 +386,12 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		assertEquals(1, found.getOccurrences(),
 				"exactly the one merge in this slice, and not the five controls beside it. Detail was: "
 						+ found.getDetail());
-		assertTrue(found.getDetail().contains("Fluoroestradiol f-18")
-				&& found.getDetail().contains("estradiol"),
-				"item 4: the tracer, and the substance it was merged into. Detail was: "
-						+ found.getDetail());
+		// One string, not two `contains` calls: "estradiol" is a substring of "Fluoroestradiol f-18", so
+		// a second conjunct asking for it separately is true whenever the first is and asserts nothing.
+		assertTrue(found.getDetail().contains("Fluoroestradiol f-18 is filed as 'estradiol' beside "
+				+ "[Estradiol, Estradiol (topical)]"),
+				"item 4: the tracer, the substance it was merged into, and the rows it was merged with. "
+						+ "Detail was: " + found.getDetail());
 		assertFalse(found.getDetail().contains("Beclomethasone dipropionate (nasal) is filed as"),
 				"the closest control there is — a row with no drugbank_id of its own inheriting its "
 						+ "family's, exactly as the tracer does, but whose name extends the substance "
@@ -420,8 +416,8 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 						+ found.getDetail());
 
 		assertEquals(11, service.getAll().size(), "every row is still loaded; nothing was dropped");
-		assertEquals(rowNamed(service, "Estradiol").substanceGroupKey(),
-				rowNamed(service, "Fluoroestradiol f-18").substanceGroupKey(),
+		assertEquals(DrugReferenceTestSupport.row(service.getAll(), "Estradiol").substanceGroupKey(),
+				DrugReferenceTestSupport.row(service.getAll(), "Fluoroestradiol f-18").substanceGroupKey(),
 				"and nothing was repaired: the two rows are still one substance, because deciding they "
 						+ "are two would be inventing a fact the data does not carry");
 
@@ -429,6 +425,60 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 				"the sibling rule still fires on this slice — Levoketoconazole publishes 'ketoconazole' "
 						+ "— which is what shows the two rules answer different questions about the same "
 						+ "row. Rules were: " + rulesOf(status));
+	}
+
+	/**
+	 * The three edges of that rule the shipped file cannot reach, in one hand-authored dataset. Each is
+	 * a decision the shipped case leaves untested, and each fails in a direction the other cases would
+	 * not show.
+	 * <ul>
+	 *   <li><b>The fold.</b> Both conditions have to read one alphabet, so the substring test folds
+	 *       diacritics exactly as {@link DrugReference#containsWord} already does. Unfolded,
+	 *       {@code Fluoroestradiól f-18} carries {@code estradiol} neither as a bounded word nor as a
+	 *       raw substring, so a localized dataset would be quieter about a real merge than an ASCII
+	 *       one. Measured over the shipped 19 MB KB: none of its 2283 rows carries a non-ASCII
+	 *       character in {@code name} or {@code rxnorm_name}, so this decision has no verbatim witness
+	 *       and the file says it is hand-authored.</li>
+	 *   <li><b>The one input the two halves can disagree about.</b> A substance name of nothing but
+	 *       combining marks is non-blank to {@code normalizeName} and folds to EMPTY, which
+	 *       {@code containsWord} refuses and {@code contains} accepts from every stem — so both rows of
+	 *       that family would be reported. It fails OPEN, which is why the gate is a guard and not a
+	 *       nicety.</li>
+	 *   <li><b>What "merged" means.</b> A derivative that the module has correctly kept APART from its
+	 *       parent, but which has a route variant of its own, is a family of two derivatives with no
+	 *       parent in it. Reporting those states a merge that never happened — so the rule requires a
+	 *       row that is not a derivative, and a size check alone is not that.</li>
+	 * </ul>
+	 */
+	@Test
+	public void theRuleHoldsAtItsThreeEdges() throws IOException {
+		DrugReferenceService service = loading(DERIVATIVE_RULE_EDGES_FIXTURE, "h196-item4-edges.json",
+				ChartSearchAiConstants.DRUG_REFERENCE_SOURCE_DDINTER);
+
+		DrugReferenceLoad status;
+		try (LogCapture capture = LogCapture.on(DrugReferenceTestSupport.REFERENCE_LOGGER)) {
+			status = service.getLoadStatus();
+			assertTrue(capture.messagesAt(Level.WARN).stream().anyMatch(
+					m -> m.contains(DrugReferenceValidity.DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE)),
+					"a localized dataset is not a quieter one. Captured: " + capture.describeAll());
+		}
+		assertEquals(8, service.getAll().size(), "a ddi document that parses to nothing does so in "
+				+ "silence (issue #242), and every assertion below would then pass vacuously");
+
+		DrugReferenceValidity.Finding found = finding(status,
+				DrugReferenceValidity.DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE);
+		assertEquals(1, found.getOccurrences(), "the localized derivative, and only it — not the two "
+				+ "rows whose substance name folds to nothing, and not the two route variants of a "
+				+ "derivative that has no parent in its family. Detail was: " + found.getDetail());
+		assertTrue(found.getDetail().contains("Fluoroestradiól f-18 is filed as"),
+				"the accented display name is the row reported. Detail was: " + found.getDetail());
+		assertFalse(found.getDetail().contains("Marcaine") || found.getDetail().contains("Sensorcaine"),
+				"a substance name that folds to nothing names nothing, so no row derives from it. "
+						+ "Detail was: " + found.getDetail());
+		assertFalse(found.getDetail().contains("Levoketoconazole"),
+				"the module kept this derivative apart from Ketoconazole exactly as designed; its two "
+						+ "rows are route variants of the derivative itself, and nothing was merged. "
+						+ "Detail was: " + found.getDetail());
 	}
 
 	// ------------------------------------------------------------------

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
@@ -351,7 +351,7 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 	 * driving {@link DrugReferenceService#getLoadStatus()} over it: {@code alias-names-another-substance}
 	 * fires 18 times and {@code Fluoroestradiol f-18} is in none of them.
 	 *
-	 * <p>The five controls are the point of the case. A rule keyed on "one substance, unlike names"
+	 * <p>The six controls are the point of the case. A rule keyed on "one substance, unlike names"
 	 * would report {@code Daxibotulinumtoxina} — a merge issue #164 measured as CORRECT — so this one is
 	 * keyed on the derivative relationship the row's OWN name states, and
 	 * {@code Beclomethasone dipropionate (nasal)} is the control that separates the two: same inherited
@@ -384,7 +384,7 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 				DrugReferenceValidity.DERIVATIVE_MERGED_WITH_ITS_PARENT_SUBSTANCE);
 		assertEquals(DrugReferenceValidity.Remedy.REPORTED, found.getRemedy());
 		assertEquals(1, found.getOccurrences(),
-				"exactly the one merge in this slice, and not the five controls beside it. Detail was: "
+				"exactly the one merge in this slice, and not the six controls beside it. Detail was: "
 						+ found.getDetail());
 		// One string, not two `contains` calls: "estradiol" is a substring of "Fluoroestradiol f-18", so
 		// a second conjunct asking for it separately is true whenever the first is and asserts nothing.
@@ -395,8 +395,15 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		assertFalse(found.getDetail().contains("Beclomethasone dipropionate (nasal) is filed as"),
 				"the closest control there is — a row with no drugbank_id of its own inheriting its "
 						+ "family's, exactly as the tracer does, but whose name extends the substance "
-						+ "name by a WORD. Only containsWord keeps it silent, and 12 rows of the shipped "
-						+ "KB are silent for that reason. Detail was: " + found.getDetail());
+						+ "name by a WORD. Detail was: " + found.getDetail());
+		// The control that isolates containsWord ON ITS OWN, and the only one that can: the two
+		// Beclomethasone rows share a display stem, so they answer the predicate alike and the parent
+		// gate silences that family whatever the word test does. Sodium oxybate's family has rows that
+		// carry `oxybate` as a word and rows that do not carry it at all, so it has a parent — and
+		// weakening containsWord to bare equality reports it.
+		assertFalse(found.getDetail().contains("Sodium oxybate is filed as"),
+				"a salt whose own name extends the substance name by a word is a salt, not a "
+						+ "derivative. Detail was: " + found.getDetail());
 		// Asked as "not the SUBJECT of an occurrence" rather than "absent", because this control is a row
 		// of the offending row's own family and the detail names those deliberately — an operator needs
 		// to know what the derivative was merged WITH. Daxibotulinumtoxina is in a two-row family of its
@@ -411,11 +418,7 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		assertFalse(found.getDetail().contains("Daxibotulinumtoxina"),
 				"the control that makes this rule narrower than 'one substance, unlike names': issue "
 						+ "#164 measured that merge as correct. Detail was: " + found.getDetail());
-		assertFalse(found.getDetail().contains("Ospemifene"),
-				"an unrelated partner is not a derivative of anything here. Detail was: "
-						+ found.getDetail());
-
-		assertEquals(11, service.getAll().size(), "every row is still loaded; nothing was dropped");
+		assertEquals(14, service.getAll().size(), "every row is still loaded; nothing was dropped");
 		List<DrugReference> all = service.getAll();
 		assertEquals(DrugReferenceTestSupport.row(all, "Estradiol").substanceGroupKey(),
 				DrugReferenceTestSupport.row(all, "Fluoroestradiol f-18").substanceGroupKey(),

--- a/api/src/test/resources/chartsearchai-test/ddi-derivative-merged-into-one-substance.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-derivative-merged-into-one-substance.json
@@ -1,0 +1,590 @@
+{
+  "metadata": {
+    "note": "Verbatim DDInter 2.0 slice for the load-time validity check on issue #196 item 4 - real shipped rows, unedited. ONE POSITIVE: Fluoroestradiol f-18 publishes rxnorm_name `estradiol` and no drugbank_id of its own, so the per-family resolution hands it Estradiol's DB00783 and a PET imaging tracer and a therapeutic oestrogen become ONE substance to substanceKey(). Its own name says otherwise - `fluoroestradiol` carries `estradiol` as a substring and NOT as a word, which is this module's own rule for a derivative being a different substance. FIVE CONTROLS that must NOT be reported, each excluding a shape that is correct: (1) Beclomethasone dipropionate (nasal) is the closest control there is - a row with no drugbank_id of its own inheriting DB00394 from its family, exactly as the tracer does - but its name extends the substance name `beclomethasone` by a WORD, which is what an ester or a salt legitimately looks like, so containsWord alone keeps it silent; 12 rows of the shipped KB are silent for that reason and every one inspected is an ester, a salt or a preparation. (2) Estradiol (topical) is a route variant of the positive's own family whose stem IS the substance name - a presentation, not a derivative. (3) Levoketoconazole is the identical prefix-derivative shape and carries its OWN drugbank_id (DB05667) against Ketoconazole's DB01026, so the family names two DrugBank substances, the id is withheld and the display stem already separates them - nothing is merged, so there is nothing to report. (4) Daxibotulinumtoxina and Botulinum toxin type A are one substance under two DISJOINT names, which issue #164 measured as a correct merge - this is the row a rule keyed on \"one substance, unlike names\" would flag, and it is why this rule is keyed on the derivative relationship instead. (5) Ospemifene and Bcg vaccine are the interaction partners that give every row here a rule, so no entry is rule-less and the load is not the parses-to-nothing-in-silence shape issue #242 records."
+  },
+  "mechanisms": {
+    "1985": {
+      "text": "The concurrent use of ospemifene with estrogens or other estrogen agonists/antagonists has not been evaluated. Safety and efficacy of this combination are unknown.",
+      "categories": [
+        "others"
+      ]
+    },
+    "3720": {
+      "text": "Azole antifungal agents may increase the plasma concentrations of estrogens and progestins. The mechanism is decreased clearance of the hormones due to inhibition of CYP450 3A4 activity by azole antifungals.",
+      "categories": [
+        "metabolism"
+      ]
+    },
+    "4988": {
+      "text": "Coadministration with potent inhibitors of CYP450 3A4 may increase the plasma concentrations of ospemifene, which is partially metabolized by the isoenzyme.",
+      "categories": [
+        "metabolism"
+      ]
+    },
+    "6406": {
+      "text": "Coadministration with potent inhibitors of CYP450 3A4 may increase the plasma concentrations of ospemifene, which is partially metabolized by the isoenzyme.",
+      "categories": [
+        "metabolism"
+      ]
+    },
+    "6747": {
+      "text": "Levoketoconazole can cause concentration-dependent, life-threatening prolongation of the QT interval.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    },
+    "6939": {
+      "text": "Coadministration of the radioactive diagnostic agent fluoroestradiol F 18 with drugs that block the estrogen receptor (ER), such as tamoxifen and fulvestrant, may reduce the uptake of fluoroestradiol F 18 into ER-positive tumors.",
+      "categories": [
+        "distribution"
+      ]
+    },
+    "7257": {
+      "text": "The effect of administering different botulinum neurotoxin serotypes concurrently or within several months of one another is unknown.  Excessive weakness may be exacerbated by another administration of botulinum toxin prior to the resolution of the effects of a previously administered botulinum toxin.",
+      "categories": [
+        "others"
+      ]
+    },
+    "7258": {
+      "text": "Azole antifungal agents may increase the plasma concentrations of estrogens and progestins.  The mechanism is decreased clearance of the hormones due to inhibition of CYP450 3A4 activity by azole antifungals.",
+      "categories": [
+        "metabolism"
+      ]
+    },
+    "7481": {
+      "text": "Administration of intravesical BCG during immunosuppressive corticosteroid therapy may be associated with a risk of disseminated infection due to enhanced replication of the BCG strain of Mycobacterium bovis in the presence of diminished immune competence.",
+      "categories": [
+        "synergistic_effect"
+      ]
+    }
+  },
+  "drugs": [
+    {
+      "id": "DDInter1008",
+      "name": "Ketoconazole",
+      "rxcui": "6135",
+      "rxnorm_name": "ketoconazole",
+      "drugbank_id": "DB01026",
+      "atc": [
+        "D01AC08",
+        "G01AF11",
+        "H02CA03",
+        "J02AB02"
+      ],
+      "ciel": [
+        {
+          "code": "78476",
+          "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ketoconazole"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1353",
+      "name": "Ospemifene",
+      "rxcui": "1370971",
+      "rxnorm_name": "ospemifene",
+      "drugbank_id": "DB04938",
+      "atc": [
+        "G03XC05"
+      ],
+      "ciel": []
+    },
+    {
+      "id": "DDInter168",
+      "name": "Beclomethasone dipropionate",
+      "rxcui": "1347",
+      "rxnorm_name": "beclomethasone",
+      "drugbank_id": "DB00394",
+      "atc": [
+        "A07EA07",
+        "D07AC15",
+        "R01AD01",
+        "R03BA01"
+      ],
+      "ciel": [
+        {
+          "code": "103335",
+          "uuid": "103335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Albuterol / beclomethasone"
+        },
+        {
+          "code": "169918",
+          "uuid": "6070c4ba-c62f-433b-9802-7c14a80a88a9",
+          "name": "Beclomethasone / formoterol"
+        },
+        {
+          "code": "71916",
+          "uuid": "71916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Beclomethasone"
+        },
+        {
+          "code": "71917",
+          "uuid": "71917AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Beclomethasone dipropionate"
+        },
+        {
+          "code": "71918",
+          "uuid": "71918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Beclomethasone dipropionate monohydrate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter169",
+      "name": "Beclomethasone dipropionate (nasal)",
+      "rxcui": "1347",
+      "rxnorm_name": "beclomethasone",
+      "drugbank_id": null,
+      "atc": [
+        "A07EA07",
+        "D07AC15",
+        "R01AD01",
+        "R03BA01"
+      ],
+      "ciel": [
+        {
+          "code": "103335",
+          "uuid": "103335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Albuterol / beclomethasone"
+        },
+        {
+          "code": "169918",
+          "uuid": "6070c4ba-c62f-433b-9802-7c14a80a88a9",
+          "name": "Beclomethasone / formoterol"
+        },
+        {
+          "code": "71916",
+          "uuid": "71916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Beclomethasone"
+        },
+        {
+          "code": "71917",
+          "uuid": "71917AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Beclomethasone dipropionate"
+        },
+        {
+          "code": "71918",
+          "uuid": "71918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Beclomethasone dipropionate monohydrate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter1974",
+      "name": "Bcg vaccine",
+      "rxcui": "221050",
+      "rxnorm_name": "BCG, live, Tice strain",
+      "drugbank_id": null,
+      "atc": [],
+      "ciel": [
+        {
+          "code": "71905",
+          "uuid": "71905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "BCG, live, tice strain"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2007",
+      "name": "Levoketoconazole",
+      "rxcui": "6135",
+      "rxnorm_name": "ketoconazole",
+      "drugbank_id": "DB05667",
+      "atc": [
+        "D01AC08",
+        "G01AF11",
+        "H02CA03",
+        "J02AB02"
+      ],
+      "ciel": [
+        {
+          "code": "78476",
+          "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Ketoconazole"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2152",
+      "name": "Fluoroestradiol f-18",
+      "rxcui": "4083",
+      "rxnorm_name": "estradiol",
+      "drugbank_id": null,
+      "atc": [
+        "G03CA03"
+      ],
+      "ciel": [
+        {
+          "code": "104597",
+          "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / ethinyl estradiol / levonorgestrel"
+        },
+        {
+          "code": "104598",
+          "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / hydroxyprogesterone"
+        },
+        {
+          "code": "104599",
+          "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / levonorgestrel"
+        },
+        {
+          "code": "104600",
+          "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / medroxyprogesterone"
+        },
+        {
+          "code": "104601",
+          "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / norethindrone"
+        },
+        {
+          "code": "104602",
+          "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / norgestimate"
+        },
+        {
+          "code": "104603",
+          "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / testosterone"
+        },
+        {
+          "code": "165449",
+          "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol valerate / norethisterone enantate"
+        },
+        {
+          "code": "165467",
+          "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Algestone acetophenide / estradiol enantate"
+        },
+        {
+          "code": "167605",
+          "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
+          "name": "Estradiol / norethindrone / relugolix"
+        },
+        {
+          "code": "75900",
+          "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol"
+        },
+        {
+          "code": "75901",
+          "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol 17 beta-cypionate"
+        },
+        {
+          "code": "75902",
+          "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol 3-benzoate"
+        },
+        {
+          "code": "75904",
+          "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol hemihydrate"
+        },
+        {
+          "code": "75905",
+          "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol valerate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter2169",
+      "name": "Daxibotulinumtoxina",
+      "rxcui": "1712",
+      "rxnorm_name": "botulinum toxin type A",
+      "drugbank_id": null,
+      "atc": [],
+      "ciel": [
+        {
+          "code": "72303",
+          "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Botulinum toxin type A"
+        },
+        {
+          "code": "72305",
+          "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Botulinum type A toxin-haemagglutinin complex"
+        }
+      ]
+    },
+    {
+      "id": "DDInter225",
+      "name": "Botulinum toxin type A",
+      "rxcui": "1712",
+      "rxnorm_name": "botulinum toxin type A",
+      "drugbank_id": "DB00083",
+      "atc": [],
+      "ciel": [
+        {
+          "code": "72303",
+          "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Botulinum toxin type A"
+        },
+        {
+          "code": "72305",
+          "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Botulinum type A toxin-haemagglutinin complex"
+        }
+      ]
+    },
+    {
+      "id": "DDInter679",
+      "name": "Estradiol",
+      "rxcui": "4083",
+      "rxnorm_name": "estradiol",
+      "drugbank_id": "DB00783",
+      "atc": [
+        "G03CA03"
+      ],
+      "ciel": [
+        {
+          "code": "104597",
+          "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / ethinyl estradiol / levonorgestrel"
+        },
+        {
+          "code": "104598",
+          "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / hydroxyprogesterone"
+        },
+        {
+          "code": "104599",
+          "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / levonorgestrel"
+        },
+        {
+          "code": "104600",
+          "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / medroxyprogesterone"
+        },
+        {
+          "code": "104601",
+          "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / norethindrone"
+        },
+        {
+          "code": "104602",
+          "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / norgestimate"
+        },
+        {
+          "code": "104603",
+          "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / testosterone"
+        },
+        {
+          "code": "165449",
+          "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol valerate / norethisterone enantate"
+        },
+        {
+          "code": "165467",
+          "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Algestone acetophenide / estradiol enantate"
+        },
+        {
+          "code": "167605",
+          "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
+          "name": "Estradiol / norethindrone / relugolix"
+        },
+        {
+          "code": "75900",
+          "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol"
+        },
+        {
+          "code": "75901",
+          "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol 17 beta-cypionate"
+        },
+        {
+          "code": "75902",
+          "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol 3-benzoate"
+        },
+        {
+          "code": "75904",
+          "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol hemihydrate"
+        },
+        {
+          "code": "75905",
+          "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol valerate"
+        }
+      ]
+    },
+    {
+      "id": "DDInter680",
+      "name": "Estradiol (topical)",
+      "rxcui": "4083",
+      "rxnorm_name": "estradiol",
+      "drugbank_id": "DB00783",
+      "atc": [
+        "G03CA03"
+      ],
+      "ciel": [
+        {
+          "code": "104597",
+          "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / ethinyl estradiol / levonorgestrel"
+        },
+        {
+          "code": "104598",
+          "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / hydroxyprogesterone"
+        },
+        {
+          "code": "104599",
+          "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / levonorgestrel"
+        },
+        {
+          "code": "104600",
+          "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / medroxyprogesterone"
+        },
+        {
+          "code": "104601",
+          "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / norethindrone"
+        },
+        {
+          "code": "104602",
+          "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / norgestimate"
+        },
+        {
+          "code": "104603",
+          "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol / testosterone"
+        },
+        {
+          "code": "165449",
+          "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol valerate / norethisterone enantate"
+        },
+        {
+          "code": "165467",
+          "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Algestone acetophenide / estradiol enantate"
+        },
+        {
+          "code": "167605",
+          "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
+          "name": "Estradiol / norethindrone / relugolix"
+        },
+        {
+          "code": "75900",
+          "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol"
+        },
+        {
+          "code": "75901",
+          "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol 17 beta-cypionate"
+        },
+        {
+          "code": "75902",
+          "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol 3-benzoate"
+        },
+        {
+          "code": "75904",
+          "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol hemihydrate"
+        },
+        {
+          "code": "75905",
+          "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "name": "Estradiol valerate"
+        }
+      ]
+    }
+  ],
+  "interactions": [
+    [
+      "DDInter1008",
+      "DDInter1353",
+      "Moderate",
+      "4988"
+    ],
+    [
+      "DDInter1008",
+      "DDInter2007",
+      "Major",
+      "6747"
+    ],
+    [
+      "DDInter1008",
+      "DDInter679",
+      "Moderate",
+      "3720"
+    ],
+    [
+      "DDInter1008",
+      "DDInter680",
+      "Moderate",
+      "3720"
+    ],
+    [
+      "DDInter1353",
+      "DDInter2007",
+      "Moderate",
+      "6406"
+    ],
+    [
+      "DDInter1353",
+      "DDInter2152",
+      "Major",
+      "6939"
+    ],
+    [
+      "DDInter1353",
+      "DDInter679",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "DDInter1353",
+      "DDInter680",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "DDInter168",
+      "DDInter1974",
+      "Moderate",
+      "7481"
+    ],
+    [
+      "DDInter169",
+      "DDInter1974",
+      "Moderate",
+      "7481"
+    ],
+    [
+      "DDInter2007",
+      "DDInter679",
+      "Moderate",
+      "7258"
+    ],
+    [
+      "DDInter2007",
+      "DDInter680",
+      "Moderate",
+      "7258"
+    ],
+    [
+      "DDInter2169",
+      "DDInter225",
+      "Moderate",
+      "7257"
+    ]
+  ]
+}

--- a/api/src/test/resources/chartsearchai-test/ddi-derivative-merged-into-one-substance.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-derivative-merged-into-one-substance.json
@@ -1,590 +1,649 @@
 {
-  "metadata": {
-    "note": "Verbatim DDInter 2.0 slice for the load-time validity check on issue #196 item 4 - real shipped rows, unedited. ONE POSITIVE: Fluoroestradiol f-18 publishes rxnorm_name `estradiol` and no drugbank_id of its own, so the per-family resolution hands it Estradiol's DB00783 and a PET imaging tracer and a therapeutic oestrogen become ONE substance to substanceKey(). Its own name says otherwise - `fluoroestradiol` carries `estradiol` as a substring and NOT as a word, which is this module's own rule for a derivative being a different substance. FIVE CONTROLS that must NOT be reported, each excluding a shape that is correct: (1) Beclomethasone dipropionate (nasal) is the closest control there is - a row with no drugbank_id of its own inheriting DB00394 from its family, exactly as the tracer does - but its name extends the substance name `beclomethasone` by a WORD, which is what an ester or a salt legitimately looks like, so containsWord alone keeps it silent; 12 rows of the shipped KB are silent for that reason and every one inspected is an ester, a salt or a preparation. (2) Estradiol (topical) is a route variant of the positive's own family whose stem IS the substance name - a presentation, not a derivative. (3) Levoketoconazole is the identical prefix-derivative shape and carries its OWN drugbank_id (DB05667) against Ketoconazole's DB01026, so the family names two DrugBank substances, the id is withheld and the display stem already separates them - nothing is merged, so there is nothing to report. (4) Daxibotulinumtoxina and Botulinum toxin type A are one substance under two DISJOINT names, which issue #164 measured as a correct merge - this is the row a rule keyed on \"one substance, unlike names\" would flag, and it is why this rule is keyed on the derivative relationship instead. (5) Ospemifene and Bcg vaccine are the interaction partners that give every row here a rule, so no entry is rule-less and the load is not the parses-to-nothing-in-silence shape issue #242 records."
+ "metadata": {
+  "note": "Verbatim DDInter 2.0 slice for the load-time validity check on issue #196 item 4 - real shipped rows, unedited. ONE POSITIVE: Fluoroestradiol f-18 publishes rxnorm_name `estradiol` and no drugbank_id of its own, so the per-family resolution hands it Estradiol's DB00783 and a PET imaging tracer and a therapeutic oestrogen become ONE substance to substanceKey(). Its own name says otherwise - `fluoroestradiol` carries `estradiol` as a substring and NOT as a word, which is this module's own rule for a derivative being a different substance. SIX CONTROLS that must NOT be reported, each excluding a shape that is correct: (1) Beclomethasone dipropionate (nasal) is the closest control there is - a row with no drugbank_id of its own inheriting DB00394 from its family, exactly as the tracer does - but its name extends the substance name `beclomethasone` by a WORD, which is what an ester or a salt legitimately looks like, so containsWord alone keeps it silent; 12 rows of the shipped KB are silent for that reason and every one inspected is an ester, a salt or a preparation. (2) Estradiol (topical) is a route variant of the positive's own family whose stem IS the substance name - a presentation, not a derivative. (3) Levoketoconazole is the identical prefix-derivative shape and carries its OWN drugbank_id (DB05667) against Ketoconazole's DB01026, so the family names two DrugBank substances, the id is withheld and the display stem already separates them - nothing is merged, so there is nothing to report. (4) Daxibotulinumtoxina and Botulinum toxin type A are one substance under two DISJOINT names, which issue #164 measured as a correct merge - this is the row a rule keyed on \"one substance, unlike names\" would flag, and it is why this rule is keyed on the derivative relationship instead. (5) Sodium oxybate is the row that isolates the WORD boundary on its own: its family's substance name is `oxybate`, its own stem carries that as a bounded word, and the three gamma-Hydroxybutyric acid rows beside it carry it not at all - so the family has a parent and the only thing keeping Sodium oxybate silent is containsWord. Weaken that test to bare equality and this row is reported. (6) Ospemifene, Bcg vaccine and Ropeginterferon alfa-2b are the interaction partners, so the load is not the parses-to-nothing-in-silence shape issue #242 records. Two rows do load rule-less and that is the data's doing rather than an omission: Daxibotulinumtoxina and Botulinum toxin type A interact only with EACH OTHER in the shipped file, and the parser drops that row as a self-pair precisely because they are one substance - which is the same fact control (3) rests on."
+ },
+ "mechanisms": {
+  "1985": {
+   "text": "The concurrent use of ospemifene with estrogens or other estrogen agonists/antagonists has not been evaluated. Safety and efficacy of this combination are unknown.",
+   "categories": [
+    "others"
+   ]
   },
-  "mechanisms": {
-    "1985": {
-      "text": "The concurrent use of ospemifene with estrogens or other estrogen agonists/antagonists has not been evaluated. Safety and efficacy of this combination are unknown.",
-      "categories": [
-        "others"
-      ]
-    },
-    "3720": {
-      "text": "Azole antifungal agents may increase the plasma concentrations of estrogens and progestins. The mechanism is decreased clearance of the hormones due to inhibition of CYP450 3A4 activity by azole antifungals.",
-      "categories": [
-        "metabolism"
-      ]
-    },
-    "4988": {
-      "text": "Coadministration with potent inhibitors of CYP450 3A4 may increase the plasma concentrations of ospemifene, which is partially metabolized by the isoenzyme.",
-      "categories": [
-        "metabolism"
-      ]
-    },
-    "6406": {
-      "text": "Coadministration with potent inhibitors of CYP450 3A4 may increase the plasma concentrations of ospemifene, which is partially metabolized by the isoenzyme.",
-      "categories": [
-        "metabolism"
-      ]
-    },
-    "6747": {
-      "text": "Levoketoconazole can cause concentration-dependent, life-threatening prolongation of the QT interval.",
-      "categories": [
-        "synergistic_effect"
-      ]
-    },
-    "6939": {
-      "text": "Coadministration of the radioactive diagnostic agent fluoroestradiol F 18 with drugs that block the estrogen receptor (ER), such as tamoxifen and fulvestrant, may reduce the uptake of fluoroestradiol F 18 into ER-positive tumors.",
-      "categories": [
-        "distribution"
-      ]
-    },
-    "7257": {
-      "text": "The effect of administering different botulinum neurotoxin serotypes concurrently or within several months of one another is unknown.  Excessive weakness may be exacerbated by another administration of botulinum toxin prior to the resolution of the effects of a previously administered botulinum toxin.",
-      "categories": [
-        "others"
-      ]
-    },
-    "7258": {
-      "text": "Azole antifungal agents may increase the plasma concentrations of estrogens and progestins.  The mechanism is decreased clearance of the hormones due to inhibition of CYP450 3A4 activity by azole antifungals.",
-      "categories": [
-        "metabolism"
-      ]
-    },
-    "7481": {
-      "text": "Administration of intravesical BCG during immunosuppressive corticosteroid therapy may be associated with a risk of disseminated infection due to enhanced replication of the BCG strain of Mycobacterium bovis in the presence of diminished immune competence.",
-      "categories": [
-        "synergistic_effect"
-      ]
-    }
+  "3720": {
+   "text": "Azole antifungal agents may increase the plasma concentrations of estrogens and progestins. The mechanism is decreased clearance of the hormones due to inhibition of CYP450 3A4 activity by azole antifungals.",
+   "categories": [
+    "metabolism"
+   ]
   },
-  "drugs": [
+  "4988": {
+   "text": "Coadministration with potent inhibitors of CYP450 3A4 may increase the plasma concentrations of ospemifene, which is partially metabolized by the isoenzyme.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "6406": {
+   "text": "Coadministration with potent inhibitors of CYP450 3A4 may increase the plasma concentrations of ospemifene, which is partially metabolized by the isoenzyme.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "6747": {
+   "text": "Levoketoconazole can cause concentration-dependent, life-threatening prolongation of the QT interval.",
+   "categories": [
+    "synergistic_effect"
+   ]
+  },
+  "6939": {
+   "text": "Coadministration of the radioactive diagnostic agent fluoroestradiol F 18 with drugs that block the estrogen receptor (ER), such as tamoxifen and fulvestrant, may reduce the uptake of fluoroestradiol F 18 into ER-positive tumors.",
+   "categories": [
+    "distribution"
+   ]
+  },
+  "7257": {
+   "text": "The effect of administering different botulinum neurotoxin serotypes concurrently or within several months of one another is unknown.  Excessive weakness may be exacerbated by another administration of botulinum toxin prior to the resolution of the effects of a previously administered botulinum toxin.",
+   "categories": [
+    "others"
+   ]
+  },
+  "7258": {
+   "text": "Azole antifungal agents may increase the plasma concentrations of estrogens and progestins.  The mechanism is decreased clearance of the hormones due to inhibition of CYP450 3A4 activity by azole antifungals.",
+   "categories": [
+    "metabolism"
+   ]
+  },
+  "7481": {
+   "text": "Administration of intravesical BCG during immunosuppressive corticosteroid therapy may be associated with a risk of disseminated infection due to enhanced replication of the BCG strain of Mycobacterium bovis in the presence of diminished immune competence.",
+   "categories": [
+    "synergistic_effect"
+   ]
+  },
+  "7090": {
+   "text": "Coadministration with narcotics, hypnotics, or sedatives may potentiate the neuropsychiatric side effects of ropeginterferon alfa-2b.",
+   "categories": [
+    "synergistic_effect"
+   ]
+  }
+ },
+ "drugs": [
+  {
+   "id": "DDInter1008",
+   "name": "Ketoconazole",
+   "rxcui": "6135",
+   "rxnorm_name": "ketoconazole",
+   "drugbank_id": "DB01026",
+   "atc": [
+    "D01AC08",
+    "G01AF11",
+    "H02CA03",
+    "J02AB02"
+   ],
+   "ciel": [
     {
-      "id": "DDInter1008",
-      "name": "Ketoconazole",
-      "rxcui": "6135",
-      "rxnorm_name": "ketoconazole",
-      "drugbank_id": "DB01026",
-      "atc": [
-        "D01AC08",
-        "G01AF11",
-        "H02CA03",
-        "J02AB02"
-      ],
-      "ciel": [
-        {
-          "code": "78476",
-          "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Ketoconazole"
-        }
-      ]
-    },
-    {
-      "id": "DDInter1353",
-      "name": "Ospemifene",
-      "rxcui": "1370971",
-      "rxnorm_name": "ospemifene",
-      "drugbank_id": "DB04938",
-      "atc": [
-        "G03XC05"
-      ],
-      "ciel": []
-    },
-    {
-      "id": "DDInter168",
-      "name": "Beclomethasone dipropionate",
-      "rxcui": "1347",
-      "rxnorm_name": "beclomethasone",
-      "drugbank_id": "DB00394",
-      "atc": [
-        "A07EA07",
-        "D07AC15",
-        "R01AD01",
-        "R03BA01"
-      ],
-      "ciel": [
-        {
-          "code": "103335",
-          "uuid": "103335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Albuterol / beclomethasone"
-        },
-        {
-          "code": "169918",
-          "uuid": "6070c4ba-c62f-433b-9802-7c14a80a88a9",
-          "name": "Beclomethasone / formoterol"
-        },
-        {
-          "code": "71916",
-          "uuid": "71916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Beclomethasone"
-        },
-        {
-          "code": "71917",
-          "uuid": "71917AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Beclomethasone dipropionate"
-        },
-        {
-          "code": "71918",
-          "uuid": "71918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Beclomethasone dipropionate monohydrate"
-        }
-      ]
-    },
-    {
-      "id": "DDInter169",
-      "name": "Beclomethasone dipropionate (nasal)",
-      "rxcui": "1347",
-      "rxnorm_name": "beclomethasone",
-      "drugbank_id": null,
-      "atc": [
-        "A07EA07",
-        "D07AC15",
-        "R01AD01",
-        "R03BA01"
-      ],
-      "ciel": [
-        {
-          "code": "103335",
-          "uuid": "103335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Albuterol / beclomethasone"
-        },
-        {
-          "code": "169918",
-          "uuid": "6070c4ba-c62f-433b-9802-7c14a80a88a9",
-          "name": "Beclomethasone / formoterol"
-        },
-        {
-          "code": "71916",
-          "uuid": "71916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Beclomethasone"
-        },
-        {
-          "code": "71917",
-          "uuid": "71917AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Beclomethasone dipropionate"
-        },
-        {
-          "code": "71918",
-          "uuid": "71918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Beclomethasone dipropionate monohydrate"
-        }
-      ]
-    },
-    {
-      "id": "DDInter1974",
-      "name": "Bcg vaccine",
-      "rxcui": "221050",
-      "rxnorm_name": "BCG, live, Tice strain",
-      "drugbank_id": null,
-      "atc": [],
-      "ciel": [
-        {
-          "code": "71905",
-          "uuid": "71905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "BCG, live, tice strain"
-        }
-      ]
-    },
-    {
-      "id": "DDInter2007",
-      "name": "Levoketoconazole",
-      "rxcui": "6135",
-      "rxnorm_name": "ketoconazole",
-      "drugbank_id": "DB05667",
-      "atc": [
-        "D01AC08",
-        "G01AF11",
-        "H02CA03",
-        "J02AB02"
-      ],
-      "ciel": [
-        {
-          "code": "78476",
-          "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Ketoconazole"
-        }
-      ]
-    },
-    {
-      "id": "DDInter2152",
-      "name": "Fluoroestradiol f-18",
-      "rxcui": "4083",
-      "rxnorm_name": "estradiol",
-      "drugbank_id": null,
-      "atc": [
-        "G03CA03"
-      ],
-      "ciel": [
-        {
-          "code": "104597",
-          "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / ethinyl estradiol / levonorgestrel"
-        },
-        {
-          "code": "104598",
-          "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / hydroxyprogesterone"
-        },
-        {
-          "code": "104599",
-          "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / levonorgestrel"
-        },
-        {
-          "code": "104600",
-          "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / medroxyprogesterone"
-        },
-        {
-          "code": "104601",
-          "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / norethindrone"
-        },
-        {
-          "code": "104602",
-          "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / norgestimate"
-        },
-        {
-          "code": "104603",
-          "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / testosterone"
-        },
-        {
-          "code": "165449",
-          "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol valerate / norethisterone enantate"
-        },
-        {
-          "code": "165467",
-          "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Algestone acetophenide / estradiol enantate"
-        },
-        {
-          "code": "167605",
-          "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
-          "name": "Estradiol / norethindrone / relugolix"
-        },
-        {
-          "code": "75900",
-          "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol"
-        },
-        {
-          "code": "75901",
-          "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol 17 beta-cypionate"
-        },
-        {
-          "code": "75902",
-          "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol 3-benzoate"
-        },
-        {
-          "code": "75904",
-          "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol hemihydrate"
-        },
-        {
-          "code": "75905",
-          "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol valerate"
-        }
-      ]
-    },
-    {
-      "id": "DDInter2169",
-      "name": "Daxibotulinumtoxina",
-      "rxcui": "1712",
-      "rxnorm_name": "botulinum toxin type A",
-      "drugbank_id": null,
-      "atc": [],
-      "ciel": [
-        {
-          "code": "72303",
-          "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Botulinum toxin type A"
-        },
-        {
-          "code": "72305",
-          "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Botulinum type A toxin-haemagglutinin complex"
-        }
-      ]
-    },
-    {
-      "id": "DDInter225",
-      "name": "Botulinum toxin type A",
-      "rxcui": "1712",
-      "rxnorm_name": "botulinum toxin type A",
-      "drugbank_id": "DB00083",
-      "atc": [],
-      "ciel": [
-        {
-          "code": "72303",
-          "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Botulinum toxin type A"
-        },
-        {
-          "code": "72305",
-          "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Botulinum type A toxin-haemagglutinin complex"
-        }
-      ]
-    },
-    {
-      "id": "DDInter679",
-      "name": "Estradiol",
-      "rxcui": "4083",
-      "rxnorm_name": "estradiol",
-      "drugbank_id": "DB00783",
-      "atc": [
-        "G03CA03"
-      ],
-      "ciel": [
-        {
-          "code": "104597",
-          "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / ethinyl estradiol / levonorgestrel"
-        },
-        {
-          "code": "104598",
-          "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / hydroxyprogesterone"
-        },
-        {
-          "code": "104599",
-          "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / levonorgestrel"
-        },
-        {
-          "code": "104600",
-          "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / medroxyprogesterone"
-        },
-        {
-          "code": "104601",
-          "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / norethindrone"
-        },
-        {
-          "code": "104602",
-          "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / norgestimate"
-        },
-        {
-          "code": "104603",
-          "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / testosterone"
-        },
-        {
-          "code": "165449",
-          "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol valerate / norethisterone enantate"
-        },
-        {
-          "code": "165467",
-          "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Algestone acetophenide / estradiol enantate"
-        },
-        {
-          "code": "167605",
-          "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
-          "name": "Estradiol / norethindrone / relugolix"
-        },
-        {
-          "code": "75900",
-          "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol"
-        },
-        {
-          "code": "75901",
-          "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol 17 beta-cypionate"
-        },
-        {
-          "code": "75902",
-          "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol 3-benzoate"
-        },
-        {
-          "code": "75904",
-          "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol hemihydrate"
-        },
-        {
-          "code": "75905",
-          "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol valerate"
-        }
-      ]
-    },
-    {
-      "id": "DDInter680",
-      "name": "Estradiol (topical)",
-      "rxcui": "4083",
-      "rxnorm_name": "estradiol",
-      "drugbank_id": "DB00783",
-      "atc": [
-        "G03CA03"
-      ],
-      "ciel": [
-        {
-          "code": "104597",
-          "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / ethinyl estradiol / levonorgestrel"
-        },
-        {
-          "code": "104598",
-          "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / hydroxyprogesterone"
-        },
-        {
-          "code": "104599",
-          "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / levonorgestrel"
-        },
-        {
-          "code": "104600",
-          "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / medroxyprogesterone"
-        },
-        {
-          "code": "104601",
-          "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / norethindrone"
-        },
-        {
-          "code": "104602",
-          "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / norgestimate"
-        },
-        {
-          "code": "104603",
-          "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol / testosterone"
-        },
-        {
-          "code": "165449",
-          "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol valerate / norethisterone enantate"
-        },
-        {
-          "code": "165467",
-          "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Algestone acetophenide / estradiol enantate"
-        },
-        {
-          "code": "167605",
-          "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
-          "name": "Estradiol / norethindrone / relugolix"
-        },
-        {
-          "code": "75900",
-          "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol"
-        },
-        {
-          "code": "75901",
-          "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol 17 beta-cypionate"
-        },
-        {
-          "code": "75902",
-          "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol 3-benzoate"
-        },
-        {
-          "code": "75904",
-          "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol hemihydrate"
-        },
-        {
-          "code": "75905",
-          "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-          "name": "Estradiol valerate"
-        }
-      ]
+     "code": "78476",
+     "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Ketoconazole"
     }
+   ]
+  },
+  {
+   "id": "DDInter1353",
+   "name": "Ospemifene",
+   "rxcui": "1370971",
+   "rxnorm_name": "ospemifene",
+   "drugbank_id": "DB04938",
+   "atc": [
+    "G03XC05"
+   ],
+   "ciel": []
+  },
+  {
+   "id": "DDInter168",
+   "name": "Beclomethasone dipropionate",
+   "rxcui": "1347",
+   "rxnorm_name": "beclomethasone",
+   "drugbank_id": "DB00394",
+   "atc": [
+    "A07EA07",
+    "D07AC15",
+    "R01AD01",
+    "R03BA01"
+   ],
+   "ciel": [
+    {
+     "code": "103335",
+     "uuid": "103335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Albuterol / beclomethasone"
+    },
+    {
+     "code": "169918",
+     "uuid": "6070c4ba-c62f-433b-9802-7c14a80a88a9",
+     "name": "Beclomethasone / formoterol"
+    },
+    {
+     "code": "71916",
+     "uuid": "71916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Beclomethasone"
+    },
+    {
+     "code": "71917",
+     "uuid": "71917AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Beclomethasone dipropionate"
+    },
+    {
+     "code": "71918",
+     "uuid": "71918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Beclomethasone dipropionate monohydrate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter169",
+   "name": "Beclomethasone dipropionate (nasal)",
+   "rxcui": "1347",
+   "rxnorm_name": "beclomethasone",
+   "drugbank_id": null,
+   "atc": [
+    "A07EA07",
+    "D07AC15",
+    "R01AD01",
+    "R03BA01"
+   ],
+   "ciel": [
+    {
+     "code": "103335",
+     "uuid": "103335AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Albuterol / beclomethasone"
+    },
+    {
+     "code": "169918",
+     "uuid": "6070c4ba-c62f-433b-9802-7c14a80a88a9",
+     "name": "Beclomethasone / formoterol"
+    },
+    {
+     "code": "71916",
+     "uuid": "71916AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Beclomethasone"
+    },
+    {
+     "code": "71917",
+     "uuid": "71917AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Beclomethasone dipropionate"
+    },
+    {
+     "code": "71918",
+     "uuid": "71918AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Beclomethasone dipropionate monohydrate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1974",
+   "name": "Bcg vaccine",
+   "rxcui": "221050",
+   "rxnorm_name": "BCG, live, Tice strain",
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": [
+    {
+     "code": "71905",
+     "uuid": "71905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "BCG, live, tice strain"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2007",
+   "name": "Levoketoconazole",
+   "rxcui": "6135",
+   "rxnorm_name": "ketoconazole",
+   "drugbank_id": "DB05667",
+   "atc": [
+    "D01AC08",
+    "G01AF11",
+    "H02CA03",
+    "J02AB02"
+   ],
+   "ciel": [
+    {
+     "code": "78476",
+     "uuid": "78476AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Ketoconazole"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2152",
+   "name": "Fluoroestradiol f-18",
+   "rxcui": "4083",
+   "rxnorm_name": "estradiol",
+   "drugbank_id": null,
+   "atc": [
+    "G03CA03"
+   ],
+   "ciel": [
+    {
+     "code": "104597",
+     "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / ethinyl estradiol / levonorgestrel"
+    },
+    {
+     "code": "104598",
+     "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / hydroxyprogesterone"
+    },
+    {
+     "code": "104599",
+     "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / levonorgestrel"
+    },
+    {
+     "code": "104600",
+     "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / medroxyprogesterone"
+    },
+    {
+     "code": "104601",
+     "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / norethindrone"
+    },
+    {
+     "code": "104602",
+     "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / norgestimate"
+    },
+    {
+     "code": "104603",
+     "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / testosterone"
+    },
+    {
+     "code": "165449",
+     "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol valerate / norethisterone enantate"
+    },
+    {
+     "code": "165467",
+     "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Algestone acetophenide / estradiol enantate"
+    },
+    {
+     "code": "167605",
+     "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
+     "name": "Estradiol / norethindrone / relugolix"
+    },
+    {
+     "code": "75900",
+     "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol"
+    },
+    {
+     "code": "75901",
+     "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol 17 beta-cypionate"
+    },
+    {
+     "code": "75902",
+     "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol 3-benzoate"
+    },
+    {
+     "code": "75904",
+     "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol hemihydrate"
+    },
+    {
+     "code": "75905",
+     "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol valerate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2169",
+   "name": "Daxibotulinumtoxina",
+   "rxcui": "1712",
+   "rxnorm_name": "botulinum toxin type A",
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": [
+    {
+     "code": "72303",
+     "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum toxin type A"
+    },
+    {
+     "code": "72305",
+     "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum type A toxin-haemagglutinin complex"
+    }
+   ]
+  },
+  {
+   "id": "DDInter225",
+   "name": "Botulinum toxin type A",
+   "rxcui": "1712",
+   "rxnorm_name": "botulinum toxin type A",
+   "drugbank_id": "DB00083",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "72303",
+     "uuid": "72303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum toxin type A"
+    },
+    {
+     "code": "72305",
+     "uuid": "72305AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Botulinum type A toxin-haemagglutinin complex"
+    }
+   ]
+  },
+  {
+   "id": "DDInter679",
+   "name": "Estradiol",
+   "rxcui": "4083",
+   "rxnorm_name": "estradiol",
+   "drugbank_id": "DB00783",
+   "atc": [
+    "G03CA03"
+   ],
+   "ciel": [
+    {
+     "code": "104597",
+     "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / ethinyl estradiol / levonorgestrel"
+    },
+    {
+     "code": "104598",
+     "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / hydroxyprogesterone"
+    },
+    {
+     "code": "104599",
+     "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / levonorgestrel"
+    },
+    {
+     "code": "104600",
+     "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / medroxyprogesterone"
+    },
+    {
+     "code": "104601",
+     "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / norethindrone"
+    },
+    {
+     "code": "104602",
+     "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / norgestimate"
+    },
+    {
+     "code": "104603",
+     "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / testosterone"
+    },
+    {
+     "code": "165449",
+     "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol valerate / norethisterone enantate"
+    },
+    {
+     "code": "165467",
+     "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Algestone acetophenide / estradiol enantate"
+    },
+    {
+     "code": "167605",
+     "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
+     "name": "Estradiol / norethindrone / relugolix"
+    },
+    {
+     "code": "75900",
+     "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol"
+    },
+    {
+     "code": "75901",
+     "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol 17 beta-cypionate"
+    },
+    {
+     "code": "75902",
+     "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol 3-benzoate"
+    },
+    {
+     "code": "75904",
+     "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol hemihydrate"
+    },
+    {
+     "code": "75905",
+     "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol valerate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter680",
+   "name": "Estradiol (topical)",
+   "rxcui": "4083",
+   "rxnorm_name": "estradiol",
+   "drugbank_id": "DB00783",
+   "atc": [
+    "G03CA03"
+   ],
+   "ciel": [
+    {
+     "code": "104597",
+     "uuid": "104597AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / ethinyl estradiol / levonorgestrel"
+    },
+    {
+     "code": "104598",
+     "uuid": "104598AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / hydroxyprogesterone"
+    },
+    {
+     "code": "104599",
+     "uuid": "104599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / levonorgestrel"
+    },
+    {
+     "code": "104600",
+     "uuid": "104600AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / medroxyprogesterone"
+    },
+    {
+     "code": "104601",
+     "uuid": "104601AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / norethindrone"
+    },
+    {
+     "code": "104602",
+     "uuid": "104602AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / norgestimate"
+    },
+    {
+     "code": "104603",
+     "uuid": "104603AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol / testosterone"
+    },
+    {
+     "code": "165449",
+     "uuid": "165449AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol valerate / norethisterone enantate"
+    },
+    {
+     "code": "165467",
+     "uuid": "165467AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Algestone acetophenide / estradiol enantate"
+    },
+    {
+     "code": "167605",
+     "uuid": "7911cbdf-66f0-42a1-a75d-e398d675f25c",
+     "name": "Estradiol / norethindrone / relugolix"
+    },
+    {
+     "code": "75900",
+     "uuid": "75900AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol"
+    },
+    {
+     "code": "75901",
+     "uuid": "75901AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol 17 beta-cypionate"
+    },
+    {
+     "code": "75902",
+     "uuid": "75902AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol 3-benzoate"
+    },
+    {
+     "code": "75904",
+     "uuid": "75904AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol hemihydrate"
+    },
+    {
+     "code": "75905",
+     "uuid": "75905AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Estradiol valerate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter1690",
+   "name": "Sodium oxybate",
+   "rxcui": "2387302",
+   "rxnorm_name": "oxybate",
+   "drugbank_id": "DB09072",
+   "atc": [],
+   "ciel": [
+    {
+     "code": "84082",
+     "uuid": "84082AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Sodium oxybate"
+    }
+   ]
+  },
+  {
+   "id": "DDInter2099",
+   "name": "Ropeginterferon alfa-2b",
+   "rxcui": "2587059",
+   "rxnorm_name": "ropeginterferon alfa-2b",
+   "drugbank_id": "DB15119",
+   "atc": [
+    "L03AB15"
+   ],
+   "ciel": []
+  },
+  {
+   "id": "DDInter2279",
+   "name": "gamma-Hydroxybutyric acid (potassium oxybate)",
+   "rxcui": "2387302",
+   "rxnorm_name": "oxybate",
+   "drugbank_id": null,
+   "atc": [],
+   "ciel": [
+    {
+     "code": "84082",
+     "uuid": "84082AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+     "name": "Sodium oxybate"
+    }
+   ]
+  }
+ ],
+ "interactions": [
+  [
+   "DDInter1008",
+   "DDInter1353",
+   "Moderate",
+   "4988"
   ],
-  "interactions": [
-    [
-      "DDInter1008",
-      "DDInter1353",
-      "Moderate",
-      "4988"
-    ],
-    [
-      "DDInter1008",
-      "DDInter2007",
-      "Major",
-      "6747"
-    ],
-    [
-      "DDInter1008",
-      "DDInter679",
-      "Moderate",
-      "3720"
-    ],
-    [
-      "DDInter1008",
-      "DDInter680",
-      "Moderate",
-      "3720"
-    ],
-    [
-      "DDInter1353",
-      "DDInter2007",
-      "Moderate",
-      "6406"
-    ],
-    [
-      "DDInter1353",
-      "DDInter2152",
-      "Major",
-      "6939"
-    ],
-    [
-      "DDInter1353",
-      "DDInter679",
-      "Moderate",
-      "1985"
-    ],
-    [
-      "DDInter1353",
-      "DDInter680",
-      "Moderate",
-      "1985"
-    ],
-    [
-      "DDInter168",
-      "DDInter1974",
-      "Moderate",
-      "7481"
-    ],
-    [
-      "DDInter169",
-      "DDInter1974",
-      "Moderate",
-      "7481"
-    ],
-    [
-      "DDInter2007",
-      "DDInter679",
-      "Moderate",
-      "7258"
-    ],
-    [
-      "DDInter2007",
-      "DDInter680",
-      "Moderate",
-      "7258"
-    ],
-    [
-      "DDInter2169",
-      "DDInter225",
-      "Moderate",
-      "7257"
-    ]
+  [
+   "DDInter1008",
+   "DDInter2007",
+   "Major",
+   "6747"
+  ],
+  [
+   "DDInter1008",
+   "DDInter679",
+   "Moderate",
+   "3720"
+  ],
+  [
+   "DDInter1008",
+   "DDInter680",
+   "Moderate",
+   "3720"
+  ],
+  [
+   "DDInter1353",
+   "DDInter2007",
+   "Moderate",
+   "6406"
+  ],
+  [
+   "DDInter1353",
+   "DDInter2152",
+   "Major",
+   "6939"
+  ],
+  [
+   "DDInter1353",
+   "DDInter679",
+   "Moderate",
+   "1985"
+  ],
+  [
+   "DDInter1353",
+   "DDInter680",
+   "Moderate",
+   "1985"
+  ],
+  [
+   "DDInter168",
+   "DDInter1974",
+   "Moderate",
+   "7481"
+  ],
+  [
+   "DDInter169",
+   "DDInter1974",
+   "Moderate",
+   "7481"
+  ],
+  [
+   "DDInter2007",
+   "DDInter679",
+   "Moderate",
+   "7258"
+  ],
+  [
+   "DDInter2007",
+   "DDInter680",
+   "Moderate",
+   "7258"
+  ],
+  [
+   "DDInter2169",
+   "DDInter225",
+   "Moderate",
+   "7257"
+  ],
+  [
+   "DDInter1690",
+   "DDInter2099",
+   "Moderate",
+   "7090"
+  ],
+  [
+   "DDInter2099",
+   "DDInter2279",
+   "Moderate",
+   "7090"
   ]
+ ]
 }

--- a/api/src/test/resources/chartsearchai-test/ddi-derivative-rule-edges.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-derivative-rule-edges.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "note": "HAND-AUTHORED, unlike its sibling ddi-derivative-merged-into-one-substance.json, and deliberately so: measured 2026-08-13 over the shipped 19 MB knowledge base, ZERO of its 2283 rows carry a non-ASCII character in `name` or `rxnorm_name`, so no verbatim slice can exercise the diacritic fold this rule performs. The shape is a real deployment one — a ddinter-format build whose display names are localized while `rxnorm_name` stays RxNorm's ASCII English, the same asymmetry drug-reference-accented-tokens.json covers for the curated format. Here `Fluoroestradiól f-18` carries `estradiol` neither as a bounded word nor as a raw substring; it carries it only once both sides are folded, which is what makes this file the test of the fold rather than of the rule. Ospemifene is the partner that gives every row a rule, so the load is not the parses-to-nothing-in-silence shape issue #242 records. Every field of those three rows except the accented display name and the ids is the shipped value, so the one invention is the one the case is about. THE OTHER END OF THE SAME FOLD, and the one shape that can make the rule's two tests disagree: Marcaine and Sensorcaine share an rxnorm_name of nothing but a combining acute accent. It is non-blank, so it survives normalizeName and keys them as one substance, but it folds to EMPTY — and an empty token is one containsWord refuses while String.contains accepts from every stem, so without the namesAnything gate BOTH rows are reported as derivatives of it. Malformed data, deliberately: this is the only way found to make the halves read different alphabets, and it fails open. THIRD SHAPE, the one that decides what 'merged' means: Ketoconazole (DB01026) and Levoketoconazole (DB05667) are shipped rows verbatim, and Levoketoconazole (oral) is invented beside them. The family names two DrugBank substances, so the id is withheld and the keys fall back to display stems - which puts the TWO Levoketoconazole rows in one family with no parent in it. Nothing was merged there: the module separated the derivative from Ketoconazole exactly as designed, and these are two route variants of the derivative itself. The rule must therefore require a NON-derivative row in the family, or it reports a merge that never happened, twice, for any derivative that has a route variant.",
+    "note": "HAND-AUTHORED, unlike its sibling ddi-derivative-merged-into-one-substance.json, and deliberately so: measured 2026-08-13 over the shipped 19 MB knowledge base, ZERO of its 2283 rows carry a non-ASCII character in `name` or `rxnorm_name`, so no verbatim slice can exercise the diacritic fold this rule performs. The shape is a real deployment one — a ddinter-format build whose display names are localized while `rxnorm_name` stays RxNorm's ASCII English, the same asymmetry drug-reference-accented-tokens.json covers for the curated format. Here `Fluoroestradiól f-18` carries `estradiol` neither as a bounded word nor as a raw substring; it carries it only once both sides are folded, which is what makes this file the test of the fold rather than of the rule. Ospemifene is the partner that gives every row a rule, so the load is not the parses-to-nothing-in-silence shape issue #242 records. Every field of those three rows except the accented display name and the ids is the shipped value, so the one invention is the one the case is about. THE OTHER END OF THE SAME FOLD, and the one input on which the rule's two tests disagree: Bupivacaine hcl-2 and Marcaine share an rxnorm_name of a bare hyphen. It is non-blank, so it survives normalizeName and keys them as one substance, and it names nothing - and containsWord refuses a token with no letter or digit while String.contains happily finds '-' inside 'bupivacaine hcl-2' and not inside 'marcaine'. So without the namesAnything gate the family holds a parent (Marcaine) and a 'derivative' (Bupivacaine hcl-2), and the row is reported as deriving from '-'. Malformed data, deliberately, and it fails OPEN. A substance name of nothing but combining marks does NOT witness this: it folds to empty, contains(\"\") is true of every stem, so every row derives, and the parent gate silences the family before the guard matters. THIRD SHAPE, the one that decides what 'merged' means: Ketoconazole (DB01026) and Levoketoconazole (DB05667) are shipped rows verbatim, and Levoketoconazole (oral) is invented beside them. The family names two DrugBank substances, so the id is withheld and the keys fall back to display stems - which puts the TWO Levoketoconazole rows in one family with no parent in it. Nothing was merged there: the module separated the derivative from Ketoconazole exactly as designed, and these are two route variants of the derivative itself. The rule must therefore require a NON-derivative row in the family, or it reports a merge that never happened, twice, for any derivative that has a route variant.",
     "warning": "Not a slice of the shipped dataset. Do not copy rows from here into a fixture that claims to be verbatim."
   },
   "mechanisms": {
@@ -57,7 +57,12 @@
       "rxcui": "6135",
       "rxnorm_name": "ketoconazole",
       "drugbank_id": "DB01026",
-      "atc": ["D01AC08", "G01AF11", "H02CA03", "J02AB02"],
+      "atc": [
+        "D01AC08",
+        "G01AF11",
+        "H02CA03",
+        "J02AB02"
+      ],
       "ciel": []
     },
     {
@@ -66,7 +71,12 @@
       "rxcui": "6135",
       "rxnorm_name": "ketoconazole",
       "drugbank_id": "DB05667",
-      "atc": ["D01AC08", "G01AF11", "H02CA03", "J02AB02"],
+      "atc": [
+        "D01AC08",
+        "G01AF11",
+        "H02CA03",
+        "J02AB02"
+      ],
       "ciel": []
     },
     {
@@ -75,23 +85,28 @@
       "rxcui": "6135",
       "rxnorm_name": "ketoconazole",
       "drugbank_id": null,
-      "atc": ["D01AC08", "G01AF11", "H02CA03", "J02AB02"],
+      "atc": [
+        "D01AC08",
+        "G01AF11",
+        "H02CA03",
+        "J02AB02"
+      ],
       "ciel": []
     },
     {
-      "id": "MARKS1",
-      "name": "Marcaine",
+      "id": "NAMELESS1",
+      "name": "Bupivacaine hcl-2",
       "rxcui": "1000001",
-      "rxnorm_name": "́",
+      "rxnorm_name": "-",
       "drugbank_id": null,
       "atc": [],
       "ciel": []
     },
     {
-      "id": "MARKS2",
-      "name": "Sensorcaine",
+      "id": "NAMELESS2",
+      "name": "Marcaine",
       "rxcui": "1000001",
-      "rxnorm_name": "́",
+      "rxnorm_name": "-",
       "drugbank_id": null,
       "atc": [],
       "ciel": []
@@ -112,18 +127,6 @@
     ],
     [
       "LOCALE1353",
-      "MARKS1",
-      "Moderate",
-      "1985"
-    ],
-    [
-      "LOCALE1353",
-      "MARKS2",
-      "Moderate",
-      "1985"
-    ],
-    [
-      "LOCALE1353",
       "DDInter1008",
       "Moderate",
       "1985"
@@ -137,6 +140,18 @@
     [
       "LOCALE1353",
       "LEVOKETO-ORAL",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "LOCALE1353",
+      "NAMELESS1",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "LOCALE1353",
+      "NAMELESS2",
       "Moderate",
       "1985"
     ]

--- a/api/src/test/resources/chartsearchai-test/ddi-derivative-rule-edges.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-derivative-rule-edges.json
@@ -1,0 +1,144 @@
+{
+  "metadata": {
+    "note": "HAND-AUTHORED, unlike its sibling ddi-derivative-merged-into-one-substance.json, and deliberately so: measured 2026-08-13 over the shipped 19 MB knowledge base, ZERO of its 2283 rows carry a non-ASCII character in `name` or `rxnorm_name`, so no verbatim slice can exercise the diacritic fold this rule performs. The shape is a real deployment one — a ddinter-format build whose display names are localized while `rxnorm_name` stays RxNorm's ASCII English, the same asymmetry drug-reference-accented-tokens.json covers for the curated format. Here `Fluoroestradiól f-18` carries `estradiol` neither as a bounded word nor as a raw substring; it carries it only once both sides are folded, which is what makes this file the test of the fold rather than of the rule. Ospemifene is the partner that gives every row a rule, so the load is not the parses-to-nothing-in-silence shape issue #242 records. Every field of those three rows except the accented display name and the ids is the shipped value, so the one invention is the one the case is about. THE OTHER END OF THE SAME FOLD, and the one shape that can make the rule's two tests disagree: Marcaine and Sensorcaine share an rxnorm_name of nothing but a combining acute accent. It is non-blank, so it survives normalizeName and keys them as one substance, but it folds to EMPTY — and an empty token is one containsWord refuses while String.contains accepts from every stem, so without the namesAnything gate BOTH rows are reported as derivatives of it. Malformed data, deliberately: this is the only way found to make the halves read different alphabets, and it fails open. THIRD SHAPE, the one that decides what 'merged' means: Ketoconazole (DB01026) and Levoketoconazole (DB05667) are shipped rows verbatim, and Levoketoconazole (oral) is invented beside them. The family names two DrugBank substances, so the id is withheld and the keys fall back to display stems - which puts the TWO Levoketoconazole rows in one family with no parent in it. Nothing was merged there: the module separated the derivative from Ketoconazole exactly as designed, and these are two route variants of the derivative itself. The rule must therefore require a NON-derivative row in the family, or it reports a merge that never happened, twice, for any derivative that has a route variant.",
+    "warning": "Not a slice of the shipped dataset. Do not copy rows from here into a fixture that claims to be verbatim."
+  },
+  "mechanisms": {
+    "6939": {
+      "text": "Coadministration of the radioactive diagnostic agent fluoroestradiol F 18 with drugs that block the estrogen receptor (ER), such as tamoxifen and fulvestrant, may reduce the uptake of fluoroestradiol F 18 into ER-positive tumors.",
+      "categories": [
+        "distribution"
+      ]
+    },
+    "1985": {
+      "text": "The concurrent use of ospemifene with estrogens or other estrogen agonists/antagonists has not been evaluated. Safety and efficacy of this combination are unknown.",
+      "categories": [
+        "others"
+      ]
+    }
+  },
+  "drugs": [
+    {
+      "id": "LOCALE2152",
+      "name": "Fluoroestradiól f-18",
+      "rxcui": "4083",
+      "rxnorm_name": "estradiol",
+      "drugbank_id": null,
+      "atc": [
+        "G03CA03"
+      ],
+      "ciel": []
+    },
+    {
+      "id": "LOCALE679",
+      "name": "Estradiol",
+      "rxcui": "4083",
+      "rxnorm_name": "estradiol",
+      "drugbank_id": "DB00783",
+      "atc": [
+        "G03CA03"
+      ],
+      "ciel": []
+    },
+    {
+      "id": "LOCALE1353",
+      "name": "Ospemifene",
+      "rxcui": "1370971",
+      "rxnorm_name": "ospemifene",
+      "drugbank_id": "DB04938",
+      "atc": [
+        "G03XC05"
+      ],
+      "ciel": []
+    },
+    {
+      "id": "DDInter1008",
+      "name": "Ketoconazole",
+      "rxcui": "6135",
+      "rxnorm_name": "ketoconazole",
+      "drugbank_id": "DB01026",
+      "atc": ["D01AC08", "G01AF11", "H02CA03", "J02AB02"],
+      "ciel": []
+    },
+    {
+      "id": "DDInter2007",
+      "name": "Levoketoconazole",
+      "rxcui": "6135",
+      "rxnorm_name": "ketoconazole",
+      "drugbank_id": "DB05667",
+      "atc": ["D01AC08", "G01AF11", "H02CA03", "J02AB02"],
+      "ciel": []
+    },
+    {
+      "id": "LEVOKETO-ORAL",
+      "name": "Levoketoconazole (oral)",
+      "rxcui": "6135",
+      "rxnorm_name": "ketoconazole",
+      "drugbank_id": null,
+      "atc": ["D01AC08", "G01AF11", "H02CA03", "J02AB02"],
+      "ciel": []
+    },
+    {
+      "id": "MARKS1",
+      "name": "Marcaine",
+      "rxcui": "1000001",
+      "rxnorm_name": "́",
+      "drugbank_id": null,
+      "atc": [],
+      "ciel": []
+    },
+    {
+      "id": "MARKS2",
+      "name": "Sensorcaine",
+      "rxcui": "1000001",
+      "rxnorm_name": "́",
+      "drugbank_id": null,
+      "atc": [],
+      "ciel": []
+    }
+  ],
+  "interactions": [
+    [
+      "LOCALE1353",
+      "LOCALE2152",
+      "Major",
+      "6939"
+    ],
+    [
+      "LOCALE1353",
+      "LOCALE679",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "LOCALE1353",
+      "MARKS1",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "LOCALE1353",
+      "MARKS2",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "LOCALE1353",
+      "DDInter1008",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "LOCALE1353",
+      "DDInter2007",
+      "Moderate",
+      "1985"
+    ],
+    [
+      "LOCALE1353",
+      "LEVOKETO-ORAL",
+      "Moderate",
+      "1985"
+    ]
+  ]
+}


### PR DESCRIPTION
## What this settles

Issue #196 item 4 — `Fluoroestradiol f-18` and `Estradiol` are ONE substance to this
module — and the premise a close would have rested on, which is false.

**The premise, tested first.** The plan for #196 was to close it because the load-time
validity check "already detects and reports its defects every boot". Measured by driving
`DrugReferenceService.getLoadStatus()` over the shipped 19 MB knowledge base:
`alias-names-another-substance` fires **18** times, and the full list is `Omeprazole`,
`Pfizer-BioNTech Covid-19 Vaccine`, `Trastuzumab emtansine`, `Levoketoconazole`, the five
`Tozinameran` rows, `Gallium citrate ga-67`, `Gallium chloride Ga-67`,
`Dotatate gallium ga-68`, `Fenfluramine`, `Fenofibric acid`, `Fosnetupitant`,
`Amphetamine`, `Hyoscyamine`, `Iodide I-131`. **None of #196's items 1–5 or 7 is among
them.** Item 4 is not merely absent — it is structurally unreachable by that rule, whose
first exclusion is that the two entries key ALIKE, and a shared identity is exactly what
item 4 is.

**What the identity actually is.** Measured through `substanceKey()` on the loaded rows:
`Fluoroestradiol f-18` (`rxnorm_name: estradiol`, `drugbank_id: null`), `Estradiol` and
`Estradiol (topical)` all key `[estradiol, db00783]`. The tracer carries no registry id of
its own; `DdiDrugReferenceSource`'s per-family resolution hands it estradiol's. And
`canonicalRow` for that family answers **`Fluoroestradiol f-18`** — the tracer represents
the substance.

**It reaches a clinician.** Live on the standalone at this branch's HEAD, Margaret King
(active Dexamethasone order), asked *"Is it safe to give her estradiol?"*:

```
type=interaction drug=Fluoroestradiol f-18
Fluoroestradiol f-18 interacts with active order dexamethasone — Moderate.
Estrogens may enhance the systemic effects of both endogenous and exogenous corticosteroids...
```

A PET imaging tracer named as the subject of a question about a therapeutic oestrogen,
carrying the oestrogen's own mechanism text, on the shipped default configuration.

## The rule

`derivative-merged-with-its-parent-substance`, REPORTED. A row the dataset merged into a
substance its own name says it only DERIVES from. Two gates, each excluding a shape that
is correct:

- the family must hold a row that is **not** a derivative — the parent the merge is with;
- the name must not carry the substance's name as a bounded WORD, so presentations, salts
  and esters are read as what they are (12 shipped rows carry their substance's name that
  way: `Beclomethasone dipropionate`, `Estrone sulfate`, the four `Human immunoglobulin G`
  routes …).

**The broader predicate was measured first and rejected.** "One substance, unlike published
names" fires on 15 rows across 8 families and that set includes BOTH merges issue #164
measured as CORRECT — `Daxibotulinumtoxina`/`Botulinum toxin type A` and
`Pfizer-BioNTech Covid-19 Vaccine`/`Tozinameran`. A rule reporting those tells an operator
that this module's own correct behaviour is a data defect. So the criterion is the
relationship the row's own NAME states, which is how `containsWord` already separates
`Levoketoconazole` from `Ketoconazole` and `Esomeprazole` from `Omeprazole` everywhere else
here. Those pairs stay apart only because each derivative carries its own DrugBank id; this
rule is the residue of that mechanism.

**Shipped count: 1 row.** `Fluoroestradiol f-18 is filed as 'estradiol' beside [Estradiol,
Estradiol (topical)]` — measured through the rule itself via `getLoadStatus()`, and seen on
the wire beside `alias-names-another-substance / reported / 18`.

**REPORTED, not repaired**, for the reason the class javadoc already gives: splitting the
rows invents the fact the data is missing, and dropping the row loses four real interaction
rules. Both fail closed, silently, to fix a fail-loud.

## Evidence

- Full reactor at HEAD: **1158 api + 75 omod = 1233**, 0 failures, 53 skipped
  (`main` at `0ec44e32`: 1156 + 75 = 1231).
- Live: both findings on `GET /chartsearchai/drugreferencestatus`; the four controls
  unchanged (Mary × clarithromycin 1 Major × simvastatin, Agnes × warfarin 1 Major ×
  aspirin, Joshua × ibuprofen 2, Mary × paracetamol 0). A REPORTED rule mutates nothing, so
  those are regression controls and cannot corroborate the change; the discriminating probe
  is the status payload, which is absent unless this build is deployed and the rule is
  wired.
- Every decision confirmed load-bearing by mutation: drop the parent gate → 3 occurrences
  instead of 1, two of them naming a merge that never happened; drop `containsWord` → the
  fixture fires from the parent's side and two pre-existing "loads in silence" tests redden;
  drop the substring test → `Daxibotulinumtoxina` is reported; drop the diacritic fold →
  the localized row goes silent; drop the `namesAnything` gate →
  `Bupivacaine hcl-2 is filed as '-' beside [Marcaine]`.

## Not fixed here, and worth its own issue

`canonicalRow` names the estradiol substance after the tracer because both rows answer
`namesNoRoute()` and the tie falls to dataset order, where the tracer is index 1282 and
`Estradiol` is 1927. Four shipped families would change representative row under a third
rung preferring the row whose display name IS the family's substance name — and all four
look like improvements. That is a change to a heavily-guarded shared method with its own
blast radius, so it is reported rather than folded in here.
