### PR TITLE
harden(#242 tail): the ATC leg of the fixture sweep filtered, and four claims deleted

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceService.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugReferenceService.java
@@ -907,13 +907,9 @@ public class DrugReferenceService {
 	 *
 	 *         <p>The fall-through returns the curated format's NAME rather than "whatever the default
 	 *         is", which are equal today and are not the same fact. It is paired with
-	 *         {@link #sourceFor(String)}'s own fall-through, and that one is unconditionally
-	 *         {@link JsonDrugReferenceSource} — so were the default moved to a name {@code sourceFor}
-	 *         does not recognise, this would report the new name while the curated parser ran, and
-	 *         {@link DrugReferenceLoad#getSourceFormat()}, the inert WARN's "parser in use" and
-	 *         {@link DrugReferenceValidity#configuredSourceFormatNotUsed} would each name a parser that
-	 *         did not read the file — contradicting, within the one load, the format that parser files
-	 *         its own findings under.
+	 *         {@link #sourceFor(String)}'s own fall-through, which is unconditionally
+	 *         {@link JsonDrugReferenceSource}, so the name has to be the one that parser answers to
+	 *         however the default moves.
 	 */
 	private static String effectiveFormat(String configuredFormat) {
 		if (ChartSearchAiConstants.DRUG_REFERENCE_SOURCE_ATC.equalsIgnoreCase(configuredFormat)) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugReferenceValidityContextTest.java
@@ -865,7 +865,7 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 	 * <p>The one deliberate exception is asserted rather than skipped, so the exception cannot rot into a
 	 * hole: {@link #DELIBERATELY_MIS_SHAPED} is the subject of the rule and MUST fire it.
 	 *
-	 * <p>The fixture count is asserted too, per corpus. An enumeration that finds nothing passes every
+	 * <p>The JSON fixture count is asserted too. An enumeration that finds nothing passes every
 	 * assertion inside its own loop, which is the same failure shape one level up.
 	 */
 	@Test
@@ -912,6 +912,12 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		assertNotNull(atcFixtures, "the ATC fixture directory should be on the test classpath: " + atc);
 		List<String> atcChecked = new ArrayList<String>();
 		for (File fixture : atcFixtures) {
+			// Extension-filtered like the leg above: a subdirectory here would reach FileInputStream and
+			// throw rather than fail as a finding, and a file of another format placed here would be
+			// reported by a message that names the DDInter exemption and so points away from the cause.
+			if (!fixture.getName().endsWith(".tsv")) {
+				continue;
+			}
 			atcChecked.add(fixture.getName());
 			try (InputStream in = new FileInputStream(fixture)) {
 				if (AtcDrugReferenceSource.parse(in).isEmpty()) {
@@ -926,8 +932,11 @@ public class DrugReferenceValidityContextTest extends BaseModuleContextSensitive
 		assertTrue(checked.size() > 40,
 				"the enumeration has to find the fixtures, or every check inside it is vacuous — found "
 						+ checked.size() + ": " + checked);
+		// Weaker than its JSON counterpart and worth saying so: `atc` is derived from ATC_SAMPLE's own
+		// URL, so that file is in the listing by construction. What can actually fall here is the
+		// extension filter above drifting off the corpus, which is the whole of what this buys.
 		assertFalse(atcChecked.isEmpty(),
-				"and the ATC corpus has to be found too, or its leg is vacuous: " + atc);
+				"the .tsv filter no longer matches anything in " + atc);
 		assertEquals("[]", wrong.toString(),
 				"every fixture must parse to entries under the parser its name selects, and only "
 						+ DELIBERATELY_MIS_SHAPED + " must not");

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/JsonDrugReferenceSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/JsonDrugReferenceSourceTest.java
@@ -22,6 +22,10 @@ import org.openmrs.module.chartsearchai.LogCapture;
  * Exercises the real {@link JsonDrugReferenceSource#load()} path. With no OpenMRS
  * context available it falls back to the bundled {@code /chartsearchai/drug-reference.json}
  * — the production default — so this runs the real load path against the real dataset.
+ *
+ * <p>One case does not, and says so in its own javadoc: the issue #242 case feeds the real
+ * {@link JsonDrugReferenceSource#parse} a fixture of ANOTHER format, because what it is about is the
+ * document this parser cannot read rather than the dataset it can.
  */
 public class JsonDrugReferenceSourceTest {
 

--- a/api/src/test/resources/chartsearchai-test/ddi-empty-interactions-table.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-empty-interactions-table.json
@@ -1,6 +1,6 @@
 {
  "metadata": {
-  "note": "The well-shaped twin of `ddi-no-interactions-table.json`: the same three drug rows, plus the `interactions` key below - which is EMPTY on purpose, so the pair isolates the presence of the key rather than confusing it with the table having rows. A drug catalogue declaring no interactions is a coherent document and loads all three rows here, which is why issue #242's remedy is REPORTED rather than a refusal. It is also what makes the twin's silence assertion able to fail: this load's entry count is asserted equal to the number of rows the twin's finding says were discarded, so a fixture edited on one side and not the other reddens. Verbatim DDInter 2.0 rows, unedited."
+  "note": "The well-shaped twin of `ddi-no-interactions-table.json`: the same three drug rows, plus the `interactions` key below - which is EMPTY on purpose, so the pair isolates the presence of the key rather than confusing it with the table having rows. A drug catalogue declaring no interactions is a coherent document and loads all three rows here, which is why issue #242's remedy is REPORTED rather than a refusal. Verbatim DDInter 2.0 rows, unedited."
  },
  "mechanisms": {
   "1105": {


### PR DESCRIPTION
The tail of #242's hardening. **PR #264 was merged at 07:35:32Z while Phase 2 pass 3 was still running**, so these four files missed it by about five minutes. Nothing here changes the fix's behaviour — the only code change is test-side.

Follows #264 (merged as `81827a36`). Same issue: #242.

## What is here

**One real test fix.** The corpus sweep's ATC leg had no extension filter, unlike its JSON sibling. Two consequences: a subdirectory under `api/src/test/resources/atc/` would reach `new FileInputStream(...)` and throw `FileNotFoundException (Is a directory)` rather than failing as a finding; and a file of another format placed there — which is the natural home for the fixture of the ATC rule `DrugReferenceValidity#datasetMissingARequiredTable` explicitly parks as pending — would redden the sweep under a message naming the *DDInter* exemption, pointing away from the cause. Now filtered to `.tsv`.

**One honest downgrade.** `assertFalse(atcChecked.isEmpty(), …)` claimed to catch an empty ATC corpus, but the directory is derived from `ATC_SAMPLE`'s own URL, so that file is in the listing by construction — the assertion cannot fail for the reason it stated. Kept, because the `.tsv` filter string *can* still drift off the corpus, but its message now says that, and the sweep's javadoc no longer claims a fixture count "per corpus".

**Four claims deleted rather than re-worded.** Two of them were falsehoods introduced by the *previous* hardening pass's own corrections, which is the point at which the right move is to remove a claim rather than attempt it again:

- the empty-interactions fixture note used "the twin" for two different files inside one sentence, so one clause was false on either reading. Clause removed — the test javadoc already carries the relation.
- a comment justified the `.tsv` filter by a rule "this sweep's own javadoc parks as pending". It is parked in `DrugReferenceValidity`, not there, so the pointer led nowhere.
- `effectiveFormat`'s new paragraph ended in a counterfactual whose subject bound to the fall-through *as written*, making it false of the code two lines below it. Cut; the first sentence already states the distinction. **The code there is unchanged and already merged** — only the trailing sentence goes.

**One addition.** `JsonDrugReferenceSourceTest`'s class javadoc said every case exercises the real `load()` against the bundled dataset. The #242 case does not: it feeds the real `parse` a fixture of another format, which is the whole point of it.

## Build

Full reactor `mvn -o clean install` on this branch, on top of `main` @ `81827a36`: **1186 api + 75 omod = 1261**, 0 failures, 53 skipped — identical to `main`, since nothing here adds or removes a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eoDS1LebCUy3NXyN2L9wp
