### PR TITLE
fix(frontend): a stale pre-compressed importmap shadows the assembled one, so no browser loads the ESM

### DIFF
--- a/.github/scripts/assert-spa-serves-chartsearchai.mjs
+++ b/.github/scripts/assert-spa-serves-chartsearchai.mjs
@@ -1,0 +1,150 @@
+// Post-deploy gate: assert the deployed SPA actually loads the Chart Search AI ESM.
+//
+// Why this exists. The deploy wrapper's exit code says the compose project was
+// acted on, not that a clinician can see the feature. On 2026-08-25 the deploy
+// was green and the backend module was loaded and healthy — drugreferencestatus
+// reported 2283 entries — while the AI icon was absent from every patient
+// chart, because a stale pre-compressed importmap (importmap.json.br, and .gz
+// beside it) in the frontend image shadowed the assembled one and the browser
+// never imported the ESM. Nothing in the deploy workflow could have said so.
+//
+// Why a browser rather than curl, and why HEADED. Three measurements, 2026-08-25:
+//
+//   1. The instance is behind Cloudflare, which answers a plain request with
+//      403 and a managed challenge — on every path tried
+//      (/openmrs/ws/rest/v1/session, /openmrs/spa/importmap.json,
+//      /openmrs/index.htm), with and without a browser User-Agent. A
+//      curl-based gate cannot reach the origin, so it would assert nothing
+//      while looking green.
+//   2. HEADLESS Chromium is challenged too: the page never leaves the
+//      interstitial (title stays "Loading …") and an in-page fetch throws.
+//      Headed Chromium cleared the challenge and read the importmap at t+10s.
+//      So this launches headed and CI runs it under xvfb.
+//   3. The regression itself is only visible to a client that asks for a
+//      compressed response. The frontend image's nginx serves <file>.br or
+//      <file>.gz when one exists, trying .br first; a plain curl sends no
+//      Accept-Encoding, and measured directly against the image it read the
+//      CORRECT plain importmap while both compressed siblings were stale.
+//      Every browser asks for br and gzip; so does fetch() here.
+//
+// This reads only files nginx serves statically, so it does not wait on
+// OpenMRS's own startup, which can run to 30 minutes on a first boot.
+//
+// Usage: xvfb-run -a node assert-spa-serves-chartsearchai.mjs [baseUrl]
+
+import { chromium } from 'playwright';
+
+const BASE = (process.argv[2] || 'https://chartsearchai.openmrs.org').replace(/\/+$/, '');
+const ESM = '@openmrs/esm-chartsearchai-app';
+const IMPORTMAP = '/openmrs/spa/importmap.json';
+const ROUTES = '/openmrs/spa/routes.registry.json';
+
+// Overridable so the gate can be exercised without waiting out the full poll.
+const ATTEMPTS = Number(process.env.GATE_ATTEMPTS || 10);
+const DELAY_MS = Number(process.env.GATE_DELAY_MS || 30_000);
+const CHALLENGE_MS = Number(process.env.GATE_CHALLENGE_MS || 60_000);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Reads the two files that decide whether the ESM is loaded at all.
+ *
+ * The Cloudflare challenge is waited out by polling for a response that is not
+ * a 403, rather than by sleeping a fixed interval — a fixed sleep either
+ * over-waits on every healthy run or reports the challenge as an outage.
+ */
+async function probe(page, paths) {
+  await page.goto(`${BASE}/openmrs/spa/login`, { waitUntil: 'domcontentloaded', timeout: 120_000 });
+  return page.evaluate(
+    async ({ paths, challengeMs }) => {
+      const read = async (path) => {
+        const deadline = Date.now() + challengeMs;
+        for (;;) {
+          try {
+            const r = await fetch(path, { cache: 'no-store' });
+            if (r.status !== 403 || Date.now() > deadline) {
+              return {
+                status: r.status,
+                encoding: r.headers.get('content-encoding'),
+                body: await r.text(),
+              };
+            }
+          } catch (e) {
+            if (Date.now() > deadline) return { status: 0, encoding: null, body: '', error: e.message };
+          }
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        }
+      };
+      const out = {};
+      for (const [key, path] of Object.entries(paths)) out[key] = await read(path);
+      return out;
+    },
+    { paths, challengeMs: CHALLENGE_MS },
+  );
+}
+
+/** Returns the reasons the deployment is not serving the ESM; empty means healthy. */
+function problemsWith({ importmap, routes }) {
+  const problems = [];
+  const enc = (r) => `content-encoding: ${r.encoding ?? 'none'}`;
+
+  if (importmap.status !== 200) {
+    problems.push(`${IMPORTMAP} returned HTTP ${importmap.status}${importmap.error ? ` (${importmap.error})` : ''}`);
+  } else {
+    let names;
+    try {
+      names = Object.keys(JSON.parse(importmap.body).imports || {});
+    } catch {
+      problems.push(`${IMPORTMAP} was not parseable JSON (${enc(importmap)})`);
+    }
+    if (names && !names.includes(ESM)) {
+      problems.push(`${IMPORTMAP} names ${names.length} modules and none of them is ${ESM} (${enc(importmap)})`);
+    }
+  }
+
+  if (routes.status !== 200) {
+    problems.push(`${ROUTES} returned HTTP ${routes.status}${routes.error ? ` (${routes.error})` : ''}`);
+  } else if (!routes.body.includes('chartsearchai')) {
+    problems.push(`${ROUTES} names no chartsearchai route (${enc(routes)})`);
+  }
+
+  return problems;
+}
+
+const browser = await chromium.launch({ headless: false });
+try {
+  const page = await browser.newPage();
+  let problems = ['the gate never completed a probe'];
+
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    try {
+      problems = problemsWith(await probe(page, { importmap: IMPORTMAP, routes: ROUTES }));
+    } catch (e) {
+      problems = [`probe failed: ${e.message.split('\n')[0]}`];
+    }
+    if (problems.length === 0) {
+      console.log(`OK: ${BASE} serves an importmap naming ${ESM} (attempt ${attempt})`);
+      process.exit(0);
+    }
+    console.log(`attempt ${attempt}/${ATTEMPTS}: ${problems.join('; ')}`);
+    if (attempt < ATTEMPTS) await sleep(DELAY_MS);
+  }
+
+  console.error(`\nFAILED: ${BASE} does not load ${ESM}.`);
+  for (const p of problems) console.error(`  - ${p}`);
+  console.error(
+    [
+      '',
+      'The backend module can be installed and healthy and this still fails: the',
+      'icon is drawn by the ESM, so an importmap that does not name it means the',
+      'browser never loads it. Check that the frontend container runs',
+      'openmrs/openmrs-reference-application-3-frontend:nightly-chartsearch, and',
+      'that no stale importmap.json.br or .gz shadows the assembled',
+      'importmap.json — Dockerfile.frontend guards the image against exactly',
+      'that at build time.',
+    ].join('\n'),
+  );
+  process.exit(1);
+} finally {
+  await browser.close();
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
       name: chartsearchai
       url: https://chartsearchai.openmrs.org/openmrs/spa
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Deploy via scoped SSH
         env:
           DEPLOY_COMMAND: ${{ inputs.reset && 'deploy emr-3-ai --destroy-volumes --no-health-check' || 'deploy emr-3-ai --no-health-check' }}
@@ -34,3 +36,34 @@ jobs:
             -o StrictHostKeyChecking=yes \
             deploy@${{ secrets.SERVER_HOST }} \
             "$DEPLOY_COMMAND"
+
+      # The wrapper's exit code says the compose project was acted on, not that
+      # a clinician can see the feature. #275 asked for a post-deploy gate for
+      # that reason; this is the narrowest one that would have caught a real
+      # outage. On 2026-08-25 the deploy was green, the backend module was
+      # loaded and healthy (drugreferencestatus reported 2283 entries), and the
+      # AI icon was absent from every patient chart because a stale
+      # pre-compressed importmap in the frontend image (importmap.json.br, the
+      # variant a browser is served) shadowed the assembled one. Nothing in
+      # this workflow could have said so.
+      #
+      # It reads only files nginx serves statically, so it does not wait on
+      # OpenMRS's own startup — which is why --no-health-check above stays as it
+      # is rather than being traded for a gate that can time out on a legitimate
+      # first boot.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      # xvfb-run because the browser must be HEADED: measured 2026-08-25, a
+      # headless Chromium never clears Cloudflare's managed challenge (the page
+      # stays on the interstitial and an in-page fetch throws), while a headed
+      # one read the importmap at t+10s. The script's header records the rest.
+      - name: Assert the deployed SPA loads the Chart Search AI ESM
+        run: |
+          sudo apt-get update && sudo apt-get install -y xvfb
+          npm install --no-save playwright@1.59.1
+          npx playwright install --with-deps chromium
+          xvfb-run -a node .github/scripts/assert-spa-serves-chartsearchai.mjs \
+            "https://chartsearchai.openmrs.org"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ de/
 # Python bytecode from running the eval harnesses locally
 __pycache__/
 *.pyc
+
+# The post-deploy gate installs playwright into the repo root (see
+# .github/workflows/deploy.yml); nothing here is a checked-in dependency.
+node_modules/

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -19,7 +19,65 @@ WORKDIR /app
 
 RUN openmrs assemble --mode config --config spa-build-config.json
 
+# Give the assembled SPA the pre-compressed siblings the base image's nginx
+# expects. Without them the base's own siblings answer for these files — see
+# the deletion in the next stage.
+#
+# This runs in the BUILDPLATFORM stage on purpose. It compressed 6031 files in
+# 61s here, natively; the final stage is built once per target platform, so
+# doing it there would run the whole pass under qemu for linux/arm64 — where,
+# measured 2026-08-25, a shell loop doing only the gzip half took 441s in an
+# emulated amd64 container.
+COPY precompress-spa.mjs /app/precompress-spa.mjs
+RUN node /app/precompress-spa.mjs /app/dist
+
 # Use the official O3 frontend image as the base — it has the correct
 # index.html (with SPA bootstrap), nginx config, and env var substitution.
 FROM openmrs/openmrs-reference-application-3-frontend:nightly
+
+# Drop the base's pre-compressed siblings BEFORE the copy below, never after —
+# the copy brings the assembled SPA's own siblings with it.
+#
+# The base's nginx answers a request with <file>.br or <file>.gz when one
+# exists, picking the encoding from Accept-Encoding via a map in its config,
+# and it tries .br first. It pre-compresses its own assembly (3900 of each) and
+# `openmrs assemble` emitted none, so the copy replaced importmap.json and
+# routes.registry.json while leaving the base's stale siblings beside them.
+# nginx then handed every browser the base's 46-module importmap, which does
+# not name @openmrs/esm-chartsearchai-app. The ESM's own bundle shipped and was
+# reachable — a new filename has no stale sibling to shadow it — the app simply
+# never imported it, so no icon appeared on the patient chart.
+#
+# A plain curl sends no Accept-Encoding and read the correct plain file, which
+# is why this survived every check that was not a browser. Measured 2026-08-25
+# against the image published that morning: the plain importmap.json named the
+# ESM, importmap.json.gz and importmap.json.br both did not.
+#
+# Both variants matter and neither is redundant: .br is what a browser gets, so
+# a pattern covering only .gz would have left the defect in place. Anything
+# added to the nginx encoding map later belongs in this pattern too.
+#
+# The base's own module bundles stay behind, now uncompressed and unreferenced
+# by the new importmap, exactly as unreferenced as they were before.
+RUN find /usr/share/nginx/html \( -name '*.gz' -o -name '*.br' \) -delete
+
 COPY --from=build-spa /app/dist /usr/share/nginx/html
+
+# Guard the two files that decide whether the ESM is loaded at all.
+#
+# The .gz halves are checked by content. The .br halves are checked by mtime
+# against their source, because this stage has no brotli decompressor and
+# precompress-spa.mjs stamps every sibling with its source's mtime — so a
+# sibling the base image left behind carries the base's timestamp and fails,
+# while one that came from the assembly matches.
+#
+# This fails the build on the shape described above: against the image
+# published before this commit, both greps exit 1.
+RUN set -eux; \
+    cd /usr/share/nginx/html; \
+    gzip -cd importmap.json.gz | grep -q '@openmrs/esm-chartsearchai-app'; \
+    gzip -cd routes.registry.json.gz | grep -q 'chartsearchai'; \
+    for f in importmap.json routes.registry.json; do \
+      test -f "$f.br"; \
+      test "$(stat -c %Y "$f.br")" = "$(stat -c %Y "$f")"; \
+    done

--- a/precompress-spa.mjs
+++ b/precompress-spa.mjs
@@ -1,0 +1,116 @@
+// Pre-compress an assembled OpenMRS SPA in place, writing the .gz and .br
+// siblings its nginx expects.
+//
+// The frontend image's nginx answers a request with <file>.br or <file>.gz when
+// one exists, chosen from Accept-Encoding by a map in its config (br is tried
+// first, so it is the variant a browser actually receives). It ships such
+// siblings for its OWN assembly — measured 2026-08-25: 3900 .gz and 3900 .br —
+// while `openmrs assemble` emits none. Without this script the siblings beside
+// the assembled files are therefore the base image's, and they answer for
+// content that no longer exists. See Dockerfile.frontend for what that cost.
+//
+// A sibling is kept only where it is actually smaller than its source, so no
+// extension allow-list is needed and none can drift out of date.
+//
+// Brotli runs at quality 9, not the maximum. Measured 2026-08-25 on a 250-file,
+// 12.6 MB spread taken across a real SPA tree of 6554 compressible files, with
+// the time column scaled to that whole tree:
+//
+//   q9   2.55 MB    ~20s        gzip -9, for comparison: 2.82 MB
+//   q10  2.31 MB   ~149s
+//   q11  2.25 MB   ~418s
+//
+// Confirmed on the real thing rather than left as an extrapolation: over this
+// image's own 6031-file assembly, both encodings together take 61s at q9,
+// against 354s for the q11 build it replaced.
+//
+// So the maximum costs about five extra minutes of every image build — and this
+// image is rebuilt on every push to main — to land 2.6% under q10. What these
+// siblings have to be is CURRENT: a stale one is the defect Dockerfile.frontend
+// describes, and no compression level protects against it. The demo also sits
+// behind Cloudflare, which re-encodes, so the origin's brotli level barely
+// reaches a browser there at all; it only reaches a deployment served directly.
+// Raise it here if that changes, and re-measure rather than assuming these
+// numbers still hold.
+//
+// index.html is skipped deliberately: the image's startup.sh rewrites it at
+// container start (envsubst of SPA_PATH, API_URL, SPA_CONFIG_URLS, …), so a
+// pre-compressed copy would shadow the substituted file in exactly the way
+// this script exists to prevent. Today `openmrs assemble` emits no index.html
+// at all — the base image supplies it — and this keeps the invariant if that
+// ever changes.
+//
+// Each sibling is stamped with its source's mtime. Dockerfile.frontend's guard
+// reads that to tell a sibling that came from the assembly apart from one left
+// behind by the base image, which it cannot do by content because the final
+// stage has no brotli decompressor.
+//
+// Usage: node precompress-spa.mjs <dist-dir>
+
+import { constants, brotliCompressSync, gzipSync } from 'node:zlib';
+import { readdirSync, readFileSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SKIP_NAMES = new Set(['index.html']);
+const SKIP_EXTENSIONS = ['.gz', '.br'];
+const BROTLI_QUALITY = 9;
+const GZIP_LEVEL = 9;
+
+const dist = process.argv[2];
+if (!dist) {
+  console.error('usage: node precompress-spa.mjs <dist-dir>');
+  process.exit(2);
+}
+
+function* files(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* files(path);
+    else if (entry.isFile()) yield path;
+  }
+}
+
+const encoders = [
+  { extension: '.gz', encode: (buf) => gzipSync(buf, { level: GZIP_LEVEL }) },
+  {
+    extension: '.br',
+    encode: (buf) =>
+      brotliCompressSync(buf, {
+        params: {
+          [constants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY,
+          [constants.BROTLI_PARAM_SIZE_HINT]: buf.length,
+        },
+      }),
+  },
+];
+
+let considered = 0;
+const written = Object.fromEntries(encoders.map((e) => [e.extension, 0]));
+const startedAt = Date.now();
+
+for (const path of files(dist)) {
+  const name = path.slice(path.lastIndexOf('/') + 1);
+  if (SKIP_NAMES.has(name)) continue;
+  if (SKIP_EXTENSIONS.some((extension) => name.endsWith(extension))) continue;
+
+  const source = readFileSync(path);
+  const { atime, mtime } = statSync(path);
+  considered++;
+
+  for (const { extension, encode } of encoders) {
+    const encoded = encode(source);
+    // Serving a sibling that is larger than its source costs bandwidth rather
+    // than saving it, so it is simply not written.
+    if (encoded.length >= source.length) continue;
+    const sibling = path + extension;
+    writeFileSync(sibling, encoded);
+    utimesSync(sibling, atime, mtime);
+    written[extension]++;
+  }
+}
+
+const summary = encoders.map((e) => `${written[e.extension]} ${e.extension}`).join(', ');
+console.log(
+  `precompressed ${considered} file(s) under ${dist}: ${summary}` +
+    ` in ${Math.round((Date.now() - startedAt) / 1000)}s`,
+);


### PR DESCRIPTION
## What

The Chart Search AI icon is absent from every patient chart on
https://chartsearchai.openmrs.org, and has been for at least two releases. The
backend module is installed, started and healthy the whole time —
`GET /openmrs/ws/rest/v1/chartsearchai/drugreferencestatus` answers 200 with
`loaded: true`, 2283 entries, `sourceFormat: ddinter` — and the ESM's own bundle
is deployed and reachable. The browser simply never imports it.

## Root cause

The frontend image's nginx answers a request with `<file>.br` or `<file>.gz`
when one exists, choosing from `Accept-Encoding` via a map in its config, and it
tries `.br` first. The base image pre-compresses its **own** assembly — measured
3900 `.gz` and 3900 `.br` — and `openmrs assemble` emits none, so

```dockerfile
FROM openmrs/openmrs-reference-application-3-frontend:nightly
COPY --from=build-spa /app/dist /usr/share/nginx/html
```

replaced `importmap.json` and `routes.registry.json` while leaving the base's
stale siblings beside them. nginx then handed every browser the base's
46-module importmap, which does not name `@openmrs/esm-chartsearchai-app`.

The ESM's bundle shipped and was reachable — a new filename has no stale
sibling to shadow it — the app just never imported it. Nothing was misconfigured
on the host, and no image tag was wrong.

**This is why no check caught it.** A plain `curl` sends no `Accept-Encoding`, so
it read the correct plain file. Measured against the image published
2026-08-25T08:08, same container, same URL:

| `Accept-Encoding` | Last-Modified | modules | names the ESM |
|---|---|---|---|
| `identity` | 08:08:27 (the assembly) | **44** | **yes** |
| `gzip` | 07:18:33 (the base) | 46 | no |
| `br` | 07:18:33 (the base) | 46 | no |

`docker exec cat importmap.json` reads the correct file too. Only a client that
asks for a compressed response sees the stale one — which is every browser.

The live demo matches exactly: its importmap comes back with 46 modules and no
`chartsearchai`, `routes.registry.json` names no chartsearchai route, and a DOM
scan of a patient chart finds no AI control.

## The fix

- `precompress-spa.mjs` (new) gives the assembled SPA the `.gz` and `.br`
  siblings nginx expects, keeping a sibling only where it is actually smaller
  than its source, so there is no extension allow-list to drift. Siblings are
  stamped with their source's mtime, which the guard below reads.
- `Dockerfile.frontend` deletes the base's siblings **before** the copy (never
  after — the copy now brings its own), runs the pre-compression in the
  `BUILDPLATFORM` stage so the pass does not run under qemu for `linux/arm64`,
  and then **guards** the two files that decide whether the ESM loads at all.
- `.github/workflows/deploy.yml` gains a post-deploy gate — the repo-side half
  of #275, which asked for exactly this after a different silent staleness.

Brotli runs at quality 9 rather than the maximum, measured rather than guessed —
on a 250-file, 12.6 MB spread across a 6554-file SPA tree, scaled to the tree:

| level | brotli output | time |
|---|---|---|
| q9 | 2.55 MB | ~20s |
| q10 | 2.31 MB | ~149s |
| q11 | 2.25 MB | ~418s |

Confirmed on the real assembly rather than left as an extrapolation: 6031 files,
both encodings, **61s at q9 against 354s for the q11 build it replaced**. What
these siblings have to be is *current* — a stale one is this whole bug — not
maximally small, and the demo sits behind Cloudflare, which re-encodes anyway.

**The guard reddens on the real defect.** Run against the image published before
this commit:

```
$ docker run --rm openmrs/openmrs-reference-application-3-frontend:nightly-chartsearch \
    sh -c 'gzip -cd /usr/share/nginx/html/importmap.json.gz | grep -q "@openmrs/esm-chartsearchai-app"'
$ echo $?
1
```

`.br` is checked by mtime rather than content because the final stage has no
brotli decompressor; a sibling the base left behind carries the base's timestamp
and fails, one from the assembly matches.

## The deploy gate needs a browser, and needs to be headed

Three measurements, 2026-08-25, all of which shape it:

1. The instance is behind Cloudflare, which answers a plain request with 403 and
   a managed challenge — on every path tried, with and without a browser
   User-Agent. A curl-based gate cannot reach the origin, so it would assert
   nothing while looking green.
2. **Headless** Chromium is challenged too: the page never leaves the
   interstitial and an in-page `fetch` throws. Headed Chromium cleared the
   challenge and read the importmap at t+10s. So the gate runs headed under
   `xvfb`.
3. The defect is invisible to a client that does not ask for compression, per
   the table above — a browser's `fetch` asks.

Run against the live instance today it fails, for the right reason:

```
attempt 1/1: /openmrs/spa/importmap.json names 46 modules and none of them is
@openmrs/esm-chartsearchai-app (content-encoding: br); /openmrs/spa/routes.registry.json
names no chartsearchai route (content-encoding: br)
```

It reads only files nginx serves statically, so it does not wait on OpenMRS's
own startup — which is why `--no-health-check` stays as it is rather than being
traded for a gate that can time out on a legitimate first boot.

**Expect the first deploy after this merges to be the one that proves it.** The
gate will stay red until `Build Docker Images` has published a frontend image
built from this commit and `Deploy to Server` has picked it up, in that order.

## Verified

Built locally and served, checking the thing a browser actually receives:

```
importmap.json         identity  http=200 enc=none  44 modules, names the ESM: true
importmap.json         gzip      http=200 enc=gzip  44 modules, names the ESM: true
importmap.json         br        http=200 enc=br    44 modules, names the ESM: true
routes.registry.json   identity  http=200 enc=none  chartsearchai route: true
routes.registry.json   gzip      http=200 enc=gzip  chartsearchai route: true
routes.registry.json   br        http=200 enc=br    chartsearchai route: true
```

`index.html` is served substituted (0 unsubstituted placeholders) with no
compressed sibling beside it — the base ships an `index.html.gz`/`.br` still
carrying `$SPA_PATH`/`$API_URL`, which `startup.sh` cannot reach because it only
rewrites the plain file. nginx does not serve those for `/` today, so that one
was latent rather than live; deleting them closes it.

## What this does not cover

- Whether the gateway container is the chartsearch build is still undetermined.
  `X-Accel-Buffering: no` was absent from a request to the stream location on
  the live instance, but Cloudflare sits in front and may strip it, so that
  observation proves nothing either way. `Dockerfile.gateway` is unchanged.
- The gate depends on clearing Cloudflare's challenge from a GitHub Actions IP,
  which is not something this repo controls; datacenter ranges are scored more
  harshly than a laptop. If it proves flaky, the durable fix is a WAF bypass for
  a secret header or for the runner ranges, after which the gate can drop the
  browser entirely — #275 reached the same conclusion from the other direction.
- The base image's own module bundles stay behind, now uncompressed and
  unreferenced by the new importmap. They were already unreferenced. Pruning
  the base's assembly down to the files that are actually used is a larger and
  separate change; this one deliberately does not attempt it.
- The build guard runs inside `Build Docker Images`, which triggers on push to
  `main` only, so it gates *publication* rather than merge: a regression would
  turn that run red and publish nothing, but would not redden this PR. Giving
  the workflow a `pull_request` trigger with `push: false` would close that, and
  is left out here as its own change.
- The image grows from 898 MB to 1.03 GB — the new siblings are 159 MB, of which
  68 MB is source maps. The base pre-compresses maps too (1083 of its 2927), so
  this keeps parity with it rather than inventing an exclusion.

## Provenance

Every figure above was measured on 2026-08-25 against the published
`openmrs/openmrs-reference-application-3-frontend:nightly-chartsearch` (amd64,
built 08:08 UTC) and against the live instance driven through a real Chromium,
not inferred from the Dockerfile. The sibling counts come from `find` inside the
image; the encoding table from three `curl` runs against a container of it; the
importmap and routes-registry contents on the live instance from in-page
`fetch`; the backend's health from its own `drugreferencestatus` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
