### PR TITLE
fix(drug-safety): the drug-in-play interaction arm states its most severe finding first

### DIFF
--- a/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
+++ b/api/src/main/java/org/openmrs/module/chartsearchai/reference/DrugSafetyValidator.java
@@ -2367,6 +2367,13 @@ public class DrugSafetyValidator {
 		DrugReference ref = subjects.subjectOf(rows.get(0));
 		List<SubjectRule> rules = new ArrayList<SubjectRule>(
 				bestRulePerPartner(rows, context, severityFloor, orderEntries));
+		// Most severe first, matching addQuestionPairInteractions and addActiveOrderPairInteractions
+		// (issue #346) — this arm used to leave the chips in the knowledge base's own row order, so an
+		// answer that enumerates them and stops partway through could drop the single most severe
+		// finding while stating several milder ones. Collections.sort is stable, so two rules tied on
+		// severity keep the dataset order the loop above produced them in, exactly as the other two
+		// arms already do.
+		Collections.sort(rules, RULE_SEVERITY_DESCENDING);
 		// Which rule row carries which class sentence, decided before anything is emitted: the class
 		// arm is walked per active-order CO-MEDICATION (issue #171 — it used to walk per CODE, so a
 		// substance filed under several codes reached this loop once per code) while the chips are one
@@ -2907,6 +2914,18 @@ public class DrugSafetyValidator {
 		}
 	}
 
+	/** Orders the drug-in-play arm's candidate rules most-severe first (issue #346); see
+	 *  {@link #severityPriority}. The same ordering {@link #PAIR_SEVERITY_DESCENDING} and
+	 *  {@link #SCREENED_PAIR_SEVERITY_DESCENDING} already apply to the other two interaction arms, on
+	 *  {@link SubjectRule} rather than on either of those arms' own candidate types. */
+	private static final Comparator<SubjectRule> RULE_SEVERITY_DESCENDING = new Comparator<SubjectRule>() {
+
+		@Override
+		public int compare(SubjectRule a, SubjectRule b) {
+			return Integer.compare(severityPriority(b.rule.getSeverity()), severityPriority(a.rule.getSeverity()));
+		}
+	};
+
 	/**
 	 * The (substance, partner) pairs an interaction chip has already been raised for in this pass, so the
 	 * screening arm ({@link #addActiveOrderPairInteractions}) can stand down from a pair the drug-in-play
@@ -3095,9 +3114,12 @@ public class DrugSafetyValidator {
 	 *         both name one order: across the full KB exactly one such pair exists, {@code enalapril}
 	 *         and {@code enalaprilat}, two genuinely different entries which that grouping deliberately
 	 *         keeps as two chips — the population that figure counts, and its base, are named at
-	 *         {@link #bestRulePerPartner} (issue #263). The first in dataset order takes the fold; the
-	 *         other keeps its rule chip unfolded, which is the conservative direction, since the
-	 *         alternative is stating one duplicate-therapy relationship twice.
+	 *         {@link #bestRulePerPartner} (issue #263). Since issue #346 {@code rules} arrives sorted
+	 *         most-severe-first ({@link #RULE_SEVERITY_DESCENDING}), so the first of the two to match
+	 *         takes the fold — the more severe of the two against this order where they differ, else
+	 *         whichever the dataset lists first, since the sort is stable. The other keeps its rule
+	 *         chip unfolded, which is the conservative direction, since the alternative is stating one
+	 *         duplicate-therapy relationship twice.
 	 */
 	private SubjectRule ruleAbout(Set<String> orderCodes, List<SubjectRule> rules,
 			CoMedications coMedications) {

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/CoMedicationResolutionPerPassTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/CoMedicationResolutionPerPassTest.java
@@ -126,18 +126,25 @@ public class CoMedicationResolutionPerPassTest {
 	 * is called, the rating and the arrival order, and it still fails if sharing one partner list
 	 * across two subjects disturbs any of them. A rename that made these lower-case again would fail
 	 * {@code OneOrderNameAcrossOneResponseTest} instead.
+	 *
+	 * <p><b>The WITHIN-SUBJECT order moved once more, for issue #346.</b>
+	 * {@code DrugSafetyValidator.addInteractionWarnings} now sorts each subject's own rule chips
+	 * most-severe-first (matching the two pairwise arms, which already sorted) instead of leaving them
+	 * in the knowledge base's own row order, so each subject's block below is reordered accordingly —
+	 * content, partner, name and rating are untouched, and so is the pairwise entry after them, which
+	 * that arm sorts on its own and this fixture never lets exceed one pair.
 	 */
 	private static final List<String> TWO_DRUG_CHIPS = Arrays.asList(
-			"interaction | Minor | Simvastatin interacts with active order Warfarin",
-			"interaction | Moderate | Simvastatin interacts with active order Ciprofloxacin",
 			"interaction | Major | Simvastatin interacts with active order Amiodarone",
+			"interaction | Moderate | Simvastatin interacts with active order Ciprofloxacin",
+			"interaction | Minor | Simvastatin interacts with active order Warfarin",
+			"interaction | Major | Clarithromycin interacts with active order Warfarin",
+			"interaction | Major | Clarithromycin interacts with active order Digoxin",
+			"interaction | Major | Clarithromycin interacts with active order Amiodarone",
 			"interaction | Moderate | Clarithromycin interacts with active order Metformin",
 			"interaction | Moderate | Clarithromycin interacts with active order Sertraline",
 			"interaction | Moderate | Clarithromycin interacts with active order Tramadol",
-			"interaction | Major | Clarithromycin interacts with active order Warfarin",
 			"interaction | Moderate | Clarithromycin interacts with active order Ciprofloxacin",
-			"interaction | Major | Clarithromycin interacts with active order Digoxin",
-			"interaction | Major | Clarithromycin interacts with active order Amiodarone",
 			"interaction | Major | Simvastatin interacts with Clarithromycin, also named in the question");
 
 	/** A question naming nothing the excerpt classifies, so no arm asks for a co-medication. */

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
@@ -501,11 +501,21 @@ public class DdiDrugReferenceSourceTest {
 		// Real slice: Dolutegravir's rows in dataset order are phenytoin (Major), iron (Major, the
 		// shorter note), dexamethasone (Minor), iron (Major, the fuller note). With iron AND
 		// dexamethasone both active, iron's group is opened first, dexamethasone's group is opened
-		// next, and only THEN does iron's second row take its group — so this is the arrangement in
-		// which a collapse that re-inserts a replaced winner (a HashMap, or remove-then-put) puts
-		// dexamethasone's chip ahead of iron's. Chip order is first-appearance order and the
-		// clinician reads the list top-down, so the most severe finding must not be demoted by the
-		// mechanics of the collapse.
+		// next, and only THEN does iron's second row takes its group — a winner replacement
+		// (bestRulePerPartner's LinkedHashMap re-put) in between the two groups being opened.
+		//
+		// Before issue #346 this was also the one thing deciding chip order: the arm raised its chips
+		// in whatever order the map's iteration produced, so a collapse that re-inserted a replaced
+		// winner (a plain HashMap, or remove-then-put) would have put dexamethasone's chip ahead of
+		// iron's here. Since #346 the arm sorts most-severe-first
+		// (DrugSafetyValidator.RULE_SEVERITY_DESCENDING), so iron (Major) now precedes dexamethasone
+		// (Minor) for that reason alone, whichever order the map produced them in — this fixture's two
+		// severities differ, so it no longer independently exercises the winner-replacement mechanic
+		// the comment above describes; it only shows that severity governs, which
+		// DrugInPlayInteractionSeverityOrderTest already pins directly and more simply. The
+		// map-mutation regression this case was built for would need two partners TIED on severity to
+		// surface again — untested since #346, and worth a dedicated case if that map ever needs to
+		// change.
 		List<SafetyWarning> warnings = routeVariantValidator().validate(
 				"Dolutegravir could be started.", "Is it safe to start dolutegravir?",
 				DrugReferenceTestSupport.ctx(60, null,
@@ -518,8 +528,8 @@ public class DdiDrugReferenceSourceTest {
 		// business, and pinning its opening words here would couple this case to the note text.
 		assertTrue(warnings.get(0).getDetail()
 				.startsWith("Dolutegravir interacts with active order iron — Major. "),
-				"iron's row appears first in the dataset, so its chip must come first even though its"
-						+ " group's winner was decided last, was: " + warnings.get(0).getDetail());
+				"iron is rated Major and must sort ahead of dexamethasone's Minor, whichever order its "
+						+ "own group's winner was decided in, was: " + warnings.get(0).getDetail());
 		assertTrue(warnings.get(1).getDetail()
 				.startsWith("Dolutegravir interacts with active order dexamethasone — Minor. "),
 				"dexamethasone's chip must stay second, was: " + warnings.get(1).getDetail());

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DdiDrugReferenceSourceTest.java
@@ -501,7 +501,7 @@ public class DdiDrugReferenceSourceTest {
 		// Real slice: Dolutegravir's rows in dataset order are phenytoin (Major), iron (Major, the
 		// shorter note), dexamethasone (Minor), iron (Major, the fuller note). With iron AND
 		// dexamethasone both active, iron's group is opened first, dexamethasone's group is opened
-		// next, and only THEN does iron's second row takes its group — a winner replacement
+		// next, and only THEN does iron's second row take its group — a winner replacement
 		// (bestRulePerPartner's LinkedHashMap re-put) in between the two groups being opened.
 		//
 		// Before issue #346 this was also the one thing deciding chip order: the arm raised its chips

--- a/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugInPlayInteractionSeverityOrderTest.java
+++ b/api/src/test/java/org/openmrs/module/chartsearchai/reference/DrugInPlayInteractionSeverityOrderTest.java
@@ -1,0 +1,73 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.chartsearchai.reference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #346 — the drug-in-play interaction arm ({@link DrugSafetyValidator#addInteractionWarnings})
+ * appended one chip per partner in the knowledge base's own row order, with no severity sort, unlike
+ * the other two interaction arms ({@code addQuestionPairInteractions}, {@code
+ * addActiveOrderPairInteractions}), which both sort most-severe-first before emitting
+ * ({@code PAIR_SEVERITY_DESCENDING}, {@code SCREENED_PAIR_SEVERITY_DESCENDING}). An LLM answer that
+ * enumerates the chips it is given and stops partway through then drops whichever finding happens to
+ * sit last in the KB — which can be the most severe one, exactly as it was live on issue #346's
+ * warfarin/ibuprofen reproduction.
+ *
+ * <p>Runs the real production path: a verbatim-shaped DDInter fixture parsed by the real
+ * {@link DdiDrugReferenceSource}, and the real {@link DrugSafetyValidator#validate} entry point.
+ */
+public class DrugInPlayInteractionSeverityOrderTest {
+
+	private static final String FIXTURE = "chartsearchai-test/ddi-drug-in-play-severity-order.json";
+
+	private static List<SafetyWarning> interactionChips(List<SafetyWarning> warnings) {
+		List<SafetyWarning> out = new ArrayList<SafetyWarning>();
+		for (SafetyWarning warning : warnings) {
+			if (SafetyWarning.TYPE_INTERACTION.equals(warning.getType())) {
+				out.add(warning);
+			}
+		}
+		return out;
+	}
+
+	private static List<String> severities(List<SafetyWarning> warnings) {
+		List<String> out = new ArrayList<String>();
+		for (SafetyWarning warning : warnings) {
+			out.add(warning.getSeverity());
+		}
+		return out;
+	}
+
+	@Test
+	public void theDrugInPlayArmOrdersItsChipsMostSevereFirst() throws Exception {
+		DrugReferenceService service = DrugReferenceTestSupport.ddiFixtureService(FIXTURE);
+		// The fixture's own KB row order is Moderate, Minor, Major — the shape issue #346 reproduced
+		// live, where the Major finding sits last and is exactly the one an answer that stops partway
+		// through an enumeration drops.
+		PatientClinicalContext context = DrugReferenceTestSupport.ctx(60, null,
+				DrugReferenceTestSupport.set("Alphadrug", "Betadrug", "Gammadrug"), null, null, null);
+
+		List<SafetyWarning> chips = interactionChips(DrugReferenceTestSupport.validator(service)
+				.validate("", "Is it safe to give her Coagulon?", context));
+
+		assertEquals(3, chips.size(), "one chip per active-order partner, was: " + chips);
+		assertEquals(Arrays.asList("Major", "Moderate", "Minor"), severities(chips),
+				"the drug-in-play arm must order its chips most-severe-first, exactly as the other two "
+						+ "interaction arms already do, not in the knowledge base's own row order, was: "
+						+ chips);
+	}
+}

--- a/api/src/test/resources/chartsearchai-test/ddi-drug-in-play-severity-order.json
+++ b/api/src/test/resources/chartsearchai-test/ddi-drug-in-play-severity-order.json
@@ -1,0 +1,89 @@
+{
+ "metadata": {
+  "schema_version": "1.0",
+  "title": "Test fixture: one subject's KB row order for its interaction partners disagrees with severity (issue #346)",
+  "note": "A minimal synthetic slice, not drawn from the real DDInter KB. One subject drug, Coagulon, carries three interaction rows against three distinct partner substances, listed in the interactions array in KB row order Moderate, Minor, Major - deliberately NOT severity-sorted, and with the Major row LAST, mirroring the live reproduction on issue #346 where a Major bleeding interaction sat at the end of an unsorted list and never reached the answer. All three partners are on distinct ATC-4 subgroups from each other and from the subject, so no shared-class relationship is in play here - this fixture isolates the drug-in-play arm's own chip ORDER, nothing else. Parsed by the real DdiDrugReferenceSource.",
+  "source": {
+   "name": "Synthetic test fixture",
+   "url": "n/a",
+   "normalization": "RxNorm (NLM)",
+   "bridge": "n/a"
+  },
+  "format": {
+   "interactions": "[drug_a_id, drug_b_id, severity, group_id]",
+   "note": "Hand-authored for this test."
+  }
+ },
+ "mechanisms": {
+  "moderate1": {
+   "text": "Concurrent use of Coagulon and Alphadrug may moderately increase bleeding risk.",
+   "categories": []
+  },
+  "minor1": {
+   "text": "Concurrent use of Coagulon and Betadrug has a minor pharmacodynamic interaction.",
+   "categories": []
+  },
+  "major1": {
+   "text": "Concurrent use of Coagulon and Gammadrug significantly increases the risk of major bleeding.",
+   "categories": []
+  }
+ },
+ "drugs": [
+  {
+   "id": "DDInterTestSubject",
+   "name": "Coagulon",
+   "rxnorm_name": "coagulon",
+   "drugbank_id": "DBTEST00",
+   "atc": [
+    "B01AA99"
+   ]
+  },
+  {
+   "id": "DDInterTestAlpha",
+   "name": "Alphadrug",
+   "rxnorm_name": "alphadrug",
+   "drugbank_id": "DBTESTA1",
+   "atc": [
+    "N02BA99"
+   ]
+  },
+  {
+   "id": "DDInterTestBeta",
+   "name": "Betadrug",
+   "rxnorm_name": "betadrug",
+   "drugbank_id": "DBTESTA2",
+   "atc": [
+    "M01AB99"
+   ]
+  },
+  {
+   "id": "DDInterTestGamma",
+   "name": "Gammadrug",
+   "rxnorm_name": "gammadrug",
+   "drugbank_id": "DBTESTA3",
+   "atc": [
+    "A10BA99"
+   ]
+  }
+ ],
+ "interactions": [
+  [
+   "DDInterTestSubject",
+   "DDInterTestAlpha",
+   "Moderate",
+   "moderate1"
+  ],
+  [
+   "DDInterTestSubject",
+   "DDInterTestBeta",
+   "Minor",
+   "minor1"
+  ],
+  [
+   "DDInterTestSubject",
+   "DDInterTestGamma",
+   "Major",
+   "major1"
+  ]
+ ]
+}


### PR DESCRIPTION
Fixes #346

## What was broken

`DrugSafetyValidator.addInteractionWarnings` (the drug-in-play arm — the question's drug checked
against the patient's active orders) appended one interaction chip per partner in the knowledge base's
own row order, with no severity sort. The other two interaction arms already sort most-severe-first
before emitting (`Collections.sort(found, PAIR_SEVERITY_DESCENDING)` in
`addQuestionPairInteractions`, `Collections.sort(pairs, SCREENED_PAIR_SEVERITY_DESCENDING)` in
`addActiveOrderPairInteractions`).

Live on `main` @ `77c0f9a2`, a patient with 8 active orders asked "Can I give her warfarin?" got 8
interaction chips in KB row order; the LLM's answer enumerates the chips it is given and stops
partway through, so the Major warfarin×ibuprofen bleeding interaction (chip #8) never reached the
answer while five Moderate corticosteroid interactions did.

## The fix

Sorts the arm's candidate rules with a new `RULE_SEVERITY_DESCENDING` comparator on `SubjectRule`,
built from the same shared `severityPriority` ordering the other two arms' comparators already use, so
all three arms agree on "most severe first, unrated ranks above major." `Collections.sort` is stable,
so partners tied on severity keep the knowledge base's own row order, matching how the other two arms
already describe their own sort.

One javadoc paragraph on `ruleAbout` (which scans the arm's candidate list to decide which rule's chip
absorbs a class-arm sentence, for the one documented case where two distinct rows can name one active
order) was corrected: it used to say "the first in dataset order takes the fold," which is no longer
literally true now that the list arrives sorted by severity first.

A pre-existing test, `CoMedicationResolutionPerPassTest`, pins an exact golden list of chip
order for a two-drug question; its expected order was reordered to match the newly-correct
severity-first order (same content — same subject, partner, name and rating for every chip — verified
against the real `validate()` output, not hand-derived). A second pre-existing test's comment,
`DdiDrugReferenceSourceTest.replacingAGroupsWinnerLeavesTheChipsInDatasetOrderOfFirstAppearance`,
was also corrected: it used to explain a Major-before-Minor chip order by dataset position, which this
fix's severity sort now also explains on its own, so the comment was stale about *why* — the assertion
itself still holds and needed no change.

## Scope

Only the drug-in-play arm's chip order, per the ticket. Not #336 (bounded-screen extent) or #337
(mechanism-text garbling), both mentioned in the ticket's reproduction but explicitly out of scope.

One tangential, deliberately-deferred item: the corrected `DdiDrugReferenceSourceTest` case used to
double as a regression guard for `bestRulePerPartner`'s `LinkedHashMap` preserving a group's
dataset-first-appearance position across a winner replacement (verified by reverting that map to a
plain `HashMap` and confirming the test still passes either way, since its two chips differ in
severity and the new sort now decides their order on its own). Restoring that guard would need a new
fixture with two partners tied on severity; left as a follow-up rather than folded into this PR, since
it's a pre-existing implementation-detail risk unrelated to chip ordering by severity.

## Testing

- New test `DrugInPlayInteractionSeverityOrderTest`, with a dedicated fixture whose KB row order
  (Moderate, Minor, Major) does not match severity order — fails on `main` (chips return
  `[Moderate, Minor, Major]`), passes after the fix (`[Major, Moderate, Minor]`).
- `mvn -o clean install` from the repository root: 1694 api tests + 105 omod tests, 0 failures.